### PR TITLE
feat(web): problem-chains view on the board

### DIFF
--- a/web/src/components/shared/ChainTree.tsx
+++ b/web/src/components/shared/ChainTree.tsx
@@ -1,0 +1,85 @@
+import { Link } from "react-router-dom";
+import { GitMerge, GitPullRequest, CheckCircle2 } from "lucide-react";
+import type { ChainNode } from "@/lib/lineage";
+import type { IssueLite } from "@/lib/types";
+import { Card } from "@/components/ui/card";
+import { StageBadge, StatusBadge, DomainBadge } from "./Badges";
+import { PersonAvatar } from "./PersonAvatar";
+import { relativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+function PrChip({ pr }: { pr: IssueLite }) {
+  const merged = pr.merged;
+  return (
+    <a href={pr.url} target="_blank" rel="noreferrer"
+      className={cn("inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium transition-colors",
+        merged ? "border-violet-300/50 text-violet-600 hover:bg-violet-500/10" : "border-emerald-300/50 text-emerald-600 hover:bg-emerald-500/10")}>
+      {merged ? <GitMerge className="h-3 w-3" /> : <GitPullRequest className="h-3 w-3" />}
+      PR #{pr.number}{merged ? " · merged" : ""}
+    </a>
+  );
+}
+
+function NodeRow({ node, dimmed }: { node: ChainNode; dimmed: boolean }) {
+  const { issue } = node;
+  const closed = issue.state === "closed";
+  return (
+    <div className={cn("flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg px-2 py-1.5 transition-colors hover:bg-secondary/60", dimmed && "opacity-45")}>
+      <StageBadge stage={issue.stage} />
+      <Link to={`/issue/${issue.number}`} className="min-w-0 flex-1 basis-48">
+        <span className="mr-1.5 font-mono text-xs text-muted-foreground">#{issue.number}</span>
+        <span className={cn("text-sm font-medium hover:text-brand-cyan-dark", closed && "text-muted-foreground line-through decoration-border")}>
+          {issue.title.replace(/^\[[^\]]+\]\s*/, "")}
+        </span>
+      </Link>
+      {node.prs.map((pr) => <PrChip key={pr.number} pr={pr} />)}
+      {closed ? (
+        <span className="inline-flex items-center gap-1 text-xs text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" /> done</span>
+      ) : (
+        <StatusBadge status={issue.status} />
+      )}
+      {issue.assignees.length > 0 ? (
+        <div className="flex -space-x-2">
+          {issue.assignees.slice(0, 3).map((p) => <PersonAvatar key={p.login} login={p.login} avatar={p.avatar} size={20} />)}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Branches({ nodes, matches }: { nodes: ChainNode[]; matches: (i: IssueLite) => boolean }) {
+  return (
+    <div className="ml-4 space-y-1 border-l border-border/80 pl-3">
+      {nodes.map((n) => (
+        <div key={n.issue.number}>
+          <NodeRow node={n} dimmed={!matches(n.issue)} />
+          {n.children.length > 0 ? <Branches nodes={n.children} matches={matches} /> : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One problem chain: the root issue and everything that hangs off it via
+ * "Part of #n", with PRs attached to the issues they close. Nodes that don't
+ * match the current filters render dimmed so the chain keeps its shape.
+ */
+export function ChainTree({ root, matches }: { root: ChainNode; matches: (i: IssueLite) => boolean }) {
+  return (
+    <Card className="p-4">
+      <div className="mb-1 flex items-center justify-between gap-2 px-2">
+        <DomainBadge domain={root.issue.domain} />
+        <span className="text-xs text-muted-foreground">updated {relativeTime(root.issue.updatedAt)}</span>
+      </div>
+      <NodeRow node={root} dimmed={!matches(root.issue)} />
+      {root.children.length > 0 ? (
+        <Branches nodes={root.children} matches={matches} />
+      ) : (
+        <p className="ml-4 border-l border-border/80 py-1 pl-3 text-xs text-muted-foreground">
+          No linked work yet — child issues that say “Part of #{root.issue.number}” will appear here.
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/web/src/lib/lineage.ts
+++ b/web/src/lib/lineage.ts
@@ -1,0 +1,93 @@
+import type { IssueLite } from "./types";
+import { STAGE_ORDER } from "./meta";
+
+export interface ChainNode {
+  issue: IssueLite;
+  children: ChainNode[];
+  /** PRs whose body closes this issue */
+  prs: IssueLite[];
+}
+
+// "Part of #12" is the linking convention from AGENTS.md / the issue templates.
+const PARENT_RE = /part of #(\d+)/i;
+const CLOSES_RE = /\b(?:clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed))\s+#(\d+)/gi;
+
+export function parentNumber(issue: IssueLite): number | null {
+  const m = PARENT_RE.exec(issue.body);
+  return m ? Number(m[1]) : null;
+}
+
+function closedNumbers(pr: IssueLite): number[] {
+  const out: number[] = [];
+  let m;
+  CLOSES_RE.lastIndex = 0;
+  while ((m = CLOSES_RE.exec(pr.body))) out.push(Number(m[1]));
+  return out;
+}
+
+const stageRank = (issue: IssueLite) => {
+  const i = STAGE_ORDER.indexOf(issue.stage as (typeof STAGE_ORDER)[number]);
+  return i === -1 ? STAGE_ORDER.length : i;
+};
+
+/** Latest activity anywhere in the chain, for sorting roots. */
+export function chainUpdatedAt(node: ChainNode): string {
+  let latest = node.issue.updatedAt;
+  for (const pr of node.prs) if (pr.updatedAt > latest) latest = pr.updatedAt;
+  for (const c of node.children) {
+    const t = chainUpdatedAt(c);
+    if (t > latest) latest = t;
+  }
+  return latest;
+}
+
+export function chainSize(node: ChainNode): number {
+  return 1 + node.children.reduce((n, c) => n + chainSize(c), 0);
+}
+
+/**
+ * Build problem chains from all issues: every issue whose body says
+ * "Part of #n" hangs under issue n; the rest are roots. PRs attach to the
+ * issues they close. Unknown parents and cycles fall back to root.
+ */
+export function buildChains(all: IssueLite[]): ChainNode[] {
+  const issues = all.filter((i) => !i.isPR);
+  const prs = all.filter((i) => i.isPR);
+
+  const nodes = new Map<number, ChainNode>();
+  for (const issue of issues) nodes.set(issue.number, { issue, children: [], prs: [] });
+
+  for (const pr of prs)
+    for (const n of closedNumbers(pr)) nodes.get(n)?.prs.push(pr);
+
+  const roots: ChainNode[] = [];
+  for (const node of nodes.values()) {
+    const parent = parentNumber(node.issue);
+    const parentNode = parent != null && parent !== node.issue.number ? nodes.get(parent) : undefined;
+    if (parentNode) parentNode.children.push(node);
+    else roots.push(node);
+  }
+
+  // A cycle (a "Part of" loop) leaves its members unreachable from any root —
+  // promote one member so the chain still renders.
+  const reachable = new Set<number>();
+  const mark = (n: ChainNode) => {
+    if (reachable.has(n.issue.number)) return;
+    reachable.add(n.issue.number);
+    n.children.forEach(mark);
+  };
+  roots.forEach(mark);
+  for (const node of nodes.values()) {
+    if (reachable.has(node.issue.number)) continue;
+    roots.push(node);
+    mark(node);
+  }
+
+  const sortChildren = (n: ChainNode) => {
+    n.children.sort((a, b) => stageRank(a.issue) - stageRank(b.issue) || a.issue.number - b.issue.number);
+    n.children.forEach(sortChildren);
+  };
+  roots.forEach(sortChildren);
+  roots.sort((a, b) => chainUpdatedAt(b).localeCompare(chainUpdatedAt(a)));
+  return roots;
+}

--- a/web/src/pages/Board.tsx
+++ b/web/src/pages/Board.tsx
@@ -1,11 +1,14 @@
 import { useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Search, LayoutGrid, List, Inbox } from "lucide-react";
+import { Search, LayoutGrid, List, Network, Inbox } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { IssueCard } from "@/components/shared/IssueCard";
+import { ChainTree } from "@/components/shared/ChainTree";
 import { EmptyState } from "@/components/shared/EmptyState";
+import { buildChains } from "@/lib/lineage";
+import type { ChainNode } from "@/lib/lineage";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -18,7 +21,7 @@ export default function Board() {
   const [q, setQ] = useState("");
   const [domain, setDomain] = useState("all");
   const [status, setStatus] = useState("all");
-  const [view, setView] = useState<"board" | "list">("board");
+  const [view, setView] = useState<"board" | "list" | "chains">("board");
   const stageParam = params.get("stage") || "all";
 
   const domains = useMemo(() => {
@@ -27,16 +30,24 @@ export default function Board() {
     return [...s];
   }, [data]);
 
+  const chains = useMemo(() => (data ? buildChains(data.issues) : []), [data]);
+
   if (loading) return <Loading />;
   if (error || !data) return <ErrorState message={error || "No data"} />;
 
-  const filtered = data.issues.filter((i) => !i.isPR && i.state === "open").filter((i) => {
+  const matchesFilters = (i: IssueLite) => {
     if (stageParam !== "all" && i.stage !== stageParam) return false;
     if (domain !== "all" && i.domain !== domain) return false;
     if (status !== "all" && i.status !== status) return false;
     if (q && !i.title.toLowerCase().includes(q.toLowerCase()) && !String(i.number).includes(q)) return false;
     return true;
-  });
+  };
+
+  const filtered = data.issues.filter((i) => !i.isPR && i.state === "open").filter(matchesFilters);
+
+  // A chain is shown when any of its issues matches; non-matching nodes render dimmed.
+  const chainMatches = (n: ChainNode): boolean => matchesFilters(n.issue) || n.children.some(chainMatches);
+  const visibleChains = chains.filter(chainMatches);
 
   const setStage = (s: string) => {
     const next = new URLSearchParams(params);
@@ -77,10 +88,22 @@ export default function Board() {
         <div className="flex rounded-md border border-border">
           <Button variant={view === "board" ? "secondary" : "ghost"} size="icon" onClick={() => setView("board")} aria-label="Board view"><LayoutGrid className="h-4 w-4" /></Button>
           <Button variant={view === "list" ? "secondary" : "ghost"} size="icon" onClick={() => setView("list")} aria-label="List view"><List className="h-4 w-4" /></Button>
+          <Button variant={view === "chains" ? "secondary" : "ghost"} size="icon" onClick={() => setView("chains")} aria-label="Chains view"><Network className="h-4 w-4" /></Button>
         </div>
       </div>
 
-      {filtered.length === 0 ? (
+      {view === "chains" ? (
+        visibleChains.length === 0 ? (
+          <EmptyState icon={Inbox} title="Nothing matches">Try clearing a filter, or submit a new problem.</EmptyState>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Each problem and everything that grew out of it — child issues link up with “Part of #n”, and pull requests attach to the issue they close.
+            </p>
+            {visibleChains.map((c) => <ChainTree key={c.issue.number} root={c} matches={matchesFilters} />)}
+          </div>
+        )
+      ) : filtered.length === 0 ? (
         <EmptyState icon={Inbox} title="Nothing matches">Try clearing a filter, or submit a new problem.</EmptyState>
       ) : view === "list" ? (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## What this is

**Stage:** 🔨 Build (site infrastructure — `web/`)
**Domain:** n/a (dashboard)

## Summary

Adds a third view to the board — **problem chains** — that shows each problem's full lineage: child issues nest under their parent via the "Part of #n" body convention, and pull requests attach to the issues they close (via "Closes/Fixes/Resolves #n"). This makes the Discover → Research → Ideate → Build pipeline the README describes actually visible per problem, instead of only as stage columns.

Details:
- New `web/src/lib/lineage.ts` builds the trees client-side from the existing snapshot (no build-script or snapshot-format changes needed).
- New `ChainTree` component renders a card per root problem with indented children, PR chips (open/merged), status badges, and assignee avatars.
- Filters still work in chains view: a chain is shown if any node matches; non-matching nodes render dimmed so the chain keeps its shape. Closed issues stay visible as completed steps (struck through, "done").
- Defensive handling: unknown "Part of" targets and cycles fall back to root, so every issue always renders.

## Method checklist

- [x] No personal or identifying data; no overstated or fabricated claims
- [x] Files are in the right place and follow the relevant template
- (Findings-specific items n/a — this is a site change.)

## For the reviewer

- Verified locally: `npm ci && npm run lint && npm run build` pass; tested in the browser with real snapshot data (PR chips attach to #5/#6) and with a synthetic "Part of #2" chain to confirm nesting, filter dimming, and closed-issue rendering.
- The weakest point to push on: parent detection is regex on the issue body ("part of #n", first match, case-insensitive). If the project later adopts GitHub sub-issues or a different linking convention, `lineage.ts` is the one place to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1728" height="1002" alt="Screenshot 2026-07-02 at 11 35 01 AM" src="https://github.com/user-attachments/assets/03ecd58c-42b7-49f4-9ca9-89b6067c999b" />


Closes #41.
