### PR TITLE
docs(adr): accept ADR-0005 & 0006 (cleaned) + Decisions page on the site

### DIFF
--- a/docs/adr/0005-agent-execution-environment.md
+++ b/docs/adr/0005-agent-execution-environment.md
@@ -1,0 +1,97 @@
+# ADR-0005: How and where we run the agents (execution environment & permission modes)
+
+- **Status:** accepted
+- **Date:** 2026-07-02
+- **Deciders:** Maintainers (Adam Holt), 2026-07-02
+- **Discussion:** For Good WhatsApp, 2 July 2026 ("I don't like dangerously skip perms, we should be running on auto mode… we could try to containerise it") — [PR #99](https://github.com/thecolab-ai/the-for-good-project/pull/99)
+
+## Context
+
+The runner scripts (`start_work.sh`, `review_work.sh`, `synthesize_work.sh` via
+`scripts/fg-common.sh:run_agent`) invoke the agent CLIs with **blanket bypass
+flags**: Claude `--permission-mode bypassPermissions`, Codex
+`--dangerously-bypass-approvals-and-sandbox`.
+
+Two problems with that as the default:
+
+1. **It's "dangerous mode" on the host.** It disables the CLI's own guardrails,
+   so a misbehaving or prompt-injected agent has the run user's full authority.
+   `bypassPermissions` also *refuses to run as root*, which caused real friction.
+2. **We hadn't decided where these runs should live** — a contributor's laptop,
+   a container, a cloud VM, GitHub Actions, or a hosted/web agent.
+
+Constraints that shape the answer:
+
+- **Residential-IP sensitivity.** Research and review both fetch NZ official
+  sources (Stats NZ, data.govt.nz, councils, Charities Register). Datacentre /
+  cloud IP ranges are commonly throttled or bot-blocked; residential IPs are
+  not. Running from a cloud/CI IP risks silent blocks or bad data.
+- **The "bring your own tokens" model.** Cost is deliberately distributed across
+  contributors' own subscriptions. Routing all runs through one cloud secret (a
+  VM, or CI with one repo key) re-centralises the bill.
+- **Consistency & safety.** We want a repeatable environment and a real sandbox
+  without depending on every contributor's local setup.
+
+## Decision
+
+**1. Treat the container as the sandbox.** Provide an official hardened image
+that bundles `git`, `gh`, `jq`, and the agent CLIs. Inside a properly
+locked-down container, a blanket "bypass" is *acceptable* — the blast radius is
+the throwaway container, not the host. Hardening baseline: **non-root user
+inside**, no host bind-mounts, dropped Linux capabilities, default seccomp,
+CPU/memory limits, and (later) an egress allowlist.
+
+**2. On the host (no container), default to *sandboxed auto*, not blanket bypass:**
+
+- **Codex** → `--sandbox workspace-write --ask-for-approval never` (real
+  unattended mode that *keeps* the OS sandbox; no root restriction).
+- **Claude** → `--permission-mode acceptEdits` as the safer default where it
+  suffices (auto-approves edits, runs as non-root); fall back to
+  `bypassPermissions` **only inside the container**, since `acceptEdits` can
+  still pause on some tool calls headless.
+- Both remain overridable via the existing env hooks (`CODEX_FLAGS`,
+  `CLAUDE_PERMISSION_MODE`, `HERMES_FLAGS`).
+
+**3. Where runs live:** default is **the container on a contributor's own
+(residential) machine** — keeps IPs residential *and* tokens distributed.
+Cloud VM / GitHub Actions are acceptable for **review** (little scraping) but
+**not the default for research** (IP-block risk + centralised token cost).
+Prefer **official NZ APIs** over scraping to reduce IP sensitivity.
+
+**4. Credentials:** prefer a **GitHub App installation token** (short-lived,
+repo-scoped) or a fine-grained PAT limited to this repo with least privilege
+(`contents: read`, `pull_requests: write`, `issues: write`). **Never bake tokens
+into the image**; pass via env or a mounted secret.
+
+## Consequences
+
+**Positive**
+- No naked "dangerous" flag as the host default; safety comes from the sandbox
+  (container) or a real OS sandbox (Codex), not from trusting the agent.
+- Fixes the root-refusal friction; lowers setup cost for new contributors.
+- Keeps the distributed-token model and residential IPs for research.
+
+**Negative / costs**
+- Someone must build and maintain the image (Dockerfile + docs).
+- `acceptEdits` may occasionally stall a headless Claude run on a tool that
+  wants approval; the container (where bypass is fine) is the workaround.
+- Plain Docker shares the host kernel; for reviewing *untrusted* external PRs,
+  stronger isolation (gVisor / Firecracker / Kata) is worth considering later.
+
+## Alternatives considered
+
+- **Status quo — blanket bypass on the host.** Rejected: unsafe default, root
+  friction — the thing this ADR replaces.
+- **Cloud VM / GitHub Actions as the default.** Rejected as default: datacentre
+  IP blocks degrade research and one shared secret re-centralises token cost.
+  Fine as an *optional* review runner.
+- **Hosted / web agent product.** Attractive UX, but orchestration (the bash
+  runner owns status transitions) and non-residential egress are limitations
+  today. Revisit if a good fit appears.
+
+## Follow-ups (tracked separately)
+
+- Author the Dockerfile + a short "run the reviewer in a container" guide.
+- Decide plain Docker vs microVM isolation for untrusted-PR review.
+- Optionally stand up one opt-in hosted review runner (distinct bot identity).
+- The fetch layer inside this environment is [ADR-0006](0006-fetch-proxy-browser-management.md).

