### PR TITLE
chore: default runner scripts to poll every 60s instead of exiting

### DIFF
--- a/review_work.sh
+++ b/review_work.sh
@@ -26,6 +26,8 @@
 #   REVIEW_GITHUB_TOKEN=<bot-pat> AUTO_MERGE=1 ./review_work.sh
 #   PR=7 ./review_work.sh                                    # a single PR
 #   DRY_RUN=1 ./review_work.sh
+#   POLL_SECONDS=0 ./review_work.sh                          # exit instead of polling when empty
+#                                                             # (default: poll every 60s and never exit)
 #
 # Args: [claude|codex|hermes] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
 # Env:  REVIEW_GITHUB_TOKEN AGENT MODEL AUTO_MERGE PR MAX POLL_SECONDS DRY_RUN
@@ -39,7 +41,7 @@ trap 'remove_worktree || true' EXIT INT TERM
 
 DRY_RUN="${DRY_RUN:-0}"
 AUTO_MERGE="${AUTO_MERGE:-0}"
-POLL_SECONDS="${POLL_SECONDS:-0}"
+POLL_SECONDS="${POLL_SECONDS:-60}"    # keep polling when queue empty (0 to exit instead)
 MAX="${MAX:-0}"
 ONLY_PR="${PR:-}"
 REVIEW_FILE=""

--- a/start_work.sh
+++ b/start_work.sh
@@ -20,6 +20,8 @@
 #   STAGE=research ./start_work.sh  # only pick up research-stage issues
 #   MAX=1 ./start_work.sh           # do a single issue and stop
 #   DRY_RUN=1 ./start_work.sh       # show what it would do, touch nothing
+#   POLL_SECONDS=0 ./start_work.sh  # exit instead of polling when queue empty
+#                                    # (default: poll every 60s and never exit)
 #
 # Args: [claude|codex|hermes] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
 # Env:  AGENT MODEL MAX STAGE POLL_SECONDS DRY_RUN AGENT_TIMEOUT
@@ -31,7 +33,7 @@ RUNS_AGENT=1
 parse_agent_args "$@"
 
 MAX="${MAX:-0}"                       # 0 = no limit
-POLL_SECONDS="${POLL_SECONDS:-0}"     # >0 = keep polling when queue empty
+POLL_SECONDS="${POLL_SECONDS:-60}"    # keep polling when queue empty (0 to exit instead)
 DRY_RUN="${DRY_RUN:-0}"
 CLAIMED_ISSUE=""
 

--- a/synthesize_work.sh
+++ b/synthesize_work.sh
@@ -18,6 +18,8 @@
 #   STREAM=4 ./synthesize_work.sh         # target one stream root
 #   MAX=1 ./synthesize_work.sh            # one stream, then stop
 #   DRY_RUN=1 ./synthesize_work.sh        # print target + evidence + prompt, touch nothing
+#   POLL_SECONDS=0 ./synthesize_work.sh   # exit instead of polling when queue empty
+#                                          # (default: poll every 60s and never exit)
 #
 # Args: [claude|codex|hermes] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
 # Env:  STREAM MAX POLL_SECONDS DRY_RUN AGENT MODEL AGENT_TIMEOUT
@@ -30,7 +32,7 @@ parse_agent_args "$@"
 trap 'remove_worktree || true' EXIT INT TERM
 
 MAX="${MAX:-0}"
-POLL_SECONDS="${POLL_SECONDS:-0}"
+POLL_SECONDS="${POLL_SECONDS:-60}"    # keep polling when queue empty (0 to exit instead)
 DRY_RUN="${DRY_RUN:-0}"
 ONLY_STREAM="${STREAM:-}"
 


### PR DESCRIPTION
## Summary
- `start_work.sh`, `synthesize_work.sh`, and `review_work.sh` now default `POLL_SECONDS` to `60` instead of `0`, so they keep polling on an empty queue rather than exiting.
- `POLL_SECONDS=0` still restores the previous exit-on-empty behavior for one-shot/cron use.

## Test plan
- [x] `bash -n` on all three scripts
- [x] Reviewed the empty-queue branches in each `main()` loop to confirm the new default only changes polling cadence, not one-shot/`DRY_RUN`/single-target (`STREAM`/`PR`) behavior.