### PR TITLE
chore(scripts): default agent to claude + positional agent/--model args

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -42,12 +42,18 @@ issue. Runs your agent on it following the project method, and moves it to
 **in review** once the agent opens (or updates) a PR.
 
 ```bash
-./start_work.sh                 # work the queue until it's empty
-AGENT=codex ./start_work.sh     # use `codex exec` instead of the default `claude`
+./start_work.sh                 # work the queue until it's empty (default agent: claude)
+./start_work.sh codex           # use `codex exec` instead
+./start_work.sh --model <name>  # override the agent model
+./start_work.sh codex --model gpt-5.5
 STAGE=research ./start_work.sh  # only pick up research-stage issues
 MAX=1 ./start_work.sh           # one issue, then stop
 DRY_RUN=1 ./start_work.sh       # show what it would do, change nothing
 ```
+
+The agent can be given as a positional word (`claude` or `codex`) and the model
+via `--model <name>`; both override the `AGENT` / `MODEL` env vars. `claude` is
+the default.
 
 For a **new issue** it claims (assigns you + `status: claimed`), creates a fresh
 worktree from `origin/main`, hands the issue to the agent with the method baked

--- a/review_work.sh
+++ b/review_work.sh
@@ -19,17 +19,20 @@
 # (a bot / second GitHub account, or a GitHub App token, with write access).
 #
 # Usage:
-#   REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh          # review all open PRs
-#   REVIEW_GITHUB_TOKEN=<bot-pat> AGENT=claude ./review_work.sh
+#   REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh           # review all open PRs (claude)
+#   REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh codex     # review with codex
+#   REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh --model <name>
 #   REVIEW_GITHUB_TOKEN=<bot-pat> AUTO_MERGE=1 ./review_work.sh
 #   PR=7 ./review_work.sh                                    # a single PR
 #   DRY_RUN=1 ./review_work.sh
 #
-# Env: REVIEW_GITHUB_TOKEN AGENT MODEL AUTO_MERGE PR MAX POLL_SECONDS DRY_RUN
-#      AGENT_TIMEOUT FOR_GOOD_REPO REPO_DIR
+# Args: [claude|codex] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
+# Env:  REVIEW_GITHUB_TOKEN AGENT MODEL AUTO_MERGE PR MAX POLL_SECONDS DRY_RUN
+#       AGENT_TIMEOUT FOR_GOOD_REPO REPO_DIR
 set -euo pipefail
 cd "$(dirname "$0")"
 source "scripts/fg-common.sh"
+parse_agent_args "$@"
 trap 'remove_worktree || true' EXIT INT TERM
 
 DRY_RUN="${DRY_RUN:-0}"

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -5,10 +5,25 @@
 REPO="${FOR_GOOD_REPO:-thecolab-ai/the-for-good-project}"
 OWNER="${REPO%%/*}"
 NAME="${REPO##*/}"
-AGENT="${AGENT:-claude}"                # claude | codex
+AGENT="${AGENT:-claude}"                # claude | codex  (default claude; env or CLI can override)
 MODEL="${MODEL:-}"                       # optional model override
 AGENT_TIMEOUT="${AGENT_TIMEOUT:-2400}"   # seconds per agent run (0 = none)
 REVIEW_CHECK_CONTEXT="for-good/adversarial-review"
+
+# parse_agent_args "$@" — let callers pass the agent as a positional word
+# (claude|codex) and the model via --model <name> / --model=<name> / -m <name>.
+# CLI wins over the AGENT/MODEL env vars. Unknown args are ignored so each
+# script can still read its own env-driven options. Call it right after sourcing.
+parse_agent_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      claude|codex)   AGENT="$1"; shift ;;
+      --model|-m)     MODEL="${2:-}"; shift 2 || shift ;;
+      --model=*)      MODEL="${1#*=}"; shift ;;
+      *)              shift ;;
+    esac
+  done
+}
 
 # ---- pretty logging ----
 c_reset=$'\e[0m'; c_dim=$'\e[2m'; c_blue=$'\e[34m'; c_green=$'\e[32m'; c_yellow=$'\e[33m'; c_red=$'\e[31m'; c_bold=$'\e[1m'

--- a/start_work.sh
+++ b/start_work.sh
@@ -12,18 +12,21 @@
 # runs or how it behaves.
 #
 # Usage:
-#   ./start_work.sh                 # work issues until the queue is empty
-#   AGENT=codex ./start_work.sh     # use `codex exec` instead of the default `claude`
+#   ./start_work.sh                 # work the queue with the default agent (claude)
+#   ./start_work.sh codex           # use `codex exec` instead
+#   ./start_work.sh claude          # explicit claude (the default)
+#   ./start_work.sh --model <name>  # override the agent model
+#   ./start_work.sh codex --model gpt-5.5
 #   STAGE=research ./start_work.sh  # only pick up research-stage issues
 #   MAX=1 ./start_work.sh           # do a single issue and stop
 #   DRY_RUN=1 ./start_work.sh       # show what it would do, touch nothing
-#   MODEL=gpt-5.5 ./start_work.sh   # override the agent model
 #
-# Env: AGENT(claude|codex, default claude) MAX STAGE POLL_SECONDS DRY_RUN MODEL AGENT_TIMEOUT
-#      FOR_GOOD_REPO REPO_DIR
+# Args: [claude|codex] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
+# Env:  AGENT MODEL MAX STAGE POLL_SECONDS DRY_RUN AGENT_TIMEOUT FOR_GOOD_REPO REPO_DIR
 set -euo pipefail
 cd "$(dirname "$0")"
 source "scripts/fg-common.sh"
+parse_agent_args "$@"
 
 MAX="${MAX:-0}"                       # 0 = no limit
 POLL_SECONDS="${POLL_SECONDS:-0}"     # >0 = keep polling when queue empty


### PR DESCRIPTION
Two asks from Adam.

## 1. Default agent → `claude`
`fg-common.sh` now defaults `AGENT` to `claude` (was `codex`).

## 2. Nicer invocation: positional agent + `--model`
Added a shared `parse_agent_args` in `fg-common.sh`, wired into both `start_work.sh` and `review_work.sh`:

```bash
./start_work.sh                     # claude (default)
./start_work.sh codex               # codex
./start_work.sh claude --model <n>  # explicit agent + model
./start_work.sh --model gpt-5.5      # just a model override
```

- Agent given as a positional word (`claude`|`codex`); model via `--model <name>` / `--model=<name>` / `-m <name>`.
- **CLI wins over the `AGENT`/`MODEL` env vars**; unknown args ignored so each script keeps its own env options.
- Same syntax works for `review_work.sh`.
- Usage blocks + `docs/AUTOMATION.md` updated.

## Verified
- `bash -n` clean on all three scripts
- Parser table-tested: `codex --model gpt-5.5` → AGENT=codex/MODEL=gpt-5.5; `claude` → claude; `--model=sonnet-4.6` → claude+model; no args → claude.