### PR TITLE
fix(web): stop kanban cards stacking on top of each other

### DIFF
--- a/web/src/components/shared/IssueCard.tsx
+++ b/web/src/components/shared/IssueCard.tsx
@@ -36,8 +36,8 @@ export function IssueCard({ issue }: { issue: IssueLite }) {
     </Card>
   );
   return issue.isPR ? (
-    <a href={issue.url} target="_blank" rel="noreferrer">{inner}</a>
+    <a href={issue.url} target="_blank" rel="noreferrer" className="block h-full">{inner}</a>
   ) : (
-    <Link to={`/issue/${issue.number}`}>{inner}</Link>
+    <Link to={`/issue/${issue.number}`} className="block h-full">{inner}</Link>
   );
 }


### PR DESCRIPTION
## The actual bug
`IssueCard` wraps its content in an `<a>`/`<Link>`, which is `display: inline` by default. In the board's **kanban columns** the cards sit in a `space-y` (margin-based) stack — and vertical margins barely apply to inline elements, so the cards collapsed on top of each other.

Grid/list view forces block layout on its children, so it looked fine there — which masked the bug and is why the spacing PR (#9) didn't resolve it.

## Fix
Make the anchor wrappers `block h-full` so they stack as proper blocks and honour both the column spacing and full-height sizing.

## Verified
- `tsc -b && vite build` passes clean locally