### PR TITLE
fix(scripts): default agents to sandboxed auto mode (not permission bypass)

### DIFF
--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -190,15 +190,21 @@ set_status_label() {  # $1 issue, $2 new-status (bare, e.g. in-review), $3.. old
 run_agent() {
   local prompt="$1" dir="${2:-$REPO_DIR}" tmo=""
   if [ "$AGENT_TIMEOUT" != 0 ] && command -v timeout >/dev/null 2>&1; then tmo="timeout ${AGENT_TIMEOUT}s"; fi
+  # Default to SANDBOXED AUTO modes, not full permission bypass:
+  #  - codex  → --full-auto  (workspace-write sandbox, auto-approve, no prompts)
+  #  - claude → --permission-mode acceptEdits (auto-accept edits; also runs as
+  #             root, unlike bypassPermissions/--dangerously-skip-permissions)
+  # Override per-run with CODEX_FLAGS / CLAUDE_PERMISSION_MODE / HERMES_FLAGS if
+  # a run genuinely needs looser (or tighter) permissions.
   case "$AGENT" in
     codex)
       $tmo codex exec --cd "$dir" --skip-git-repo-check \
-        ${CODEX_FLAGS:---dangerously-bypass-approvals-and-sandbox} \
+        ${CODEX_FLAGS:---full-auto} \
         ${MODEL:+-m "$MODEL"} "$prompt"
       ;;
     claude)
       ( cd "$dir" && $tmo claude -p "$prompt" \
-        --permission-mode "${CLAUDE_PERMISSION_MODE:-bypassPermissions}" \
+        --permission-mode "${CLAUDE_PERMISSION_MODE:-acceptEdits}" \
         ${MODEL:+--model "$MODEL"} )
       ;;
     hermes)


### PR DESCRIPTION
Per Adam — we shouldn't be defaulting to `--dangerously-*` / `bypassPermissions`. Switch the runner defaults to **sandboxed auto modes**:

| agent | was | now |
|---|---|---|
| codex | `--dangerously-bypass-approvals-and-sandbox` | **`--full-auto`** (workspace-write sandbox, auto-approve, no prompts) |
| claude | `--permission-mode bypassPermissions` | **`--permission-mode acceptEdits`** |
| hermes | `--yolo` (unchanged; override via `HERMES_FLAGS`) | — |

Bonus: `acceptEdits` **runs as root**, unlike `bypassPermissions`/`--dangerously-skip-permissions` — so it also fixes the “can't run as root” wall a couple of people hit.

Still fully overridable per-run via `CODEX_FLAGS` / `CLAUDE_PERMISSION_MODE` / `HERMES_FLAGS`.

## Please smoke-test before the whole fleet adopts
I can't exercise the live CLIs from here. The one thing to confirm: under claude `acceptEdits` (headless `-p`), the reviewer can still run its **read tools** (git diff, file reads, WebFetch to check citations) and write `.fg-review.md` without stalling. Run `MAX=1 PR=<n> ./review_work.sh claude` once and check it posts a real review.

**Fallback if a claude run stalls on tool prompts:** set `CLAUDE_PERMISSION_MODE=bypassPermissions` (non-root only), or we add `--allowedTools` in a follow-up. codex `--full-auto` is a well-established safe auto mode and should just work.

`bash -n` clean.