### PR TITLE
web: submenu nav, clean URLs, in-app Method link

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { createHashRouter } from "react-router-dom";
+import { createBrowserRouter } from "react-router-dom";
 import { AppLayout } from "@/components/layout/AppLayout";
 import Dashboard from "@/pages/Dashboard";
 import Board from "@/pages/Board";
@@ -12,7 +12,7 @@ import Methodology from "@/pages/Methodology";
 import Contribute from "@/pages/Contribute";
 import NotFound from "@/pages/NotFound";
 
-export const router = createHashRouter([
+export const router = createBrowserRouter([
   {
     element: <AppLayout />,
     children: [
@@ -29,4 +29,7 @@ export const router = createHashRouter([
       { path: "*", element: <NotFound /> },
     ],
   },
-]);
+], {
+  // Served from a GitHub Pages project subpath (see vite `base`).
+  basename: import.meta.env.BASE_URL.replace(/\/$/, ""),
+});

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -10,8 +10,8 @@ export function Footer({ repoUrl, generatedAt }: { repoUrl?: string; generatedAt
         </div>
         <div className="flex items-center gap-4">
           <Link to="/submit" className="hover:text-foreground">Submit</Link>
+          <Link to="/methodology" className="hover:text-foreground">Method</Link>
           {repoUrl ? <a href={repoUrl} className="hover:text-foreground">GitHub</a> : null}
-          {repoUrl ? <a href={`${repoUrl}/blob/main/CONTRIBUTING.md`} className="hover:text-foreground">Method</a> : null}
         </div>
       </div>
       {generatedAt ? (

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,25 +1,50 @@
-import { NavLink, Link } from "react-router-dom";
-import { Moon, Sun, Plus, Menu, X } from "lucide-react";
+import { NavLink, Link, useLocation } from "react-router-dom";
+import { Moon, Sun, Plus, Menu, X, ChevronDown } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { LogoMark, GitHubIcon } from "./Logo";
 import { useTheme } from "@/hooks/useTheme";
 import { cn } from "@/lib/utils";
 
-const NAV = [
+type NavItem = { to: string; label: string; end?: boolean };
+type NavGroup = { label: string; items: NavItem[] };
+
+const LINKS: NavItem[] = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/board", label: "Board" },
-  { to: "/contribute", label: "Get started" },
-  { to: "/findings", label: "Findings" },
-  { to: "/sources", label: "Sources" },
-  { to: "/leaderboard", label: "Leaderboard" },
-  { to: "/review", label: "Review" },
-  { to: "/methodology", label: "Method" },
 ];
+
+const GROUPS: NavGroup[] = [
+  {
+    label: "Research",
+    items: [
+      { to: "/findings", label: "Findings" },
+      { to: "/sources", label: "Sources" },
+      { to: "/review", label: "Review" },
+    ],
+  },
+  {
+    label: "Community",
+    items: [
+      { to: "/leaderboard", label: "Leaderboard" },
+      { to: "/contribute", label: "Get started" },
+      { to: "/methodology", label: "Method" },
+    ],
+  },
+];
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+  cn(
+    "rounded-md px-3 py-2 text-sm font-medium transition-colors",
+    isActive ? "bg-secondary text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-secondary/60"
+  );
 
 export function Header({ repoUrl }: { repoUrl?: string }) {
   const { theme, toggle } = useTheme();
   const [open, setOpen] = useState(false);
+  const { pathname } = useLocation();
+
   return (
     <header className="sticky top-0 z-40 rounded-none border-x-0 border-t-0 border-b border-border bg-background/80 shadow-[0_1px_3px_0_rgb(0_0_0_/_0.06)] backdrop-blur-md">
       <div className="container flex h-16 items-center justify-between gap-4">
@@ -32,13 +57,38 @@ export function Header({ repoUrl }: { repoUrl?: string }) {
         </Link>
 
         <nav className="hidden items-center gap-1 md:flex">
-          {NAV.map((n) => (
-            <NavLink key={n.to} to={n.to} end={n.end}
-              className={({ isActive }) => cn("rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                isActive ? "bg-secondary text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-secondary/60")}>
+          {LINKS.map((n) => (
+            <NavLink key={n.to} to={n.to} end={n.end} className={navLinkClass}>
               {n.label}
             </NavLink>
           ))}
+          {GROUPS.map((group) => {
+            const active = group.items.some((i) => pathname === i.to);
+            return (
+              <DropdownMenu key={group.label}>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className={cn(
+                      "inline-flex items-center gap-1 rounded-md px-3 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring data-[state=open]:bg-secondary/60",
+                      active ? "bg-secondary text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-secondary/60"
+                    )}
+                  >
+                    {group.label}
+                    <ChevronDown className="h-3.5 w-3.5 opacity-60 transition-transform data-[state=open]:rotate-180" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  {group.items.map((i) => (
+                    <DropdownMenuItem key={i.to} asChild>
+                      <NavLink to={i.to} className={({ isActive }) => cn("w-full", isActive && "bg-accent text-accent-foreground")}>
+                        {i.label}
+                      </NavLink>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            );
+          })}
         </nav>
 
         <div className="flex items-center gap-2">
@@ -62,13 +112,24 @@ export function Header({ repoUrl }: { repoUrl?: string }) {
       {open ? (
         <nav className="border-t border-border bg-background md:hidden">
           <div className="container flex flex-col py-2">
-            {NAV.map((n) => (
+            {LINKS.map((n) => (
               <NavLink key={n.to} to={n.to} end={n.end} onClick={() => setOpen(false)}
                 className={({ isActive }) => cn("rounded-md px-3 py-2.5 text-sm font-medium", isActive ? "bg-secondary" : "text-muted-foreground")}>
                 {n.label}
               </NavLink>
             ))}
-            <Link to="/submit" onClick={() => setOpen(false)} className="mt-1">
+            {GROUPS.map((group) => (
+              <div key={group.label} className="mt-1">
+                <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">{group.label}</div>
+                {group.items.map((i) => (
+                  <NavLink key={i.to} to={i.to} onClick={() => setOpen(false)}
+                    className={({ isActive }) => cn("rounded-md px-3 py-2.5 text-sm font-medium", isActive ? "bg-secondary" : "text-muted-foreground")}>
+                    {i.label}
+                  </NavLink>
+                ))}
+              </div>
+            ))}
+            <Link to="/submit" onClick={() => setOpen(false)} className="mt-2">
               <Button variant="brand" className="w-full"><Plus className="h-4 w-4" /> Submit an issue</Button>
             </Link>
           </div>

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-1",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem };

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,11 +1,26 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
+import { copyFileSync } from "node:fs";
+
+// GitHub Pages has no server-side rewrite, so a deep link like
+// /the-for-good-project/findings (or a refresh on it) would return a 404.
+// Emitting 404.html as a byte-for-byte copy of index.html lets Pages serve
+// the SPA for any unknown path; the browser router then renders the route.
+function spaFallback() {
+  return {
+    name: "spa-404-fallback",
+    closeBundle() {
+      const dist = path.resolve(__dirname, "dist");
+      copyFileSync(path.join(dist, "index.html"), path.join(dist, "404.html"));
+    },
+  };
+}
 
 // Project Pages site is served from /the-for-good-project/
 export default defineConfig({
   base: "/the-for-good-project/",
-  plugins: [react()],
+  plugins: [react(), spaFallback()],
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },
   },


### PR DESCRIPTION
Three tweaks to the `web/` app. (Re-opened cleanly after PR #29 got entangled with unrelated content — see #31.)

## Changes
1. **Footer "Method" → in-app page.** Was linking out to `CONTRIBUTING.md` on GitHub; now routes to the in-app `/methodology` page.
2. **Header condensed into submenus.** Top-level **Dashboard · Board**, then **Research ▾** (Findings, Sources, Review) and **Community ▾** (Leaderboard, Get started, Method). The group trigger shows an active state when the current page lives inside it; the mobile menu uses the same grouping with section labels. Adds a shadcn-style `dropdown-menu` primitive over the already-installed `@radix-ui/react-dropdown-menu`.
3. **Clean URLs.** `createHashRouter` → `createBrowserRouter`, so paths are `/findings` instead of `/#/findings`. `basename` is derived from the Vite base. A Vite `closeBundle` plugin emits `404.html` as a copy of `index.html` so GitHub Pages serves the SPA on deep links / refresh (Pages has no server-side rewrite).

## Verification
- `tsc -b && vite build` passes; `404.html` emitted identical to `index.html`.
- `oxlint` shows only pre-existing warnings in unrelated files.
- Manually verified via `vite preview`: dropdowns open and navigate, URLs are clean (no `#`), a **direct load** of `/methodology` renders with the right nav group highlighted, and the footer Method link stays in-app.

## Note
The `404.html` SPA fallback is the standard GitHub Pages fix and the file is emitted correctly, but `vite preview` has its own fallback — real Pages behaviour on deep links can only be fully confirmed on the deployed site after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)