### PR TITLE
web: dedicated in-app finding detail page (Closes #28)

### DIFF
--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -178,6 +178,9 @@ async function main() {
         .replace(/[#>*`-]/g, " ").replace(/\s+/g, " ").trim().slice(0, 280);
       findings.push({
         path: rel,
+        // Stable, URL-safe id for the in-app detail route (/findings/<slug>),
+        // e.g. research/findings/ai-policy/foo.md -> ai-policy/foo
+        slug: rel.replace(/^research\/findings\//, "").replace(/\.md$/, ""),
         title: data.title || entry.replace(/\.md$/, ""),
         domain,
         confidence: data.confidence || "Unknown",
@@ -187,6 +190,7 @@ async function main() {
         date: data.date ? String(data.date) : "",
         url: `${repoMeta.html_url}/blob/${repoMeta.default_branch}/${rel}`,
         summary,
+        body: content,
         sources: fSources,
       });
     }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import Dashboard from "@/pages/Dashboard";
 import Board from "@/pages/Board";
 import IssueDetail from "@/pages/IssueDetail";
 import Findings from "@/pages/Findings";
+import FindingDetail from "@/pages/FindingDetail";
 import Sources from "@/pages/Sources";
 import Leaderboard from "@/pages/Leaderboard";
 import Review from "@/pages/Review";
@@ -20,6 +21,7 @@ export const router = createBrowserRouter([
       { path: "/board", element: <Board /> },
       { path: "/issue/:number", element: <IssueDetail /> },
       { path: "/findings", element: <Findings /> },
+      { path: "/findings/*", element: <FindingDetail /> },
       { path: "/sources", element: <Sources /> },
       { path: "/leaderboard", element: <Leaderboard /> },
       { path: "/review", element: <Review /> },

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -59,6 +59,7 @@ export interface FindingSource {
 
 export interface Finding {
   path: string;
+  slug: string;
   title: string;
   domain: string;
   confidence: "High" | "Medium" | "Low" | "Unknown";
@@ -68,6 +69,7 @@ export interface Finding {
   date: string;
   url: string;
   summary: string;
+  body: string;
   sources: FindingSource[];
 }
 

--- a/web/src/pages/FindingDetail.tsx
+++ b/web/src/pages/FindingDetail.tsx
@@ -1,0 +1,97 @@
+import { Link, useParams } from "react-router-dom";
+import { ArrowLeft, ExternalLink, Link2, Cpu } from "lucide-react";
+import { useSnapshot } from "@/hooks/useSnapshot";
+import { Loading, ErrorState } from "@/components/shared/States";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { DomainBadge } from "@/components/shared/Badges";
+import { Markdown } from "@/components/shared/Markdown";
+import { CONFIDENCE_COLOR } from "@/lib/meta";
+
+const hostOf = (u: string) => {
+  try { return new URL(u).hostname.replace(/^www\./, ""); } catch { return u; }
+};
+
+export default function FindingDetail() {
+  const slug = useParams()["*"];
+  const { data, error, loading } = useSnapshot();
+  if (loading) return <Loading />;
+  if (error || !data) return <ErrorState message={error || "No data"} />;
+
+  const finding = data.findings.find((f) => f.slug === slug);
+  if (!finding) {
+    return (
+      <div className="mx-auto max-w-4xl">
+        <Link to="/findings" className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+          <ArrowLeft className="h-4 w-4" /> Back to findings
+        </Link>
+        <ErrorState message="This finding isn't in the latest snapshot. It may have been renamed or not published yet." />
+      </div>
+    );
+  }
+
+  const confidenceColor = CONFIDENCE_COLOR[finding.confidence] ?? CONFIDENCE_COLOR.Unknown;
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <Link to="/findings" className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" /> Back to findings
+      </Link>
+
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <DomainBadge domain={finding.domain} />
+        <span className="inline-flex items-center gap-1.5 text-xs font-medium" style={{ color: confidenceColor }}>
+          <span className="h-2 w-2 rounded-full" style={{ backgroundColor: confidenceColor }} /> {finding.confidence} confidence
+        </span>
+      </div>
+
+      <h1 className="font-serif text-3xl font-bold leading-tight text-brand-navy dark:text-foreground">{finding.title}</h1>
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
+        {finding.author && finding.author !== "unknown" ? <span>by {finding.author}</span> : null}
+        {finding.agent ? (
+          <span className="inline-flex items-center gap-1"><Cpu className="h-3.5 w-3.5" /> {finding.agent}{finding.model ? ` · ${finding.model}` : ""}</span>
+        ) : null}
+        {finding.date ? <span>{finding.date}</span> : null}
+        <a href={finding.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-brand-cyan-dark hover:underline">
+          View source on GitHub <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
+
+      <Separator className="my-6" />
+
+      <div className="grid gap-6 md:grid-cols-3">
+        <div className="md:col-span-2">
+          <Card>
+            <CardContent className="pt-6">
+              {finding.body ? <Markdown>{finding.body}</Markdown> : <p className="text-sm text-muted-foreground">No content in this finding.</p>}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-sm uppercase tracking-wide text-muted-foreground">
+                <Link2 className="h-4 w-4" /> Sources ({finding.sources.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {finding.sources.length ? finding.sources.map((s, i) => (
+                <a key={`${s.url}-${i}`} href={s.url} target="_blank" rel="noreferrer" className="block rounded-lg p-2 transition-colors hover:bg-secondary/60">
+                  <div className="line-clamp-2 text-sm font-medium text-brand-cyan-dark">{s.label}</div>
+                  <div className="line-clamp-1 text-xs text-muted-foreground">{hostOf(s.url)}</div>
+                </a>
+              )) : <p className="text-sm text-muted-foreground">No sources listed.</p>}
+            </CardContent>
+          </Card>
+
+          <a href={finding.url} target="_blank" rel="noreferrer" className="block">
+            <Button variant="brand" className="w-full">View source on GitHub <ExternalLink className="h-4 w-4" /></Button>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Findings.tsx
+++ b/web/src/pages/Findings.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
-import { BookOpen, ExternalLink, Link2, Search, Cpu } from "lucide-react";
+import { Link } from "react-router-dom";
+import { BookOpen, Link2, Search, Cpu } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { PageHeader } from "@/components/shared/PageHeader";
@@ -47,7 +48,7 @@ export default function Findings() {
 
           <div className="grid gap-4 md:grid-cols-2">
             {findings.map((f) => (
-              <a key={f.path} href={f.url} target="_blank" rel="noreferrer">
+              <Link key={f.path} to={`/findings/${f.slug}`}>
                 <Card className="group h-full transition-all hover:-translate-y-0.5 hover:shadow-md">
                   <CardHeader>
                     <div className="flex items-center justify-between gap-2">
@@ -67,11 +68,11 @@ export default function Findings() {
                           <Cpu className="h-3 w-3" /> {f.agent}{f.model ? ` · ${f.model}` : ""}
                         </span>
                       ) : null}
-                      <span className="ml-auto inline-flex items-center gap-1"><Link2 className="h-3.5 w-3.5" /> {f.sources.length} source{f.sources.length === 1 ? "" : "s"} <ExternalLink className="ml-1 h-3.5 w-3.5" /></span>
+                      <span className="ml-auto inline-flex items-center gap-1"><Link2 className="h-3.5 w-3.5" /> {f.sources.length} source{f.sources.length === 1 ? "" : "s"}</span>
                     </div>
                   </CardContent>
                 </Card>
-              </a>
+              </Link>
             ))}
           </div>
         </>


### PR DESCRIPTION
Closes #28.

Findings previously linked out to the raw markdown blob on GitHub. This adds an in-app detail page so a finding renders within the site.

## Changes
- **New `/findings/*` route → `FindingDetail` page**: domain + confidence badges, author / agent·model / date metadata, the rendered markdown body (via the existing `Markdown` component), a **Sources** sidebar, and a **"View source on GitHub"** link kept as a secondary action.
- **`build-data.mjs`** now emits `slug` (a stable URL id derived from the file path, e.g. `ai-policy/nz-public-sector-ai-guidance`) and `body` (the finding's markdown) on each finding. `Finding` type updated to match.
- **Findings cards** navigate in-app via `<Link to="/findings/:slug">` instead of `target="_blank"` to GitHub; dropped the external-link icon that implied leaving the site.

## Verification
- `tsc -b && vite build` passes; `oxlint` clean on the changed files.
- Regenerated the snapshot locally (1 finding, `slug` + 30 KB `body` present) and verified via `vite preview`:
  - Findings card → navigates to `/findings/ai-policy/nz-public-sector-ai-guidance` (clean in-app URL).
  - Detail page renders badges, metadata, full markdown body with inline source links, and the 23-source sidebar.
- `snapshot.json` is intentionally **not** committed — it's a CI-regenerated build artifact; the deployed site will rebuild it with the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)