### PR TITLE
fix(web): improve kanban card & column spacing

### DIFF
--- a/web/src/components/shared/IssueCard.tsx
+++ b/web/src/components/shared/IssueCard.tsx
@@ -8,18 +8,18 @@ import { relativeTime } from "@/lib/format";
 
 export function IssueCard({ issue }: { issue: IssueLite }) {
   const inner = (
-    <Card className="group h-full p-4 transition-all hover:-translate-y-0.5 hover:shadow-md">
+    <Card className="group h-full p-5 transition-all hover:-translate-y-0.5 hover:shadow-md">
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <span className="font-mono">#{issue.number}</span>
         {issue.isPR ? <GitPullRequest className="h-3.5 w-3.5 text-violet-600" /> : null}
         <span className="ml-auto">{relativeTime(issue.updatedAt)}</span>
       </div>
-      <div className="mt-1.5 line-clamp-2 font-medium leading-snug group-hover:text-brand-cyan-dark">{issue.title}</div>
-      <div className="mt-3 flex flex-wrap items-center gap-1.5">
+      <div className="mt-2 line-clamp-2 font-medium leading-snug group-hover:text-brand-cyan-dark">{issue.title}</div>
+      <div className="mt-3.5 flex flex-wrap items-center gap-1.5">
         <StatusBadge status={issue.status} />
         <DomainBadge domain={issue.domain} />
       </div>
-      <div className="mt-3 flex items-center justify-between">
+      <div className="mt-4 flex items-center justify-between">
         {issue.assignees.length ? (
           <div className="flex -space-x-2">
             {issue.assignees.slice(0, 3).map((p) => (

--- a/web/src/pages/Board.tsx
+++ b/web/src/pages/Board.tsx
@@ -83,25 +83,25 @@ export default function Board() {
       {filtered.length === 0 ? (
         <EmptyState icon={Inbox} title="Nothing matches">Try clearing a filter, or submit a new problem.</EmptyState>
       ) : view === "list" ? (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((i) => <IssueCard key={i.number} issue={i} />)}
         </div>
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-4 md:grid-cols-2 md:gap-5 xl:grid-cols-4">
           {STAGE_ORDER.map((stage: Stage) => {
             const items = filtered.filter((i) => i.stage === stage);
             const m = STAGE_META[stage];
             const Icon = m.icon;
             return (
-              <div key={stage} className="rounded-xl border border-border/70 bg-secondary/30 p-3">
-                <div className="mb-3 flex items-center gap-2 px-1">
+              <div key={stage} className="rounded-xl border border-border/70 bg-secondary/30 p-4">
+                <div className="mb-4 flex items-center gap-2 px-0.5">
                   <Icon className="h-4 w-4" style={{ color: m.color }} />
                   <span className="font-serif text-sm font-semibold">{m.label}</span>
                   <span className="ml-auto rounded-full bg-background px-2 py-0.5 text-xs text-muted-foreground">{items.length}</span>
                 </div>
-                <div className="space-y-3">
+                <div className="space-y-3.5">
                   {items.map((i: IssueLite) => <IssueCard key={i.number} issue={i} />)}
-                  {items.length === 0 ? <p className="px-1 py-4 text-center text-xs text-muted-foreground">Empty</p> : null}
+                  {items.length === 0 ? <p className="px-1 py-6 text-center text-xs text-muted-foreground">Empty</p> : null}
                 </div>
               </div>
             );


### PR DESCRIPTION
## What
Tightens up the breathing room on the board / kanban, per Adam's request — cards and columns needed more margin/padding.

## Review findings
- Board columns were `p-3` — actually **tighter** than the `p-4` cards inside them, which read as cramped.
- Columns sat only `gap-4` apart with no extra separation on wider screens.
- Card internal rhythm (title → badges → footer) was a touch dense.

## Changes
- Board columns `p-3` → `p-4` so they're roomier than their cards, not tighter
- More gap between columns on md+ (`gap-5`); consistent `gap-4` in list view
- Column header `mb-3` → `mb-4`, aligned padding, roomier empty state
- Card stack spacing `space-y-3` → `space-y-3.5`
- `IssueCard` `p-4` → `p-5` with more internal spacing between title, badges and footer

## Verified
- `tsc -b && vite build` passes clean locally