### PR TITLE
build: add stream problem chains board view (Closes #41)

### DIFF
--- a/web/src/components/shared/ChainTree.tsx
+++ b/web/src/components/shared/ChainTree.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { CheckCircle2, GitMerge, GitPullRequest } from "lucide-react";
-import type { ChainNode } from "@/lib/lineage";
+import { chainUpdatedAt, type ChainNode } from "@/lib/lineage";
 import type { IssueLite } from "@/lib/types";
 import { Card } from "@/components/ui/card";
 import { DomainBadge, StageBadge, StatusBadge } from "./Badges";
@@ -77,7 +77,7 @@ export function ChainTree({ root, matches }: { root: ChainNode; matches: (issue:
     <Card className="p-4">
       <div className="mb-1 flex items-center justify-between gap-2 px-2">
         <DomainBadge domain={root.issue.domain} />
-        <span className="text-xs text-muted-foreground">updated {relativeTime(root.issue.updatedAt)}</span>
+        <span className="text-xs text-muted-foreground">updated {relativeTime(chainUpdatedAt(root))}</span>
       </div>
       <NodeRow node={root} dimmed={!matches(root.issue)} />
       {root.children.length > 0 ? (

--- a/web/src/components/shared/ChainTree.tsx
+++ b/web/src/components/shared/ChainTree.tsx
@@ -1,0 +1,92 @@
+import { Link } from "react-router-dom";
+import { CheckCircle2, GitMerge, GitPullRequest } from "lucide-react";
+import type { ChainNode } from "@/lib/lineage";
+import type { IssueLite } from "@/lib/types";
+import { Card } from "@/components/ui/card";
+import { DomainBadge, StageBadge, StatusBadge } from "./Badges";
+import { PersonAvatar } from "./PersonAvatar";
+import { relativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+function PrChip({ pr }: { pr: IssueLite }) {
+  const merged = pr.merged;
+  const closed = pr.state === "closed" && !merged;
+  return (
+    <a
+      href={pr.url}
+      target="_blank"
+      rel="noreferrer"
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium transition-colors",
+        merged
+          ? "border-violet-300/50 text-violet-600 hover:bg-violet-500/10"
+          : closed
+            ? "border-border text-muted-foreground hover:bg-secondary"
+          : "border-emerald-300/50 text-emerald-600 hover:bg-emerald-500/10",
+      )}
+    >
+      {merged ? <GitMerge className="h-3 w-3" /> : <GitPullRequest className="h-3 w-3" />}
+      PR #{pr.number}{merged ? " merged" : closed ? " closed" : " open"}
+    </a>
+  );
+}
+
+function NodeRow({ node, dimmed }: { node: ChainNode; dimmed: boolean }) {
+  const { issue } = node;
+  const closed = issue.state === "closed";
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg px-2 py-1.5 transition-colors hover:bg-secondary/60", dimmed && "opacity-50")}>
+      <StageBadge stage={issue.stage} />
+      <Link to={`/issue/${issue.number}`} className="min-w-0 flex-1 basis-56">
+        <span className="mr-1.5 font-mono text-xs text-muted-foreground">#{issue.number}</span>
+        <span className={cn("text-sm font-medium hover:text-brand-cyan-dark", closed && "text-muted-foreground line-through decoration-border")}>
+          {issue.title.replace(/^\[[^\]]+\]\s*/, "")}
+        </span>
+      </Link>
+      {node.prs.map((pr) => <PrChip key={pr.number} pr={pr} />)}
+      {closed ? (
+        <span className="inline-flex items-center gap-1 text-xs text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" /> done</span>
+      ) : (
+        <StatusBadge status={issue.status} />
+      )}
+      {issue.assignees.length > 0 ? (
+        <div className="flex -space-x-2">
+          {issue.assignees.slice(0, 3).map((person) => <PersonAvatar key={person.login} login={person.login} avatar={person.avatar} size={20} />)}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Branches({ nodes, matches }: { nodes: ChainNode[]; matches: (issue: IssueLite) => boolean }) {
+  return (
+    <div className="ml-4 space-y-1 border-l border-border/80 pl-3">
+      {nodes.map((node) => (
+        <div key={node.issue.number}>
+          <NodeRow node={node} dimmed={!matches(node.issue)} />
+          {node.children.length > 0 ? <Branches nodes={node.children} matches={matches} /> : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ChainTree({ root, matches }: { root: ChainNode; matches: (issue: IssueLite) => boolean }) {
+  return (
+    <Card className="p-4">
+      <div className="mb-1 flex items-center justify-between gap-2 px-2">
+        <DomainBadge domain={root.issue.domain} />
+        <span className="text-xs text-muted-foreground">updated {relativeTime(root.issue.updatedAt)}</span>
+      </div>
+      <NodeRow node={root} dimmed={!matches(root.issue)} />
+      {root.children.length > 0 ? (
+        <Branches nodes={root.children} matches={matches} />
+      ) : (
+        <p className="ml-4 border-l border-border/80 py-1 pl-3 text-xs text-muted-foreground">
+          No linked child issues yet.
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/web/src/lib/lineage.ts
+++ b/web/src/lib/lineage.ts
@@ -14,9 +14,9 @@ export interface StreamChainGroup {
 }
 
 const STREAM_RE = /^stream:(\d+)$/i;
-const PARENT_RE = /^\s*(?:part of|closes|fixes|resolves)\s+#(\d+)\b/im;
-const CLOSING_RE = /^\s*(?:closes|fixes|resolves)\s+#(\d+)\b/gim;
-const PART_OF_RE = /^\s*part of\s+#(\d+)\b/gim;
+const PARENT_RE = /^\s*(?:part of|closes|fixes|resolves)\s*#(\d+)\b/im;
+const CLOSING_RE = /^\s*(?:closes|fixes|resolves)\s*#(\d+)\b/gim;
+const PART_OF_RE = /^\s*part of\s*#(\d+)\b/gim;
 
 export function streamNumber(issue: IssueLite): number | null {
   for (const label of issue.labels) {

--- a/web/src/lib/lineage.ts
+++ b/web/src/lib/lineage.ts
@@ -1,0 +1,202 @@
+import { STAGE_ORDER } from "./meta";
+import type { IssueLite } from "./types";
+
+export interface ChainNode {
+  issue: IssueLite;
+  children: ChainNode[];
+  prs: IssueLite[];
+}
+
+export interface StreamChainGroup {
+  stream: number;
+  roots: ChainNode[];
+  updatedAt: string;
+}
+
+const STREAM_RE = /^stream:(\d+)$/i;
+const PARENT_RE = /^\s*(?:part of|closes|fixes|resolves)\s+#(\d+)\b/im;
+const CLOSING_RE = /^\s*(?:closes|fixes|resolves)\s+#(\d+)\b/gim;
+const PART_OF_RE = /^\s*part of\s+#(\d+)\b/gim;
+
+export function streamNumber(issue: IssueLite): number | null {
+  for (const label of issue.labels) {
+    const match = STREAM_RE.exec(label.trim());
+    if (match) return Number(match[1]);
+  }
+  return null;
+}
+
+export function parentNumber(issue: IssueLite): number | null {
+  const match = PARENT_RE.exec(issue.body);
+  return match ? Number(match[1]) : null;
+}
+
+function referencedNumbers(body: string, re: RegExp): number[] {
+  const out: number[] = [];
+  re.lastIndex = 0;
+  let match;
+  while ((match = re.exec(body))) out.push(Number(match[1]));
+  return [...new Set(out)];
+}
+
+function prTargetNumbers(pr: IssueLite): number[] {
+  const closing = referencedNumbers(pr.body, CLOSING_RE);
+  if (closing.length > 0) return closing;
+  return referencedNumbers(pr.body, PART_OF_RE);
+}
+
+function parentChainCycle(start: number, parentByIssue: Map<number, number>): number[] | null {
+  const path: number[] = [];
+  const pathIndex = new Map<number, number>();
+  let current: number | undefined = start;
+
+  while (current != null) {
+    const index = pathIndex.get(current);
+    if (index != null) return path.slice(index);
+    pathIndex.set(current, path.length);
+    path.push(current);
+    current = parentByIssue.get(current);
+  }
+
+  return null;
+}
+
+function detachFromParent(node: ChainNode, parentByIssue: Map<number, number>, nodes: Map<number, ChainNode>) {
+  const parent = parentByIssue.get(node.issue.number);
+  const parentNode = parent == null ? undefined : nodes.get(parent);
+  if (!parentNode) return;
+  parentNode.children = parentNode.children.filter((child) => child.issue.number !== node.issue.number);
+  parentByIssue.delete(node.issue.number);
+}
+
+export function chainPrCount(node: ChainNode, seenIssues = new Set<number>(), seenPrs = new Set<number>()): number {
+  if (seenIssues.has(node.issue.number)) return seenPrs.size;
+  seenIssues.add(node.issue.number);
+  for (const pr of node.prs) seenPrs.add(pr.number);
+  for (const child of node.children) chainPrCount(child, seenIssues, seenPrs);
+  return seenPrs.size;
+}
+
+function stageRank(issue: IssueLite) {
+  const rank = STAGE_ORDER.indexOf(issue.stage as (typeof STAGE_ORDER)[number]);
+  return rank === -1 ? STAGE_ORDER.length : rank;
+}
+
+export function chainUpdatedAt(node: ChainNode, seen = new Set<number>()): string {
+  if (seen.has(node.issue.number)) return node.issue.updatedAt;
+  seen.add(node.issue.number);
+
+  let latest = node.issue.updatedAt;
+  for (const pr of node.prs) if (pr.updatedAt > latest) latest = pr.updatedAt;
+  for (const child of node.children) {
+    const updatedAt = chainUpdatedAt(child, seen);
+    if (updatedAt > latest) latest = updatedAt;
+  }
+  return latest;
+}
+
+export function chainSize(node: ChainNode, seen = new Set<number>()): number {
+  if (seen.has(node.issue.number)) return 0;
+  seen.add(node.issue.number);
+  return 1 + node.children.reduce((total, child) => total + chainSize(child, seen), 0);
+}
+
+function sortChildren(node: ChainNode, path = new Set<number>()) {
+  if (path.has(node.issue.number)) {
+    node.children = [];
+    return;
+  }
+
+  path.add(node.issue.number);
+  node.children = node.children
+    .filter((child) => !path.has(child.issue.number))
+    .sort((a, b) => stageRank(a.issue) - stageRank(b.issue) || a.issue.number - b.issue.number);
+  for (const child of node.children) sortChildren(child, new Set(path));
+}
+
+function buildStreamRoots(issues: IssueLite[], prs: IssueLite[]): ChainNode[] {
+  const nodes = new Map<number, ChainNode>();
+  for (const issue of issues) nodes.set(issue.number, { issue, children: [], prs: [] });
+
+  for (const pr of prs) {
+    for (const number of prTargetNumbers(pr)) nodes.get(number)?.prs.push(pr);
+  }
+
+  const roots: ChainNode[] = [];
+  const parentByIssue = new Map<number, number>();
+  for (const node of nodes.values()) {
+    const parent = parentNumber(node.issue);
+    const parentNode = parent != null && parent !== node.issue.number ? nodes.get(parent) : undefined;
+    if (parentNode) {
+      parentByIssue.set(node.issue.number, parentNode.issue.number);
+      parentNode.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  const reachable = new Set<number>();
+  const mark = (node: ChainNode, path = new Set<number>()) => {
+    if (reachable.has(node.issue.number) || path.has(node.issue.number)) return;
+    reachable.add(node.issue.number);
+    path.add(node.issue.number);
+    for (const child of node.children) mark(child, new Set(path));
+  };
+  for (const root of roots) mark(root);
+
+  const promotedCycles = new Set<string>();
+  for (const node of nodes.values()) {
+    if (reachable.has(node.issue.number)) continue;
+    const cycle = parentChainCycle(node.issue.number, parentByIssue);
+    if (cycle) {
+      const key = [...cycle].sort((a, b) => a - b).join(",");
+      if (promotedCycles.has(key)) continue;
+      promotedCycles.add(key);
+
+      const representative = nodes.get(cycle[0]);
+      if (!representative) continue;
+      detachFromParent(representative, parentByIssue, nodes);
+      roots.push(representative);
+      mark(representative);
+      continue;
+    }
+
+    detachFromParent(node, parentByIssue, nodes);
+    roots.push(node);
+    mark(node);
+  }
+
+  for (const root of roots) sortChildren(root);
+  roots.sort((a, b) => chainUpdatedAt(b).localeCompare(chainUpdatedAt(a)));
+  return roots;
+}
+
+export function buildStreamChains(all: IssueLite[]): StreamChainGroup[] {
+  const grouped = new Map<number, { issues: IssueLite[]; prs: IssueLite[] }>();
+
+  for (const item of all) {
+    const stream = streamNumber(item);
+    if (stream == null) continue;
+    if (!grouped.has(stream)) grouped.set(stream, { issues: [], prs: [] });
+    const group = grouped.get(stream);
+    if (!group) continue;
+    if (item.isPR) group.prs.push(item);
+    else group.issues.push(item);
+  }
+
+  return [...grouped.entries()]
+    .map(([stream, group]) => {
+      const roots = buildStreamRoots(group.issues, group.prs);
+      const updatedAt = roots.reduce((latest, root) => {
+        const next = chainUpdatedAt(root);
+        return next > latest ? next : latest;
+      }, "");
+      return {
+        stream,
+        roots,
+        updatedAt,
+      };
+    })
+    .filter((group) => group.roots.length > 0)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt) || a.stream - b.stream);
+}

--- a/web/src/pages/Board.tsx
+++ b/web/src/pages/Board.tsx
@@ -1,16 +1,18 @@
 import { useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Search, LayoutGrid, List, Inbox } from "lucide-react";
+import { Search, LayoutGrid, List, Inbox, Network } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { IssueCard } from "@/components/shared/IssueCard";
+import { ChainTree } from "@/components/shared/ChainTree";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { STAGE_META, STAGE_ORDER, STATUS_META, domainLabel } from "@/lib/meta";
 import type { IssueLite, Stage } from "@/lib/types";
+import { buildStreamChains, chainPrCount, chainSize, type ChainNode } from "@/lib/lineage";
 
 export default function Board() {
   const { data, error, loading } = useSnapshot();
@@ -18,7 +20,7 @@ export default function Board() {
   const [q, setQ] = useState("");
   const [domain, setDomain] = useState("all");
   const [status, setStatus] = useState("all");
-  const [view, setView] = useState<"board" | "list">("board");
+  const [view, setView] = useState<"board" | "list" | "chains">("board");
   const stageParam = params.get("stage") || "all";
 
   const domains = useMemo(() => {
@@ -27,16 +29,24 @@ export default function Board() {
     return [...s];
   }, [data]);
 
+  const streamChains = useMemo(() => (data ? buildStreamChains(data.issues) : []), [data]);
+
   if (loading) return <Loading />;
   if (error || !data) return <ErrorState message={error || "No data"} />;
 
-  const filtered = data.issues.filter((i) => !i.isPR && i.state === "open").filter((i) => {
+  const matchesFilters = (i: IssueLite) => {
     if (stageParam !== "all" && i.stage !== stageParam) return false;
     if (domain !== "all" && i.domain !== domain) return false;
     if (status !== "all" && i.status !== status) return false;
     if (q && !i.title.toLowerCase().includes(q.toLowerCase()) && !String(i.number).includes(q)) return false;
     return true;
-  });
+  };
+
+  const filtered = data.issues.filter((i) => !i.isPR && i.state === "open").filter(matchesFilters);
+  const chainMatches = (node: ChainNode): boolean => matchesFilters(node.issue) || node.children.some(chainMatches);
+  const visibleStreamChains = streamChains
+    .map((group) => ({ ...group, roots: group.roots.filter(chainMatches) }))
+    .filter((group) => group.roots.length > 0);
 
   const setStage = (s: string) => {
     const next = new URLSearchParams(params);
@@ -77,11 +87,37 @@ export default function Board() {
         <div className="flex rounded-md border border-border">
           <Button variant={view === "board" ? "secondary" : "ghost"} size="icon" onClick={() => setView("board")} aria-label="Board view"><LayoutGrid className="h-4 w-4" /></Button>
           <Button variant={view === "list" ? "secondary" : "ghost"} size="icon" onClick={() => setView("list")} aria-label="List view"><List className="h-4 w-4" /></Button>
+          <Button variant={view === "chains" ? "secondary" : "ghost"} size="icon" onClick={() => setView("chains")} aria-label="Problem chains view"><Network className="h-4 w-4" /></Button>
         </div>
       </div>
 
-      {filtered.length === 0 ? (
-        <EmptyState icon={Inbox} title="Nothing matches">Try clearing a filter.</EmptyState>
+      {view === "chains" ? (
+        visibleStreamChains.length === 0 ? (
+          <EmptyState icon={Inbox} title="Nothing matches">Try clearing a filter, or submit a new problem.</EmptyState>
+        ) : (
+          <div className="space-y-5">
+            {visibleStreamChains.map((group) => {
+              const issueCount = group.roots.reduce((total, root) => total + chainSize(root), 0);
+              const prCount = group.roots.reduce((total, root) => total + chainPrCount(root), 0);
+              return (
+                <section key={group.stream} className="rounded-xl border border-border/70 bg-secondary/20 p-4">
+                  <div className="mb-3 flex flex-wrap items-center gap-2 px-1">
+                    <span className="font-serif text-base font-semibold">Stream #{group.stream}</span>
+                    <span className="rounded-full bg-background px-2 py-0.5 text-xs text-muted-foreground">{issueCount} issue{issueCount === 1 ? "" : "s"}</span>
+                    {prCount > 0 ? (
+                      <span className="rounded-full bg-background px-2 py-0.5 text-xs text-muted-foreground">{prCount} PR{prCount === 1 ? "" : "s"}</span>
+                    ) : null}
+                  </div>
+                  <div className="space-y-3">
+                    {group.roots.map((root) => <ChainTree key={root.issue.number} root={root} matches={matchesFilters} />)}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        )
+      ) : filtered.length === 0 ? (
+        <EmptyState icon={Inbox} title="Nothing matches">Try clearing a filter, or submit a new problem.</EmptyState>
       ) : view === "list" ? (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((i) => <IssueCard key={i.number} issue={i} />)}


### PR DESCRIPTION
## What this is

Closes #41
Part of #30

**Stage:** 🔨 Build
**Domain:** other

## Summary

Adds a stream-grouped problem chains board view to the web app. The view groups issues and PRs by `stream:<n>`, builds parent-child chains from the same line-anchored body references used by the stream sync workflow, renders attached PR chips for open, merged, and closed PRs, and displays chain-level recency consistently with the chain sort order.

## Method checklist

- [x] Every factual claim has a source (inline): code-only PR; workflow behavior is grounded in `.github/workflows/stream-sync.yml`, `docs/STREAMS.md`, and `AGENTS.md`.
- [x] Surprising / load-bearing claims have **two** independent sources (or I flagged where they don't): N/A for this implementation PR.
- [x] Confidence marked **High / Medium / Low** (findings): N/A, no finding added.
- [x] I stated what would change the conclusion and what I couldn't verify: see reviewer notes below.
- [x] No personal or identifying data; no overstated or fabricated claims.
- [x] Files are in the right place and follow the relevant template.

## Verification

- `npm run validate` passed.
- `cd web && npm ci` completed with 0 vulnerabilities.
- `cd web && npm run build` passed; Vite emitted the existing large chunk warning.
- `cd web && npm run lint` passed with pre-existing unrelated warnings in UI/page files.
- Temporary fixture run covered the reviewer cycle case, indented `Part of`, line-anchored `Closes`, `Part of`-only root PR attachment, and `Closes` taking precedence over `Part of` for ordinary child PRs.

## For the reviewer

Push hardest on `web/src/lib/lineage.ts` and `web/src/components/shared/ChainTree.tsx`: parser alignment with `.github/workflows/stream-sync.yml`, cycle promotion without duplicate rendered nodes, the PR association rule that uses closing refs first and falls back to `Part of` for root/discover PRs, and whether the displayed chain recency matches the chain sort order.