### PR TITLE
feat(scripts): priority-high queue jumping

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -70,6 +70,11 @@
   color: "0EA5E9"
   description: "Stakeholder / domain-expert feedback on a stream"
 
+# --- Priority: workers pick these up before the rest of the queue (see scripts/fg-common.sh) ---
+- name: "priority: high"
+  color: "B60205"
+  description: "Jump the queue — start_work.sh/review picks these up first"
+
 # --- Meta ---
 - name: "good first issue"
   color: "7057FF"

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -83,12 +83,15 @@ remove_worktree() {
 issue_labels()  { gh issue view "$1" --repo "$REPO" --json labels --jq '[.labels[].name]|join(",")'; }
 issue_field()   { gh issue view "$1" --repo "$REPO" --json "$2" --jq ".$2"; }
 
-# Numbers of open issues with a given status label, oldest first, optional STAGE filter.
+# Numbers of open issues with a given status label, optional STAGE filter.
+# Order: issues labelled "priority: high" first, then oldest-created first.
+# This is the whole priority system — label an issue "priority: high" to have
+# the workers pick it up before the rest of the queue.
 issues_with_status() {  # $1 = bare status (e.g. available), $2.. extra gh flags
   local status="$1"; shift
   gh issue list --repo "$REPO" --state open --label "status: $status" "$@" \
     --json number,createdAt,labels --limit 100 \
-    --jq "[.[] $( [ -n "${STAGE:-}" ] && printf '| select(.labels|map(.name)|index("stage: %s"))' "$STAGE" )] | sort_by(.createdAt) | .[].number"
+    --jq "[.[] $( [ -n "${STAGE:-}" ] && printf '| select(.labels|map(.name)|index("stage: %s"))' "$STAGE" )] | sort_by((.labels|map(.name)|index(\"priority: high\")|not), .createdAt) | .[].number"
 }
 
 available_issues() { issues_with_status "available"; }


### PR DESCRIPTION
Per Adam's ask — a lightweight priority system so specific issues get worked before the rest of the queue (there wasn't one; workers picked oldest-`available` first, so newly-filed pilots would go *last*).

## What
- Issues/PRs labelled **`priority: high`** are picked up by `start_work.sh`, `review_work.sh`, and `synthesize_work.sh` **before** the rest; within each tier, ordering stays oldest-created-first.
- One-line change in `issues_with_status` (shared selector): `sort_by((has priority:high), createdAt)`.
- New `priority: high` label in `labels.yml`.

## Verified
- `bash -n` clean.
- Sort tested: a priority issue jumps to the front, the rest stay oldest-first.

Used immediately to bump the two consumer-transparency pilots (#60, #61) to the top.