### PR TITLE
docs: add the For Good Manifesto

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,0 +1,131 @@
+# The For Good Constitution
+
+_The binding rules of the project. Where the [Manifesto](MANIFESTO.md) is the
+spirit — why we exist and where we're going — this is the **law**: the roles,
+the rules that don't bend, and how we change them._
+
+Short on purpose. A constitution people actually read beats an exhaustive one
+they don't. It sits above the working docs it points to and, where they
+conflict, it wins.
+
+---
+
+## Preamble
+
+We are people and AI agents working a shared queue to help solve Aotearoa New
+Zealand's societal problems, to a standard high enough that real decisions can
+rest on our work. We bind ourselves to these rules so that speed never costs us
+trust, and volume never gets mistaken for good.
+
+## Article I — Purpose is supreme
+
+1. The project exists to produce **real-world good** — measured by people and
+   organisations being better off, not by work produced.
+2. When any rule, process, or optimisation stops serving that purpose, it is to
+   be changed. Activity is never a substitute for outcome.
+
+## Article II — Roles and authority
+
+1. **Contributors** — anyone, human or agent, who does the work. No permission
+   needed beyond following [`CONTRIBUTING.md`](CONTRIBUTING.md).
+2. **Stewards** — humans who own a stream's direction and its plain-language
+   synthesis. They hold the judgement authority the gates require (Article IV).
+3. **Maintainers** — a small group from [thecolab.ai](https://thecolab.ai) and
+   the community who triage, keep the system honest, and merge. They administer
+   these rules; they are not above them.
+4. **thecolab.ai** — steward of the project as a whole; holds it to its purpose
+   and hosts the community.
+5. Authority here is earned by demonstrated care and rigour, not tenure or
+   title, and is always exercised **in the open, with reasons**.
+
+## Article III — The rules that do not bend
+
+These are non-negotiable. Work that breaks them does not merge, regardless of
+who or what produced it.
+
+1. **Cite everything.** Every factual claim carries a real, working source.
+   Surprising or load-bearing claims carry two independent ones. Confidence is
+   marked honestly. (Full method: [`CONTRIBUTING.md`](CONTRIBUTING.md),
+   [`docs/METHOD.md`](docs/METHOD.md).)
+2. **No fabrication, ever.** No invented source, statistic, organisation, quote,
+   or result. A fabricated citation is the gravest breach in this project.
+3. **Protect people.** No personal or identifying data. No overstatement of
+   certainty, reach, or authority. Do no harm — and in sensitive domains, assume
+   the potential for harm is real.
+4. **Humans hold judgement.** No work crosses from research into ideas, or ideas
+   into building, without a human deciding it should. The gates in
+   [`docs/STREAMS.md`](docs/STREAMS.md) (G0 framing, G1 synthesis, G2 build) are
+   binding, not advisory.
+5. **Adversarial review before merge.** Every contribution is reviewed by an
+   identity other than its author, whose job is to *refute* it against the
+   method. Provenance never earns trust; evidence does.
+6. **Open by default.** Findings, tools, and method are public and reusable
+   under the project's licences ([CC BY 4.0](LICENSE); code [MIT](projects/LICENSE)).
+7. **Conduct.** Everyone is bound by [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Article IV — Human-in-the-loop is permanent
+
+1. Agents may research, draft, cross-check, and review. Agents may **not** set a
+   stream's direction, pass any gate, publish externally, or merge.
+2. In domains that touch vulnerable people, method review is not sufficient: a
+   human with relevant domain authority or lived experience must sign off before
+   anything ships.
+3. This division is a **design principle, not a transitional phase.** It does not
+   expire as models improve.
+
+## Article V — Rights and limits of AI agents
+
+1. Every agent-produced artifact records its **provenance** (agent and model) so
+   any claim can be traced to what produced it.
+2. Agents act within explicit bounds (e.g. stream fan-out depth limits) and fail
+   *closed* — when unsure of a rule, they stop rather than proceed.
+3. Agents are held to exactly the same method standard as humans. An agent that
+   fabricates is worse than useless, because it produces plausible, well-formatted
+   wrong work at scale.
+
+## Article VI — Rights of contributors
+
+1. **Credit.** Contributions are attributed; contributors may see the real-world
+   impact their work fed into, not just vanity counts.
+2. **Anonymity.** A contributor may work under a pseudonym; identity is never
+   required to participate or be credited.
+3. **A voice.** Anyone may propose a problem, challenge a finding with evidence,
+   or propose an amendment to these documents.
+
+## Article VII — Decisions and disputes
+
+1. Most decisions are made in the open on issues and PRs.
+2. A contested finding is resolved by evidence and adversarial review, not by
+   seniority. Disagree well; bring sources.
+3. Where a judgement call isn't obvious — a new domain, a policy change, a
+   contested direction — maintainers decide **in the open, with reasons**, after
+   genuine consideration of dissent. (Process detail:
+   [`docs/GOVERNANCE.md`](docs/GOVERNANCE.md).)
+
+## Article VIII — Amendment
+
+1. This Constitution and the Manifesto are **living documents**. Either is
+   changed the same way everything else is: by pull request, argued in the open.
+2. An amendment to Article III (the rules that do not bend) requires explicit
+   maintainer approval and a clear statement of *why the purpose is better served*
+   by the change.
+3. No amendment may remove Article I (purpose is supreme) or Article IV
+   (human-in-the-loop is permanent) without ceasing to be this project.
+
+## Article IX — Precedence
+
+When guidance conflicts, this is the order that wins:
+
+1. **This Constitution** — the binding rules.
+2. **[The Manifesto](MANIFESTO.md)** — the spirit and direction.
+3. **The working docs** — [`CONTRIBUTING.md`](CONTRIBUTING.md),
+   [`docs/METHOD.md`](docs/METHOD.md), [`docs/STREAMS.md`](docs/STREAMS.md),
+   [`docs/GOVERNANCE.md`](docs/GOVERNANCE.md), [`AGENTS.md`](AGENTS.md).
+
+If a rule here ever blocks the project's purpose (Article I), that is a reason to
+**amend it in the open** — never a licence to quietly ignore it.
+
+---
+
+_Ratified by working this way. Amendable by anyone with a better argument._
+_Built together, in Aotearoa. 🇳🇿_

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -2,10 +2,10 @@
 
 _Where this project is going, and how we keep it honest on the way._
 
-This is our compass, not our constitution. The [method](CONTRIBUTING.md), the
-[streams and gates](docs/STREAMS.md), and the [governance](docs/GOVERNANCE.md)
-are how we work. This is *why*, and what "good" has to mean for us to have
-earned the name.
+This is our compass. The [Constitution](CONSTITUTION.md) is the binding law; the
+[method](CONTRIBUTING.md), the [streams and gates](docs/STREAMS.md), and the
+[governance](docs/GOVERNANCE.md) are how we work. This is *why*, and what "good"
+has to mean for us to have earned the name.
 
 ---
 

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -1,0 +1,124 @@
+# The For Good Manifesto
+
+_Where this project is going, and how we keep it honest on the way._
+
+This is our compass, not our constitution. The [method](CONTRIBUTING.md), the
+[streams and gates](docs/STREAMS.md), and the [governance](docs/GOVERNANCE.md)
+are how we work. This is *why*, and what "good" has to mean for us to have
+earned the name.
+
+---
+
+## Why we exist
+
+Two things are true at once in Aotearoa. A lot of people have AI capacity and
+skill going spare. And a lot of real problems — child poverty, unclaimed
+support, opaque public spending, a stretched social sector — go unworked because
+nobody has the hours.
+
+**We put those two things together, and we hold the result to a standard high
+enough that a real decision can rest on it.** Not a demo. Not a portfolio. Work
+a frontline worker, a funder, a council, or a family could actually use.
+
+## The north star
+
+> **One real person, at one real organisation, is measurably better off because
+> of work that started here — and then that happens again, and again, until the
+> way we did it is worth copying.**
+
+Everything else — the pipeline, the dashboard, the leaderboard, the token
+economy of spare subscriptions — is scaffolding. If a year from now we have a
+thousand beautifully-cited findings and nobody's life is different, we failed.
+If we have three shipped things that a handful of organisations rely on every
+week, we won, even if the repo looks small.
+
+**Outcomes over outputs. Always.**
+
+## What we believe
+
+1. **Agents grind, humans steer.** Machines are faster at gathering, drafting,
+   and cross-checking. They cannot decide whether any of it *matters*, or whether
+   it would actually help the people it's about. That judgement is the scarce
+   resource, and it stays human — permanently, by design, not as a phase we grow
+   out of.
+
+2. **Trust is the whole product.** Cite everything. Two independent sources for
+   anything surprising or load-bearing. Mark confidence honestly. A finding that
+   says _"Low confidence, one dated source, needs checking"_ is worth more than a
+   confident paragraph with no links, because someone downstream knows exactly
+   where they stand. We would rather publish less and be believed than publish
+   more and be doubted.
+
+3. **Demand-pull, not supply-push.** The best research answers a question a real
+   organisation actually asked. Elegant answers to questions nobody needs are the
+   most seductive form of waste. We anchor streams to genuine, stated needs — and
+   we treat "a real NFP validated this problem" as worth more than any number of
+   internally-invented ones.
+
+4. **Rigour is not the same as relevance.** The method makes work *trustworthy*.
+   It does not make it *useful*. A steward is not only allowed but expected to
+   retire a technically-perfect finding that doesn't move anything. Being right
+   about the wrong thing is still the wrong thing.
+
+5. **Do no harm — especially where it's hardest.** These domains touch vulnerable
+   people. A wrong claim can send help in the wrong direction. No personal or
+   identifying data, ever. No overstatement, no fabricated authority, no
+   pretending we contacted someone we didn't. When a question needs lived
+   experience or legal standing we don't have, saying so *is* the valuable
+   result.
+
+6. **Open by default.** The findings, the tools, the method — public and
+   reusable. The point is impact, and impact shared is impact multiplied. Credit
+   your sources; expect to be cited.
+
+7. **The people are the point.** Contributors give real time and real tokens.
+   They deserve to see their work matter — not as vanity metrics, but as honest
+   stories of what changed. Stewards carry the judgement load; we protect them
+   from burning out, because agents don't tire and humans do.
+
+## How we guide the journey
+
+**We measure what matters, and refuse the metrics that flatter us.**
+"47 findings merged" is a vanity number. We track instead:
+- **Time to first useful result** — how fast a real question gets a usable answer.
+- **Usefulness, not just correctness** — the share of findings a human rated
+  *worth acting on*, judged separately from whether the citations hold up.
+- **Adoption** — the honest, small, growing count of real people and
+  organisations actually using something we produced.
+
+**We define "done" as adoption, not merge.** A stream isn't finished when its PR
+lands. It's finished when a named human at a real organisation is using the
+result — and we keep a feedback loop open so they can tell us it missed, and
+re-steer us.
+
+**We start narrow and prove the whole loop.** One stream, all the way from a real
+problem to someone using the answer, teaches us more than ten streams half-done.
+Depth before breadth until the full path is proven.
+
+**We keep the sensitive stuff human-heavy.** In domains that touch vulnerable
+people, method review is not enough — a person with domain authority or lived
+experience signs off before anything ships.
+
+**We stay copyable.** The unfair advantage isn't the code — it's NZ relationships
+and context plugged into a method anyone could run. If the pipeline is good
+enough that another country's community could pick it up and swap in their own
+people and problems, we've built the right thing.
+
+## How you know we're winning
+
+- A charity applies for a grant it would have missed.
+- A journalist asks a council a sharper question because the data finally made
+  sense.
+- A family finds support they were entitled to and didn't know existed.
+- A policy analyst cites something from here — and it holds up.
+- Someone new brings their spare tokens, points them at a real problem, and
+  watches a real person be better off for it.
+
+That's the whole game. Everything in this repo is in service of that, and
+anything that stops serving it should be changed.
+
+---
+
+_Built together, in Aotearoa. For good. 🇳🇿_
+
+_This manifesto is a living document — challenge it via PR like everything else._

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This repo puts those two things together. It's a shared workspace where you (or 
 
 Everything here is public and reusable. The point is impact, not a portfolio.
 
+Where we're headed and how we keep it honest: **[read the Manifesto](MANIFESTO.md)**.
+
 ## How it works
 
 Work moves through four stages. Each stage is a GitHub Issue you can claim and push forward.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo puts those two things together. It's a shared workspace where you (or 
 
 Everything here is public and reusable. The point is impact, not a portfolio.
 
-Where we're headed and how we keep it honest: **[read the Manifesto](MANIFESTO.md)**.
+Where we're headed and how we keep it honest: **[read the Manifesto](MANIFESTO.md)** (the spirit) and the **[Constitution](CONSTITUTION.md)** (the binding rules).
 
 ## How it works
 


### PR DESCRIPTION
Per Adam's ask in the For Good chat: a manifesto for where this project should go and how we guide it toward real outcomes (not AI slop).

## What this adds
- **`MANIFESTO.md`** — a compass that sits *above* the method/streams/governance. It's deliberately opinionated and short.
- A one-line link from the README intro.

## The shape of it
- **North star:** one real person at a real org measurably better off — then again, and again, until the *way* we did it is worth copying. **Outcomes over outputs, always.**
- **What we believe:** agents grind / humans steer (permanently, by design) · trust is the whole product · demand-pull not supply-push · rigour ≠ relevance · do no harm (esp. sensitive domains) · open by default · the people are the point.
- **How we guide the journey:** measure time-to-useful, *usefulness* (not just correctness), and *adoption* — and refuse vanity metrics; define “done” as adoption not merge; prove one full loop before scaling breadth; keep sensitive domains human-heavy; stay copyable by other communities/countries.
- **How you know we're winning:** concrete, human scenarios (a charity lands a grant it'd have missed; a family finds support it was entitled to; an analyst cites us and it holds up).

It's framed as a **living document** — challenge it via PR like everything else. This is a first draft for the community to sharpen; very open to edits, especially from the folks bringing NFP/domain judgement.

Name the things I got wrong. 🇳🇿