### PR TITLE
web: show the rework loop and worktree flow on the site

### DIFF
--- a/web/src/components/shared/WorkflowDiagram.tsx
+++ b/web/src/components/shared/WorkflowDiagram.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, ArrowDown, ScanEye, GitMerge, Send, ShieldCheck } from "lucide-react";
+import { ArrowRight, ArrowDown, ScanEye, GitMerge, Send, ShieldCheck, Undo2 } from "lucide-react";
 import { STAGE_META, STAGE_ORDER } from "@/lib/meta";
 
 function StageNode({ stage, index }: { stage: (typeof STAGE_ORDER)[number]; index: number }) {
@@ -80,9 +80,24 @@ export function WorkflowDiagram() {
           <div className="text-sm">
             <div className="font-semibold">The gate between <span className="text-brand-cyan-dark">In review</span> and <span style={{ color: "#5319E7" }}>Merged</span></div>
             <p className="mt-0.5 text-muted-foreground">
-              Nothing merges until it passes an <strong>adversarial review — done by someone other than the author</strong>, whose job is to
+              Nothing merges until it passes an <strong>adversarial review — anyone can pick one up, except the author</strong>, and the reviewer's job is to
               refute the work: check every citation resolves and supports its claim, that surprises have two sources, and that confidence isn't inflated.
               Trusted reviewers (a whitelist, plus anyone who's earned enough credit) do the reviewing; maintainers run a one-command sweep to merge what's passed.
+            </p>
+          </div>
+        </div>
+
+        {/* Rework loop callout */}
+        <div className="mt-3 flex items-start gap-3 rounded-2xl border border-dashed border-[#D93F0B]/50 bg-[#D93F0B]/5 p-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#D93F0B]/15">
+            <Undo2 className="h-5 w-5" style={{ color: "#D93F0B" }} />
+          </div>
+          <div className="text-sm">
+            <div className="font-semibold">If the review finds problems → <span style={{ color: "#D93F0B" }}>Changes requested</span></div>
+            <p className="mt-0.5 text-muted-foreground">
+              The work goes <strong>back to whoever did it</strong> — the issue is marked <em>changes requested</em> and their next work loop picks it up
+              before anything new, fixes it against the reviewer's feedback on the same PR, and returns it to <strong>In review</strong> for a fresh
+              adversarial review. Reviewers skip it until the rework lands, so no tokens are wasted re-reviewing the same revision.
             </p>
           </div>
         </div>

--- a/web/src/lib/meta.ts
+++ b/web/src/lib/meta.ts
@@ -13,6 +13,7 @@ export const STATUS_META: Record<StatusKey, { label: string; color: string; text
   available: { label: "Available", color: "#0E8A16", text: "text-emerald-700" },
   claimed: { label: "Claimed", color: "#B8860B", text: "text-amber-700" },
   "in-review": { label: "In review", color: "#1D76DB", text: "text-blue-700" },
+  "changes-requested": { label: "Changes requested", color: "#D93F0B", text: "text-orange-700" },
   blocked: { label: "Blocked", color: "#B60205", text: "text-red-700" },
   done: { label: "Done", color: "#5319E7", text: "text-violet-700" },
   none: { label: "New", color: "#78716C", text: "text-stone-600" },

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,5 +1,5 @@
 export type Stage = "discover" | "research" | "ideate" | "build" | "none";
-export type StatusKey = "available" | "claimed" | "in-review" | "blocked" | "done" | "none";
+export type StatusKey = "available" | "claimed" | "in-review" | "changes-requested" | "blocked" | "done" | "none";
 
 export interface Person {
   login: string;

--- a/web/src/pages/Contribute.tsx
+++ b/web/src/pages/Contribute.tsx
@@ -11,8 +11,8 @@ function Code({ children }: { children: string }) {
 }
 
 const SCRIPTS = [
-  { icon: Terminal, name: "start_work.sh", tag: "do the work", desc: "Claims the next available issue, runs your agent (codex or claude) on it following the method, and opens a PR. Moves the issue to “in review” automatically.", color: "#2E4057" },
-  { icon: ScanEye, name: "review_work.sh", tag: "review", desc: "Runs an adversarial agent that tries to refute an open PR against the method, then records the review. Refuses to review your own work.", color: "#0EA5E9" },
+  { icon: Terminal, name: "start_work.sh", tag: "do the work", desc: "Works your queue: rework a reviewer sent back to you first, then the next available issue. Runs your agent (codex or claude) in a fresh worktree from the latest main, and opens (or updates) a PR. Status labels move automatically.", color: "#2E4057" },
+  { icon: ScanEye, name: "review_work.sh", tag: "review", desc: "Runs an adversarial agent that tries to refute an open PR against the method. Anyone can review — except the author. If it finds problems, the work is routed back to whoever did it for rework.", color: "#0EA5E9" },
   { icon: GitMerge, name: "merge_ready.sh", tag: "merge (maintainers)", desc: "One-command sweep: merges every PR that has passed a trusted, non-author review. Trust = a whitelist plus anyone who's earned enough credit.", color: "#5319E7" },
 ];
 
@@ -44,7 +44,7 @@ export default function Contribute() {
               <>Find an unclaimed issue on the <Link to="/board" className="text-brand-cyan-dark hover:underline">board</Link> — new? filter for <em>good first issue</em>.</>,
               <>Claim it (assign yourself, mark it <em>claimed</em>) so no one doubles up.</>,
               <>Do the work following <Link to="/methodology" className="text-brand-cyan-dark hover:underline">the method</Link> — cite everything, mark confidence, be honest about gaps.</>,
-              <>Open a pull request. Someone else adversarially reviews it, and once it passes it merges into the commons.</>,
+              <>Open a pull request. Someone else adversarially reviews it — if they find problems it comes back to you to fix — and once it passes it merges into the commons.</>,
             ].map((step, i) => (
               <li key={i} className="flex gap-3">
                 <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-brand-indigo/10 text-xs font-semibold text-brand-indigo">{i + 1}</span>
@@ -73,7 +73,9 @@ export default function Contribute() {
             <div><span className="text-brand-orange">./review_work.sh</span></div>
           </div>
           <p className="mt-4 text-sm text-muted-foreground">
-            The scripts own the status labels and the merge gate — the agent just does the work. Full guide in the repo's <Code>docs/AUTOMATION.md</Code>.
+            The scripts own the status labels and the merge gate — the agent just does the work, in a throwaway git worktree pulled fresh from{" "}
+            <Code>main</Code> every loop. If a reviewer pushes back, the work returns to <em>your</em> queue and your next loop fixes it before
+            picking up anything new. Full guide in the repo's <Code>docs/AUTOMATION.md</Code>.
           </p>
           <div className="mt-5">
             <a href={repo} target="_blank" rel="noreferrer"><Button variant="outline" size="sm">Open the repo <ArrowRight className="h-4 w-4" /></Button></a>

--- a/web/src/pages/Methodology.tsx
+++ b/web/src/pages/Methodology.tsx
@@ -88,7 +88,9 @@ export default function Methodology() {
               Review here is not a nod of approval. The reviewer's job — a person or an AI agent, always <strong>someone other than the author</strong> —
               is to <strong>try to refute the finding</strong>: hunt for an uncited claim, a surprise with only one source, an inflated confidence mark,
               or a citation that doesn't actually say what it's cited for. A finding is trusted only when a good-faith attempt to knock it down fails.
-              The standard is the same whether the work came from a person or an agent — provenance doesn't earn trust here; evidence does.
+              When a review finds problems, the work goes <strong>back to its author</strong> to fix and returns for a fresh review — pushback isn't rejection,
+              it's the loop that makes the work trustworthy. The standard is the same whether the work came from a person or an agent —
+              provenance doesn't earn trust here; evidence does.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Companion to #33 — the site now explains how the pushback loop works.

- **Workflow diagram** (Get started page): a new *Changes requested* callout shows what happens when a review finds problems — the work returns to its author's queue, their next loop fixes it on the same PR, and it comes back for a fresh adversarial review. The review-gate callout now says **anyone but the author** can pick up a review.
- **Contribute**: the `start_work.sh` / `review_work.sh` cards and the agent-autopilot path describe the rework-first queue and fresh-from-main throwaway worktrees.
- **Methodology**: the adversarial-review section explains that pushback isn't rejection — it's the loop that makes the work trustworthy.
- **Board support**: `changes-requested` added to the status types and `STATUS_META`, so issue badges and the board filter render it (colour matches the GitHub label).

## Testing
- `npm run build` (tsc + vite) passes; `npm run lint` shows only pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMRMxrZ6mw8AscsVpxaCQE