### PR TITLE
chore: default the work agent to claude

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -43,7 +43,7 @@ issue. Runs your agent on it following the project method, and moves it to
 
 ```bash
 ./start_work.sh                 # work the queue until it's empty
-AGENT=claude ./start_work.sh    # use `claude -p` instead of the default `codex`
+AGENT=codex ./start_work.sh     # use `codex exec` instead of the default `claude`
 STAGE=research ./start_work.sh  # only pick up research-stage issues
 MAX=1 ./start_work.sh           # one issue, then stop
 DRY_RUN=1 ./start_work.sh       # show what it would do, change nothing

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -5,7 +5,7 @@
 REPO="${FOR_GOOD_REPO:-thecolab-ai/the-for-good-project}"
 OWNER="${REPO%%/*}"
 NAME="${REPO##*/}"
-AGENT="${AGENT:-codex}"                 # codex | claude
+AGENT="${AGENT:-claude}"                # claude | codex
 MODEL="${MODEL:-}"                       # optional model override
 AGENT_TIMEOUT="${AGENT_TIMEOUT:-2400}"   # seconds per agent run (0 = none)
 REVIEW_CHECK_CONTEXT="for-good/adversarial-review"

--- a/start_work.sh
+++ b/start_work.sh
@@ -13,13 +13,13 @@
 #
 # Usage:
 #   ./start_work.sh                 # work issues until the queue is empty
-#   AGENT=claude ./start_work.sh    # use `claude -p` instead of `codex`
+#   AGENT=codex ./start_work.sh     # use `codex exec` instead of the default `claude`
 #   STAGE=research ./start_work.sh  # only pick up research-stage issues
 #   MAX=1 ./start_work.sh           # do a single issue and stop
 #   DRY_RUN=1 ./start_work.sh       # show what it would do, touch nothing
 #   MODEL=gpt-5.5 ./start_work.sh   # override the agent model
 #
-# Env: AGENT(codex|claude) MAX STAGE POLL_SECONDS DRY_RUN MODEL AGENT_TIMEOUT
+# Env: AGENT(claude|codex, default claude) MAX STAGE POLL_SECONDS DRY_RUN MODEL AGENT_TIMEOUT
 #      FOR_GOOD_REPO REPO_DIR
 set -euo pipefail
 cd "$(dirname "$0")"


### PR DESCRIPTION
Sets `claude` as the default agent for `start_work.sh` / `review_work.sh`, per Adam's request.

- `scripts/fg-common.sh`: `AGENT="${AGENT:-codex}"` → `AGENT="${AGENT:-claude}"`
- `start_work.sh` usage header + `docs/AUTOMATION.md`: codex is now documented as the opt-in override (`AGENT=codex ./start_work.sh`)

`bash -n` passes on both scripts. No behavioural change beyond the default — `AGENT=codex` still works exactly as before.