### PR TITLE
feat(web): contributors list + header shadow/rounding

### DIFF
--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -73,10 +73,11 @@ async function main() {
   // only if it's a substantive verdict (APPROVED / CHANGES_REQUESTED) and the
   // reviewer is not the PR author. Counted once per (reviewer, PR).
   const reviewsGiven = new Map();  // login -> Set(prNumbers)
+  const reviewLast = new Map();    // login -> most recent review ISO timestamp
   try {
     let after = null;
     for (let i = 0; i < 10; i++) {
-      const q = `query($cursor:String){repository(owner:"${OWNER}",name:"${NAME}"){pullRequests(first:50,after:$cursor,states:[OPEN,MERGED,CLOSED]){pageInfo{hasNextPage endCursor} nodes{number author{login} reviews(first:50){nodes{author{login} state}}}}}}`;
+      const q = `query($cursor:String){repository(owner:"${OWNER}",name:"${NAME}"){pullRequests(first:50,after:$cursor,states:[OPEN,MERGED,CLOSED]){pageInfo{hasNextPage endCursor} nodes{number author{login} reviews(first:50){nodes{author{login} state submittedAt}}}}}}`;
       const gres = await fetch(`${API}/graphql`, { method: "POST", headers, body: JSON.stringify({ query: q, variables: { cursor: after } }) });
       if (!gres.ok) { console.warn("reviews graphql:", gres.status); break; }
       const data = (await gres.json())?.data?.repository?.pullRequests;
@@ -89,6 +90,8 @@ async function main() {
           if (rv.state !== "APPROVED" && rv.state !== "CHANGES_REQUESTED") continue;
           if (!reviewsGiven.has(who)) reviewsGiven.set(who, new Set());
           reviewsGiven.get(who).add(pr.number);
+          const at = rv.submittedAt;
+          if (at && (!reviewLast.has(who) || new Date(at) > new Date(reviewLast.get(who)))) reviewLast.set(who, at);
         }
       }
       if (!data.pageInfo.hasNextPage) break;
@@ -190,24 +193,31 @@ async function main() {
 
   // --- leaderboard ---
   const people = new Map();
+  const newPerson = (login, avatar, url) => ({ login, avatar, url, issuesAssigned: 0, prsMerged: 0, prsOpened: 0, findingsAuthored: 0, commits: 0, reviewsGiven: 0, score: 0, lastActivity: null, domains: new Set() });
+  const bumpActivity = (r, iso) => {
+    if (!r || !iso) return;
+    const t = new Date(iso).getTime();
+    if (Number.isNaN(t)) return;
+    if (!r.lastActivity || t > new Date(r.lastActivity).getTime()) r.lastActivity = new Date(iso).toISOString();
+  };
   const ensure = (p) => {
     if (!p) return null;
-    if (!people.has(p.login))
-      people.set(p.login, { login: p.login, avatar: p.avatar, url: p.url, issuesAssigned: 0, prsMerged: 0, prsOpened: 0, findingsAuthored: 0, commits: 0, reviewsGiven: 0, score: 0, domains: new Set() });
+    if (!people.has(p.login)) people.set(p.login, newPerson(p.login, p.avatar, p.url));
     return people.get(p.login);
   };
-  for (const i of realIssues) for (const a of i.assignees) { const r = ensure(a); if (r && i.domain) r.domains.add(i.domain); if (r) r.issuesAssigned++; }
-  for (const p of prs) { const r = ensure(p.author); if (r) { r.prsOpened++; if (p.merged) r.prsMerged++; } }
+  for (const i of realIssues) for (const a of i.assignees) { const r = ensure(a); if (r && i.domain) r.domains.add(i.domain); if (r) { r.issuesAssigned++; bumpActivity(r, i.updatedAt); } }
+  for (const p of prs) { const r = ensure(p.author); if (r) { r.prsOpened++; if (p.merged) r.prsMerged++; bumpActivity(r, p.updatedAt); } }
   for (const c of commitContributors) { const r = ensure(person(c)); if (r) r.commits += c.contributions || 0; }
   for (const f of findings) {
     const login = f.author && f.author !== "unknown" ? f.author.replace(/^@/, "") : null;
     if (!login) continue;
-    if (!people.has(login)) people.set(login, { login, avatar: `https://github.com/${login}.png`, url: `https://github.com/${login}`, issuesAssigned: 0, prsMerged: 0, prsOpened: 0, findingsAuthored: 0, commits: 0, reviewsGiven: 0, score: 0, domains: new Set() });
-    const r = people.get(login); r.findingsAuthored++; if (f.domain) r.domains.add(f.domain);
+    if (!people.has(login)) people.set(login, newPerson(login, `https://github.com/${login}.png`, `https://github.com/${login}`));
+    const r = people.get(login); r.findingsAuthored++; if (f.domain) r.domains.add(f.domain); bumpActivity(r, f.date);
   }
   for (const [login, prset] of reviewsGiven) {
-    if (!people.has(login)) people.set(login, { login, avatar: `https://github.com/${login}.png`, url: `https://github.com/${login}`, issuesAssigned: 0, prsMerged: 0, prsOpened: 0, findingsAuthored: 0, commits: 0, reviewsGiven: 0, score: 0, domains: new Set() });
+    if (!people.has(login)) people.set(login, newPerson(login, `https://github.com/${login}.png`, `https://github.com/${login}`));
     people.get(login).reviewsGiven = prset.size;
+    bumpActivity(people.get(login), reviewLast.get(login));
   }
   const BOTS = new Set(["github-actions[bot]", "dependabot[bot]"]);
   const leaderboard = [...people.values()]

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -21,7 +21,7 @@ export function Header({ repoUrl }: { repoUrl?: string }) {
   const { theme, toggle } = useTheme();
   const [open, setOpen] = useState(false);
   return (
-    <header className="sticky top-0 z-40 border-b border-border/70 bg-background/80 backdrop-blur-md">
+    <header className="sticky top-0 z-40 rounded-none border-x-0 border-t-0 border-b border-border bg-background/80 shadow-[0_1px_3px_0_rgb(0_0_0_/_0.06)] backdrop-blur-md">
       <div className="container flex h-16 items-center justify-between gap-4">
         <Link to="/" className="flex items-center gap-2.5 shrink-0">
           <LogoMark />

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -48,6 +48,7 @@ export interface Contributor {
   researchScore: number;
   reviewScore: number;
   score: number;
+  lastActivity: string | null;
   domains: string[];
 }
 

--- a/web/src/pages/Leaderboard.tsx
+++ b/web/src/pages/Leaderboard.tsx
@@ -1,136 +1,110 @@
-import { useState } from "react";
 import { Trophy, BookOpen, GitPullRequest, CircleDot, GitCommit, Users, ScanEye, FlaskConical } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { Card, CardContent } from "@/components/ui/card";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { PersonAvatar } from "@/components/shared/PersonAvatar";
+import { relativeTime } from "@/lib/format";
 import type { Contributor } from "@/lib/types";
 
 const MEDAL = ["#D4AF37", "#A8A29E", "#B45309"];
 
-type Metric = "score" | "researchScore" | "reviewScore";
-const METRICS: { key: Metric; label: string; icon: typeof Trophy; unit: string; blurb: string }[] = [
-  { key: "score", label: "Overall", icon: Trophy, unit: "pts", blurb: "Research and review combined." },
-  { key: "researchScore", label: "Researchers", icon: FlaskConical, unit: "research pts", blurb: "Findings authored, PRs merged, issues claimed, commits." },
-  { key: "reviewScore", label: "Reviewers", icon: ScanEye, unit: "review pts", blurb: "Adversarial reviews given on others' PRs — the work that keeps the queue moving." },
-];
+function roles(c: Contributor): { label: string; color: string }[] {
+  const out: { label: string; color: string }[] = [];
+  if (c.researchScore > 0) out.push({ label: "Researcher", color: "#0EA5E9" });
+  if (c.reviewsGiven > 0) out.push({ label: "Reviewer", color: "#1D76DB" });
+  if (out.length === 0) out.push({ label: "Contributor", color: "#8B5CF6" });
+  return out;
+}
 
-function Podium({ board, metric, unit }: { board: Contributor[]; metric: Metric; unit: string }) {
-  const top3 = board.slice(0, 3);
-  return (
-    <div className="mb-8 grid gap-4 sm:grid-cols-3">
-      {top3.map((c, i) => (
-        <a key={c.login} href={c.url} target="_blank" rel="noreferrer" className={i === 0 ? "sm:order-2" : i === 1 ? "sm:order-1" : "sm:order-3"}>
-          <Card className="relative overflow-hidden p-6 text-center transition-all hover:-translate-y-0.5 hover:shadow-md" style={{ borderColor: `${MEDAL[i]}66` }}>
-            <div className="absolute inset-x-0 top-0 h-1" style={{ backgroundColor: MEDAL[i] }} />
-            <div className="mx-auto flex flex-col items-center">
-              <div className="relative">
-                <PersonAvatar login={c.login} avatar={c.avatar} size={i === 0 ? 72 : 60} />
-                <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold text-white" style={{ backgroundColor: MEDAL[i] }}>{i + 1}</div>
-              </div>
-              <div className="mt-3 font-serif text-lg font-semibold">@{c.login}</div>
-              <div className="text-3xl font-bold tabular-nums brand-gradient-text">{(c as any)[metric]}</div>
-              <div className="text-xs text-muted-foreground">{unit}</div>
-              <div className="mt-3 flex flex-wrap justify-center gap-2 text-xs text-muted-foreground">
-                {c.findingsAuthored > 0 ? <span className="inline-flex items-center gap-1"><BookOpen className="h-3 w-3" />{c.findingsAuthored}</span> : null}
-                {c.reviewsGiven > 0 ? <span className="inline-flex items-center gap-1"><ScanEye className="h-3 w-3" />{c.reviewsGiven}</span> : null}
-                {c.prsMerged > 0 ? <span className="inline-flex items-center gap-1"><GitPullRequest className="h-3 w-3" />{c.prsMerged}</span> : null}
-              </div>
-            </div>
-          </Card>
-        </a>
-      ))}
-    </div>
-  );
+function lastActive(iso: string | null): string {
+  if (!iso) return "—";
+  const rel = relativeTime(iso);
+  return rel || "—";
 }
 
 export default function Leaderboard() {
   const { data, error, loading } = useSnapshot();
-  const [metric, setMetric] = useState<Metric>("score");
   if (loading) return <Loading />;
   if (error || !data) return <ErrorState message={error || "No data"} />;
+
+  const board = [...data.leaderboard].filter((c) => c.score > 0).sort((a, b) => b.score - a.score);
 
   return (
     <div>
       <PageHeader title="Contributors">
-        Two ways to climb: <strong>research</strong> the problems, or <strong>review</strong> others' work. Both earn credit — reviewing is how the queue stays honest and moving.
+        Everyone moving the queue forward, ranked by points. Two ways to climb: <strong>research</strong> the problems, or <strong>review</strong> others' work — reviewing is how the queue stays honest.
       </PageHeader>
 
-      {data.leaderboard.length === 0 ? (
+      {board.length === 0 ? (
         <EmptyState icon={Users} title="No contributors yet">Be the first — claim an issue on the board and open a PR.</EmptyState>
       ) : (
-        <Tabs value={metric === "score" ? "overall" : metric === "researchScore" ? "research" : "review"}
-          onValueChange={(v) => setMetric(v === "overall" ? "score" : v === "research" ? "researchScore" : "reviewScore")}>
-          <TabsList>
-            <TabsTrigger value="overall"><Trophy className="mr-1.5 h-4 w-4" />Overall</TabsTrigger>
-            <TabsTrigger value="research"><FlaskConical className="mr-1.5 h-4 w-4" />Researchers</TabsTrigger>
-            <TabsTrigger value="review"><ScanEye className="mr-1.5 h-4 w-4" />Reviewers</TabsTrigger>
-          </TabsList>
+        <Card>
+          <CardContent className="p-0">
+            <ul className="divide-y divide-border">
+              {board.map((c, i) => {
+                const medal = i < 3 ? MEDAL[i] : null;
+                return (
+                  <li key={c.login}>
+                    <a
+                      href={c.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="flex items-center gap-3 p-4 transition-colors hover:bg-secondary/50 sm:gap-4 sm:px-5"
+                    >
+                      {/* Rank */}
+                      <div
+                        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold tabular-nums"
+                        style={medal ? { backgroundColor: medal, color: "#fff" } : { color: "hsl(var(--muted-foreground))" }}
+                      >
+                        {i + 1}
+                      </div>
 
-          {METRICS.map((m) => {
-            const board = [...data.leaderboard].filter((c) => (c as any)[m.key] > 0).sort((a, b) => (b as any)[m.key] - (a as any)[m.key]);
-            const rest = board.slice(3);
-            const tabVal = m.key === "score" ? "overall" : m.key === "researchScore" ? "research" : "review";
-            return (
-              <TabsContent key={m.key} value={tabVal}>
-                <p className="mb-5 text-sm text-muted-foreground">{m.blurb}</p>
-                {board.length === 0 ? (
-                  <EmptyState icon={m.icon} title={`No ${m.label.toLowerCase()} yet`}>
-                    {m.key === "reviewScore" ? "Run review_work.sh on a PR you didn't author to be the first reviewer." : "Claim an issue and open a PR to get on the board."}
-                  </EmptyState>
-                ) : (
-                  <>
-                    <Podium board={board} metric={m.key} unit={m.unit} />
-                    {rest.length > 0 ? (
-                      <Card>
-                        <CardContent className="p-0">
-                          <Table>
-                            <TableHeader>
-                              <TableRow>
-                                <TableHead className="w-12">#</TableHead>
-                                <TableHead>Contributor</TableHead>
-                                <TableHead className="text-center"><BookOpen className="mx-auto h-4 w-4" /></TableHead>
-                                <TableHead className="text-center"><ScanEye className="mx-auto h-4 w-4" /></TableHead>
-                                <TableHead className="text-center"><GitPullRequest className="mx-auto h-4 w-4" /></TableHead>
-                                <TableHead className="text-center"><CircleDot className="mx-auto h-4 w-4" /></TableHead>
-                                <TableHead className="text-right">{m.label === "Overall" ? "Total" : m.label === "Researchers" ? "Research" : "Review"}</TableHead>
-                              </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                              {rest.map((c, i) => (
-                                <TableRow key={c.login}>
-                                  <TableCell className="text-muted-foreground">{i + 4}</TableCell>
-                                  <TableCell>
-                                    <a href={c.url} target="_blank" rel="noreferrer" className="flex items-center gap-2.5 font-medium hover:text-brand-cyan-dark">
-                                      <PersonAvatar login={c.login} avatar={c.avatar} size={28} /> @{c.login}
-                                    </a>
-                                  </TableCell>
-                                  <TableCell className="text-center tabular-nums text-muted-foreground">{c.findingsAuthored || "–"}</TableCell>
-                                  <TableCell className="text-center tabular-nums text-muted-foreground">{c.reviewsGiven || "–"}</TableCell>
-                                  <TableCell className="text-center tabular-nums text-muted-foreground">{c.prsMerged || "–"}</TableCell>
-                                  <TableCell className="text-center tabular-nums text-muted-foreground">{c.issuesAssigned || "–"}</TableCell>
-                                  <TableCell className="text-right font-semibold tabular-nums">{(c as any)[m.key]}</TableCell>
-                                </TableRow>
-                              ))}
-                            </TableBody>
-                          </Table>
-                        </CardContent>
-                      </Card>
-                    ) : null}
-                  </>
-                )}
-              </TabsContent>
-            );
-          })}
-        </Tabs>
+                      <PersonAvatar login={c.login} avatar={c.avatar} size={40} />
+
+                      {/* Name + roles + last active */}
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate font-medium">@{c.login}</div>
+                        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                          {roles(c).map((r) => (
+                            <span
+                              key={r.label}
+                              className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium"
+                              style={{ backgroundColor: `${r.color}1A`, color: r.color }}
+                            >
+                              {r.label}
+                            </span>
+                          ))}
+                          <span className="text-xs text-muted-foreground">· active {lastActive(c.lastActivity)}</span>
+                        </div>
+                      </div>
+
+                      {/* Stats — hidden on the smallest screens */}
+                      <div className="hidden items-center gap-4 text-xs text-muted-foreground sm:flex">
+                        {c.findingsAuthored > 0 ? <span className="inline-flex items-center gap-1" title="Findings authored"><BookOpen className="h-3.5 w-3.5" />{c.findingsAuthored}</span> : null}
+                        {c.reviewsGiven > 0 ? <span className="inline-flex items-center gap-1" title="Reviews given"><ScanEye className="h-3.5 w-3.5" />{c.reviewsGiven}</span> : null}
+                        {c.prsMerged > 0 ? <span className="inline-flex items-center gap-1" title="PRs merged"><GitPullRequest className="h-3.5 w-3.5" />{c.prsMerged}</span> : null}
+                        {c.issuesAssigned > 0 ? <span className="inline-flex items-center gap-1" title="Issues claimed"><CircleDot className="h-3.5 w-3.5" />{c.issuesAssigned}</span> : null}
+                      </div>
+
+                      {/* Points */}
+                      <div className="shrink-0 text-right">
+                        <div className="text-xl font-bold tabular-nums brand-gradient-text sm:text-2xl">{c.score}</div>
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">pts</div>
+                      </div>
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </CardContent>
+        </Card>
       )}
 
       <p className="mt-4 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-        <Trophy className="h-3.5 w-3.5" /> Legend: <BookOpen className="h-3.5 w-3.5" /> findings · <ScanEye className="h-3.5 w-3.5" /> reviews given · <GitPullRequest className="h-3.5 w-3.5" /> PRs merged · <CircleDot className="h-3.5 w-3.5" /> issues claimed · <GitCommit className="h-3.5 w-3.5" /> commits
+        <Trophy className="h-3.5 w-3.5" /> Points: findings <BookOpen className="h-3.5 w-3.5" />×5 · PRs merged <GitPullRequest className="h-3.5 w-3.5" />×3 · issues claimed <CircleDot className="h-3.5 w-3.5" />×2 · reviews given <ScanEye className="h-3.5 w-3.5" />×4 · commits <GitCommit className="h-3.5 w-3.5" />
+        <span className="inline-flex items-center gap-1"><FlaskConical className="h-3.5 w-3.5" /> research + review combined.</span>
       </p>
     </div>
   );


### PR DESCRIPTION
Two asks from Adam.

## 1. Header shadow / rounding (main page)
The sticky header only had a hairline `border-b` (with a semi-transparent border colour). Gave it a clean, **downward-only** soft shadow so it reads as a proper elevated bar over scrolling content, solidified the border, and forced square corners (`rounded-none`) so no inherited rounding shows.

> Note: I couldn't screenshot the live site to confirm the exact artefact (browser session was locked), so this is a clean-elevation treatment based on the source. If you meant a different "header" (e.g. the dashboard hero banner) or wanted a floating rounded bar, it's a one-line tweak — shout.

## 2. Contributors page → ranked list
Rebuilt the leaderboard from the podium + tabbed tables into a single clean **list**, per request:
- Rank (medal colour for top 3), avatar, `@login`
- **Role chips** — Researcher / Reviewer (derived from research vs review activity)
- **Last active** date (relative)
- Key stats (findings / reviews / PRs / issues) on sm+
- **Points** on the right

### Data layer
- Added `lastActivity` per contributor in `build-data.mjs` — the max timestamp across issues assigned, PRs authored, findings, and reviews given (added `submittedAt` to the reviews GraphQL query).
- Surfaced `lastActivity` on the `Contributor` type.
- Existing snapshots without the field degrade gracefully to “—” until the next data build runs in CI.

## Verified
- `tsc -b && vite build` passes clean
- `node --check` on the build script passes