--- a/docs/adr/0006-fetch-proxy-browser-management.md
+++ b/docs/adr/0006-fetch-proxy-browser-management.md
@@ -1,0 +1,95 @@
+# ADR-0006: Fetch, proxy & browser management for research and citation checks
+
+- **Status:** accepted
+- **Date:** 2026-07-02
+- **Deciders:** Maintainers (Adam Holt), 2026-07-02
+- **Discussion:** For Good WhatsApp, 2 July 2026 ("create an ADR for proxy / browser management") — [PR #100](https://github.com/thecolab-ai/the-for-good-project/pull/100). Motivating incident: [PR #81](https://github.com/thecolab-ai/the-for-good-project/pull/81).
+- **Related:** [ADR-0005](0005-agent-execution-environment.md) (where/how we run agents). This ADR is the *fetch layer* that sits inside that environment.
+
+## Context
+
+Both halves of the pipeline live or die on fetching web sources: research
+**reads** them, review **verifies the citations**. Agents currently fetch with
+plain HTTP (`curl`/`WebFetch`), and that quietly fails on a big chunk of exactly
+the sources we care about:
+
+- **Bot-protected / WAF sites** (`charities.govt.nz`, `communitymatters.govt.nz`)
+  return **HTTP 403** to non-browser clients.
+- **JS / redirect / CDN-hosted pages** (e.g. Squarespace `/data-1`) return
+  **404** to `curl` but resolve fine in a real browser.
+- **Datacentre-IP throttling/blocking** hits cloud/CI egress on official NZ data
+  sites (see ADR-0005).
+
+**This already caused a false outcome.** In [PR #81](https://github.com/thecolab-ai/the-for-good-project/pull/81)
+the finding was sound — its DIA figures were later reproduced *to the dollar* —
+yet it collected **four NEEDS_WORK reviews** largely because reviewers' `curl`
+got 404/403 and they reported "dead links." A browser-rendering reviewer
+confirmed the citations resolved and it merged **on the same commit**. So weak
+fetch tooling produces **false rejections** (waste, erodes trust in the gate) —
+and the mirror risk: a reviewer who *can't* fetch might wave through a genuinely
+dead link, or a researcher might cite a page they never actually read.
+
+## Decision
+
+**1. Standardise a shared fetch layer** used by both research and review that
+prefers a **real browser / rendering fetch** (handles JS, redirects, cookies,
+WAF challenges, and PDFs) over plain HTTP. Verifying or citing a URL should go
+through this layer, not raw `curl`. **Agents that run in the cloud especially
+must ship a real browser** — a headless cloud agent with only `curl` will
+mis-report live government sources as dead.
+
+**2. Classify fetch failures — don't equate them:**
+- **404 (not found)** → treat as a genuine dead-link problem.
+- **403 / bot-challenge / timeout / TLS block** → treat as *likely tooling/IP*,
+  **NOT** a citation defect. Retry via browser render and/or archive before a
+  reviewer flags the citation. Reviewers state *how* they fetched.
+
+**3. Archive on cite.** When a finding cites a fragile, bot-protected, or
+date-stamped URL, also capture a **web-archive snapshot** (e.g. Wayback) so the
+citation stays verifiable and the reader has a stable copy. Prefer **official
+APIs** (Stats NZ Data API, Charities OData) over scraping wherever they exist.
+
+**4. Proxy / egress management (framework here; specifics tracked as follow-up).**
+Route fetches through egress that isn't blocked — **residential where datacentre
+IPs are refused** — with a per-site policy, sensible rate limits, respect for
+robots/ToS, and no leaking of credentials or the runner's identity/location.
+The exact mechanism (residential proxy pool vs run-on-residential-machine vs
+per-site rules, and any caching) is a follow-up, not fixed by this ADR.
+
+## Consequences
+
+**Positive**
+- Kills the #81 failure mode: far fewer false "dead link" rejections; the gate
+  becomes trustworthy on bot-protected govt sites.
+- Symmetric integrity: reviewers can actually confirm what a source says, so
+  genuinely dead links still get caught.
+- Stable citations (archive snapshots) survive link rot and date-stamped URLs.
+
+**Negative / costs**
+- Browser rendering + proxy infrastructure to build and maintain (fits inside
+  the ADR-0005 container image).
+- Proxies cost money and carry ethics/ToS obligations; must respect rate limits
+  and site terms, and must not exfiltrate secrets or the server's network
+  identity.
+- A rendering fetch is slower and heavier than `curl` — fine for verification,
+  needs sane timeouts.
+
+## Alternatives considered
+
+- **Status quo (plain `curl`/HTTP).** Rejected — the direct cause of the #81
+  false rejections.
+- **Browser rendering only, no proxy.** Fixes JS/WAF/404-in-curl, but not
+  datacentre-IP blocks.
+- **Proxy only, no browser.** Fixes IP blocks, but not JS/redirect/challenge
+  pages. Both are needed; they solve different failure modes.
+
+## Follow-ups (not fixed here)
+
+- Which rendering tool / browser-fetch, and whether it's a shared `fetch`
+  helper CLI in-repo.
+- Proxy architecture: residential proxy provider, run-on-residential-machine, or
+  per-site policy? Cost, ethics, and who operates it.
+- Caching layer for repeated fetches, and how archive snapshots are stored and
+  linked from findings.
+- Update the reviewer prompt to require "fetched via browser render / archive"
+  evidence before a link is flagged dead.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,5 +41,7 @@ routine fixes, copy changes, or web styling.
 | [0002](0002-vendor-thecolab-skills-submodule.md) | Vendor `thecolab-ai/.skills` as a git submodule | Accepted |
 | [0003](0003-agent-drafted-synthesis.md) | Agents draft the G1 synthesis; humans keep the decision | Accepted |
 | [0004](0004-analysis-documents-and-rendered-companions.md) | Project analysis lives in `analysis/` | Proposed |
+| [0005](0005-agent-execution-environment.md) | How & where we run the agents (containerise + sandboxed auto modes) | Accepted |
+| [0006](0006-fetch-proxy-browser-management.md) | Fetch, proxy & browser management for research + citation checks | Accepted |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -197,6 +197,26 @@ async function main() {
   };
   walk(findingsDir);
 
+  // --- ADRs (architecture decision records) from disk ---
+  const adrDir = path.join(REPO_ROOT, "docs", "adr");
+  const adrs = [];
+  if (existsSync(adrDir)) {
+    for (const entry of readdirSync(adrDir).sort()) {
+      if (!entry.endsWith(".md") || ["README.md", "TEMPLATE.md"].includes(entry)) continue;
+      const raw = readFileSync(path.join(adrDir, entry), "utf8");
+      adrs.push({
+        number: (raw.match(/#\s*ADR-(\d+)/) || [])[1] || (entry.match(/^(\d+)/) || [])[1] || "",
+        slug: entry.replace(/\.md$/, ""),
+        title: (raw.match(/^#\s*ADR-\d+:\s*(.+)$/m) || [])[1]?.trim() || entry.replace(/\.md$/, ""),
+        status: (raw.match(/\*\*Status:\*\*\s*(.+)$/m) || [])[1]?.trim() || "",
+        date: (raw.match(/\*\*Date:\*\*\s*(.+)$/m) || [])[1]?.trim() || "",
+        body: raw,
+        url: `${repoMeta.html_url}/blob/${repoMeta.default_branch}/docs/adr/${entry}`,
+      });
+    }
+    adrs.sort((a, b) => a.number.localeCompare(b.number));
+  }
+
   // --- leaderboard ---
   const people = new Map();
   const newPerson = (login, avatar, url) => ({ login, avatar, url, issuesAssigned: 0, prsMerged: 0, prsOpened: 0, findingsAuthored: 0, commits: 0, reviewsGiven: 0, score: 0, lastActivity: null, domains: new Set() });
@@ -294,6 +314,7 @@ async function main() {
     findings,
     sources,
     activity,
+    adrs,
   };
 
   mkdirSync(OUT_DIR, { recursive: true });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import Submit from "@/pages/Submit";
 import Methodology from "@/pages/Methodology";
 import Contribute from "@/pages/Contribute";
 import Partners from "@/pages/Partners";
+import Decisions from "@/pages/Decisions";
 import NotFound from "@/pages/NotFound";
 
 export const router = createBrowserRouter([
@@ -30,6 +31,7 @@ export const router = createBrowserRouter([
       { path: "/methodology", element: <Methodology /> },
       { path: "/contribute", element: <Contribute /> },
       { path: "/partners", element: <Partners /> },
+      { path: "/decisions", element: <Decisions /> },
       { path: "*", element: <NotFound /> },
     ],
   },

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -31,6 +31,7 @@ const GROUPS: NavGroup[] = [
       { to: "/leaderboard", label: "Leaderboard" },
       { to: "/contribute", label: "Get started" },
       { to: "/methodology", label: "Method" },
+      { to: "/decisions", label: "Decisions" },
     ],
   },
 ];

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -117,4 +117,15 @@ export interface Snapshot {
   findings: Finding[];
   sources: SourceRef[];
   activity: ActivityItem[];
+  adrs?: Adr[];
+}
+
+export interface Adr {
+  number: string;
+  slug: string;
+  title: string;
+  status: string;
+  date: string;
+  body: string;
+  url: string;
 }

--- a/web/src/pages/Decisions.tsx
+++ b/web/src/pages/Decisions.tsx
@@ -1,0 +1,70 @@
+import { ScrollText, ExternalLink } from "lucide-react";
+import { useSnapshot } from "@/hooks/useSnapshot";
+import { Loading, ErrorState } from "@/components/shared/States";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { Card } from "@/components/ui/card";
+import { Markdown } from "@/components/shared/Markdown";
+import type { Adr } from "@/lib/types";
+
+function statusStyle(status: string): { bg: string; color: string } {
+  const s = status.toLowerCase();
+  if (s.includes("accept")) return { bg: "#0E8A1618", color: "#0E8A16" };
+  if (s.includes("propos")) return { bg: "#B8860B18", color: "#B8860B" };
+  if (s.includes("supersed") || s.includes("deprecat")) return { bg: "#B6020518", color: "#B60205" };
+  return { bg: "hsl(var(--muted))", color: "hsl(var(--muted-foreground))" };
+}
+
+// Drop the H1 title + metadata bullet block; the card header shows those.
+function bodyFromContext(body: string): string {
+  const i = body.indexOf("\n## ");
+  return i >= 0 ? body.slice(i + 1) : body;
+}
+
+export default function Decisions() {
+  const { data, error, loading } = useSnapshot();
+  if (loading) return <Loading />;
+  if (error || !data) return <ErrorState message={error || "No data"} />;
+
+  const adrs: Adr[] = [...(data.adrs ?? [])].sort((a, b) => a.number.localeCompare(b.number));
+
+  return (
+    <div>
+      <PageHeader title="Decisions">
+        Architecture Decision Records — the durable <em>why</em> behind how this project works. Many humans and agents work this repo across many contexts; decisions that live only in a chat thread get silently re-litigated. Each significant one gets a small, numbered, immutable record here.
+      </PageHeader>
+
+      {adrs.length === 0 ? (
+        <EmptyState icon={ScrollText} title="No decision records yet">
+          They'll appear here on the next data build. In the meantime, browse them in the repo under <code>docs/adr/</code>.
+        </EmptyState>
+      ) : (
+        <div className="space-y-5">
+          {adrs.map((a) => {
+            const st = statusStyle(a.status);
+            return (
+              <Card key={a.slug} className="p-6">
+                <div className="mb-3 flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-xs text-muted-foreground">ADR-{a.number}</span>
+                  {a.status ? (
+                    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium capitalize" style={{ backgroundColor: st.bg, color: st.color }}>
+                      {a.status}
+                    </span>
+                  ) : null}
+                  {a.date ? <span className="text-xs text-muted-foreground">{a.date}</span> : null}
+                  <a href={a.url} target="_blank" rel="noreferrer" className="ml-auto inline-flex items-center gap-1 text-xs text-brand-cyan-dark hover:underline">
+                    View on GitHub <ExternalLink className="h-3 w-3" />
+                  </a>
+                </div>
+                <h2 className="font-serif text-xl font-semibold text-brand-navy dark:text-foreground">{a.title}</h2>
+                <div className="mt-2">
+                  <Markdown>{bodyFromContext(a.body)}</Markdown>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Per Adam: **merge ADR-0005 & 0006, cleaned up, and put the ADRs on the public site.**

## ADRs
- **ADR-0005** (agent execution environment — containerise + sandboxed auto modes) and **ADR-0006** (fetch / proxy / browser management) tidied and marked **`accepted`** by maintainer decision (Adam). Index updated.
- This **consolidates and supersedes PRs #99 and #100** (avoids the index-conflict of merging both separately). Closing those in favour of this one.

## Website
- New **Decisions** page at `/decisions` (in the Community nav) that renders every ADR — number, status pill, date, and full text — straight from `docs/adr/`.
- `build-data.mjs` now emits an `adrs` array parsed from `docs/adr/*.md`; it populates on each deploy (the Pages workflow runs build-data before the build), so the page fills in automatically as ADRs are added.

## Verified
- `tsc + vite build` clean; `node --check` on build-data; ADR field-parsing spot-checked against real files.

Admin-merging on Adam's say-so (he asked to merge these tonight).