### PR TITLE
fix: pr_for_issue fallback must not match child PRs

### DIFF
--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -125,13 +125,20 @@ review_feedback() {  # $1 = pr number
 # The open PR (if any) for a given issue number. Closing refs first; falls
 # back to a "Part of #n" body search — discover PRs deliberately do NOT close
 # their issue (a stream ROOT must stay open for the life of the stream).
+# The fallback skips PRs that close some OTHER issue: child PRs carry
+# "Part of #<root>" too, and must not be mistaken for the root's framing PR.
 pr_for_issue() {
   local pr
   pr="$(gh api graphql -f query="{repository(owner:\"$OWNER\",name:\"$NAME\"){pullRequests(states:OPEN,first:50){nodes{number closingIssuesReferences(first:10){nodes{number}}}}}}" \
     --jq ".data.repository.pullRequests.nodes[] | select(.closingIssuesReferences.nodes|map(.number)|index($1)) | .number" | head -1)"
   [ -n "$pr" ] && { echo "$pr"; return 0; }
-  gh pr list --repo "$REPO" --state open --search "\"Part of #$1\" in:body" \
-    --json number --jq '.[0].number // empty' 2>/dev/null || true
+  local cands c
+  cands="$(gh pr list --repo "$REPO" --state open --search "\"Part of #$1\" in:body" \
+    --json number --jq '.[].number' 2>/dev/null || true)"
+  for c in $cands; do
+    if [ -z "$(issue_for_pr "$c")" ]; then echo "$c"; return 0; fi
+  done
+  return 0
 }
 
 # Issue closed by a PR (first closing ref).


### PR DESCRIPTION
Follow-up to #40. Child PR bodies also carry `Part of #<root>` (per the convention), so the fallback could return a **child's** PR when looking up a root's framing PR — `finish_issue` would then track the wrong PR. A framing PR is distinguishable: it closes nothing. The fallback now skips any candidate with a closing ref.

Verified live: `pr_for_issue(2)` → empty (PR #26 closes #20, correctly skipped), `pr_for_issue(4)` → 27 (framing PR), `pr_for_issue(20)` → 26 (closing ref path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMRMxrZ6mw8AscsVpxaCQE