### PR TITLE
fix: discover PRs must not close their stream root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ You are here to move one issue forward, to a high standard, end to end. Work lik
    git push -u origin research/<slug>
    gh pr create --fill --body "Closes #<n>. Part of #<parent>."
    ```
+   **Exception — discover issues:** use `Part of #<n>` instead of `Closes #<n>`
+   everywhere. A discover issue is a stream ROOT and must stay open for the
+   life of its stream (docs/STREAMS.md); a `Closes` ref would end the stream
+   the moment your framing PR merges.
 6. **Expect adversarial review.** A reviewer (human or the review agent) will try to *refute* your claims. Respond with evidence, not defensiveness. Fix what's fair.
 
 ## No write access? (most contributors)

--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -72,6 +72,18 @@ issue is still too big, the agent narrows it in the PR and lists what it left
 uncovered; the steward decides at synthesis whether more work is spawned.
 Ideate and build issues never fan out — that's what the gates are for.
 
+### Root lifecycle: the root issue never closes via a PR
+
+A stream's root Discover issue **stays open for the life of the stream** — it
+anchors the `stream:<n>` label, the drain trigger, and the human queue. So a
+discover framing PR links with **`Part of #<root>`, never `Closes`** (the
+runner prompts this automatically and can still find the PR). Child issues
+are the opposite: their PRs **must** use `Closes #<n>` — the child closing on
+merge is exactly what fires the drain check. The root is closed by the
+steward, by hand, when the stream ships or is parked. (After a framing PR
+merges, clear the root's `status: in-review` label by hand — the root then
+has no work-status until the drain flags it `needs-synthesis`.)
+
 ### The drain → synthesis trigger
 
 When the **last open child issue in a stream closes**, `stream-sync.yml`

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -107,10 +107,16 @@ review_feedback() {  # $1 = pr number
     --jq '.[] | "- \(.path):\(.line // .original_line // 0) @\(.user.login): \(.body)"' 2>/dev/null || true
 }
 
-# The open PR (if any) that closes a given issue number, via GraphQL closing refs.
+# The open PR (if any) for a given issue number. Closing refs first; falls
+# back to a "Part of #n" body search — discover PRs deliberately do NOT close
+# their issue (a stream ROOT must stay open for the life of the stream).
 pr_for_issue() {
-  gh api graphql -f query="{repository(owner:\"$OWNER\",name:\"$NAME\"){pullRequests(states:OPEN,first:50){nodes{number closingIssuesReferences(first:10){nodes{number}}}}}}" \
-    --jq ".data.repository.pullRequests.nodes[] | select(.closingIssuesReferences.nodes|map(.number)|index($1)) | .number" | head -1
+  local pr
+  pr="$(gh api graphql -f query="{repository(owner:\"$OWNER\",name:\"$NAME\"){pullRequests(states:OPEN,first:50){nodes{number closingIssuesReferences(first:10){nodes{number}}}}}}" \
+    --jq ".data.repository.pullRequests.nodes[] | select(.closingIssuesReferences.nodes|map(.number)|index($1)) | .number" | head -1)"
+  [ -n "$pr" ] && { echo "$pr"; return 0; }
+  gh pr list --repo "$REPO" --state open --search "\"Part of #$1\" in:body" \
+    --json number --jq '.[0].number // empty' 2>/dev/null || true
 }
 
 # Issue closed by a PR (first closing ref).

--- a/start_work.sh
+++ b/start_work.sh
@@ -50,6 +50,19 @@ work_prompt() {  # $1 = issue number
   local stream; stream="$(label_field "$labels" "stream:")"
   local prov_model
   if [ -n "${MODEL:-}" ]; then prov_model="$MODEL"; else prov_model="the exact model identifier you are running as"; fi
+  # Discover issues are stream ROOTS: their PR must NOT close them (the root
+  # anchors the stream's lifecycle until the steward ends it). Children close
+  # via their PRs as normal — that's what fires the drain→synthesis trigger.
+  local link_ref link_why
+  if [ "$stage" = "discover" ]; then
+    link_ref="Part of"
+    link_why="(Use \"Part of\", NOT \"Closes\" — this issue is a stream root and must stay
+   open while its stream is worked; see docs/STREAMS.md.)"
+  else
+    link_ref="Closes"
+    link_why="(\"Closes\" is required — the issue closing on merge is what tells the
+   stream automation this piece of work is done.)"
+  fi
   # Bounded fan-out (docs/STREAMS.md): the agent on a root issue (depth 0) may
   # open sub-issues, an agent on a sub-issue (depth 1) may open one more level,
   # and depth >= 2 may not fan out at all. WHITELIST discover/research only —
@@ -114,10 +127,11 @@ we can track what produced it:
 
 Then, using git and the gh CLI (both are already authenticated):
 1. Create a branch named "$stage/<slug>".
-2. Commit your work with a message ending "(Closes #$n)".
+2. Commit your work with a message ending "($link_ref #$n)".
 3. Push the branch to origin.
-4. Open a pull request whose body contains "Closes #$n" so it links to the
-   issue. Use: gh pr create --fill --body "Closes #$n. <one-line summary>".
+4. Open a pull request whose body contains "$link_ref #$n" so it links to the
+   issue. Use: gh pr create --fill --body "$link_ref #$n. <one-line summary>".
+   $link_why
 ${stream:+   The PR body must also contain the exact text  Stream: #$stream  on the same
    line, so the PR stays tracked to its stream.
 }


### PR DESCRIPTION
Found while auditing in-flight issues: PR #27's `Closes #4` would have closed **stream #4's root** on merge — ending the stream's drain trigger and G1 queue while children #24/#25 are still open. (That PR's body is already hand-fixed to `Part of #4`.)

This makes the rule structural:
- **start_work.sh**: discover-stage prompts instruct `Part of #n` in commit + PR body (with the reason); every other stage keeps `Closes #n` — a child closing on merge is exactly what fires the drain→synthesis check.
- **fg-common.sh**: `pr_for_issue()` falls back to a `"Part of #n" in:body` search when no closing ref exists, so the runner still finds discover PRs (verified live: `pr_for_issue(4)` → 27).
- **docs/STREAMS.md + AGENTS.md**: root lifecycle documented — roots are closed by the steward when the stream ships or parks, never by a PR.

## Testing
`bash -n` both scripts; `DRY_RUN=1` prompt shows `Part of #2` for the discover issue and `Closes` for others; live `pr_for_issue(4)` returns 27 via the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMRMxrZ6mw8AscsVpxaCQE