### PR TITLE
feat(web): live comment feed + active-agents strip; disable on-site submit

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,8 @@
 # Build the site's data snapshot from the repo's issues/PRs/findings, build the
 # Vite app, and deploy to GitHub Pages. Runs on every push to the site or
-# research, whenever an issue changes, on a 30-minute schedule, and on demand —
-# so the public dashboard stays fresh without any client-side API calls.
+# research, whenever an issue or comment changes, on a 30-minute schedule, and
+# on demand — so the public dashboard (and its live feed) stays fresh without
+# any client-side API calls.
 name: Deploy site
 
 on:
@@ -10,6 +11,13 @@ on:
     paths: ["web/**", "research/**", ".github/workflows/pages.yml"]
   issues:
     types: [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned, unassigned]
+  # Rebuild when someone comments so the live feed stays near-real-time.
+  issue_comment:
+    types: [created, edited, deleted]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
   schedule:
     - cron: "*/30 * * * *"
   workflow_dispatch:

--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -116,6 +116,7 @@ async function main() {
           avatar: c.user?.avatar_url || "",
           body: c.body || "",
           createdAt: c.created_at,
+          url: c.html_url,
         }));
       } catch { /* ignore */ }
     }
@@ -289,6 +290,67 @@ async function main() {
       meta: i.isPR ? (i.merged ? "merged" : i.state) : i.stage !== "none" ? i.stage : i.state,
     }));
 
+  // --- live comment feed + active actors ---
+  // A flat, newest-first stream of comments across every issue and PR, plus a
+  // short list of who's been active recently — powering the /live feed and the
+  // dashboard's "Live activity" widget. Fully static: the client polls this
+  // snapshot, and a new comment triggers a rebuild (see pages.yml).
+  //
+  // Every active contributor on this project is currently an agent — humans are
+  // the judgement layer (they review and steward), while the volume of commits,
+  // comments and PRs is produced by agents running on contributors' own tokens.
+  // So we simply treat all non-bookkeeping-bot actors as agents. When humans
+  // start participating directly (commenting/committing as themselves), restore
+  // per-actor detection here (a [bot] check + an AGENT_LOGINS allowlist).
+  const isAgent = (login) => !!login && !BOTS.has(login);
+
+  // Strip markdown/URLs down to a readable one-line snippet for the feed.
+  const snippet = (s) =>
+    (s || "")
+      .replace(/```[\s\S]*?```/g, " ")
+      .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+      .replace(/https?:\/\/\S+/g, " ")
+      .replace(/[#>*`_~|]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 240);
+
+  const comments = [];
+  for (const it of issues) {
+    if (!it.commentsList) continue;
+    for (const c of it.commentsList) {
+      if (BOTS.has(c.author)) continue; // drop label/dependency bookkeeping noise
+      comments.push({
+        author: c.author,
+        avatar: c.avatar,
+        isAgent: isAgent(c.author),
+        body: snippet(c.body),
+        createdAt: c.createdAt,
+        url: c.url || it.url,
+        issueNumber: it.number,
+        issueTitle: it.title,
+        isPR: it.isPR,
+      });
+    }
+  }
+  comments.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  const recentComments = comments.slice(0, 60);
+
+  // Distinct actors seen recently (comments + issue/PR updates), newest first.
+  const actorSeen = new Map();
+  const noteActor = (login, avatar, at) => {
+    if (!login || BOTS.has(login) || !at) return;
+    const t = new Date(at).getTime();
+    if (Number.isNaN(t)) return;
+    const cur = actorSeen.get(login);
+    if (!cur || t > new Date(cur.at).getTime()) {
+      actorSeen.set(login, { login, avatar: avatar || cur?.avatar || "", isAgent: isAgent(login), at: new Date(at).toISOString() });
+    }
+  };
+  for (const c of comments) noteActor(c.author, c.avatar, c.createdAt);
+  for (const it of issues) noteActor(it.author?.login, it.author?.avatar, it.updatedAt);
+  const activeActors = [...actorSeen.values()].sort((a, b) => new Date(b.at) - new Date(a.at)).slice(0, 12);
+
   const snapshot = {
     generatedAt: new Date().toISOString(),
     repo: { owner: OWNER, name: NAME, url: repoMeta.html_url, description: repoMeta.description || "", homepage: repoMeta.homepage || "" },
@@ -314,12 +376,14 @@ async function main() {
     findings,
     sources,
     activity,
+    comments: recentComments,
+    activeActors,
     adrs,
   };
 
   mkdirSync(OUT_DIR, { recursive: true });
   writeFileSync(path.join(OUT_DIR, "snapshot.json"), JSON.stringify(snapshot, null, 2));
-  console.log(`Wrote snapshot: ${realIssues.length} issues, ${prs.length} PRs, ${findings.length} findings, ${leaderboard.length} contributors, ${snapshot.stats.sources} sources.`);
+  console.log(`Wrote snapshot: ${realIssues.length} issues, ${prs.length} PRs, ${findings.length} findings, ${leaderboard.length} contributors, ${snapshot.stats.sources} sources, ${recentComments.length} recent comments, ${activeActors.length} active actors.`);
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,14 +1,16 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createBrowserRouter, Navigate } from "react-router-dom";
 import { AppLayout } from "@/components/layout/AppLayout";
 import Dashboard from "@/pages/Dashboard";
+import Live from "@/pages/Live";
 import Board from "@/pages/Board";
+// Submit page kept on disk but unrouted — on-site submission is disabled for
+// now; /submit redirects to the live feed (see below).
 import IssueDetail from "@/pages/IssueDetail";
 import Findings from "@/pages/Findings";
 import FindingDetail from "@/pages/FindingDetail";
 import Sources from "@/pages/Sources";
 import Leaderboard from "@/pages/Leaderboard";
 import Review from "@/pages/Review";
-import Submit from "@/pages/Submit";
 import Methodology from "@/pages/Methodology";
 import Contribute from "@/pages/Contribute";
 import Partners from "@/pages/Partners";
@@ -20,6 +22,7 @@ export const router = createBrowserRouter([
     element: <AppLayout />,
     children: [
       { path: "/", element: <Dashboard /> },
+      { path: "/live", element: <Live /> },
       { path: "/board", element: <Board /> },
       { path: "/issue/:number", element: <IssueDetail /> },
       { path: "/findings", element: <Findings /> },
@@ -27,7 +30,7 @@ export const router = createBrowserRouter([
       { path: "/sources", element: <Sources /> },
       { path: "/leaderboard", element: <Leaderboard /> },
       { path: "/review", element: <Review /> },
-      { path: "/submit", element: <Submit /> },
+      { path: "/submit", element: <Navigate to="/live" replace /> },
       { path: "/methodology", element: <Methodology /> },
       { path: "/contribute", element: <Contribute /> },
       { path: "/partners", element: <Partners /> },

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -9,7 +9,7 @@ export function Footer({ repoUrl, generatedAt }: { repoUrl?: string; generatedAt
           <div>Built together, in Aotearoa. 🇳🇿 · <a href="https://thecolab.ai" className="text-brand-cyan-dark hover:underline">thecolab.ai</a></div>
         </div>
         <div className="flex items-center gap-4">
-          <Link to="/submit" className="hover:text-foreground">Submit</Link>
+          <Link to="/live" className="hover:text-foreground">Live</Link>
           <Link to="/methodology" className="hover:text-foreground">Method</Link>
           {repoUrl ? <a href={repoUrl} className="hover:text-foreground">GitHub</a> : null}
         </div>

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { NavLink, Link, useLocation } from "react-router-dom";
-import { Moon, Sun, Plus, Menu, X, ChevronDown } from "lucide-react";
+import { Moon, Sun, Menu, X, ChevronDown } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
@@ -12,6 +12,7 @@ type NavGroup = { label: string; items: NavItem[] };
 
 const LINKS: NavItem[] = [
   { to: "/", label: "Dashboard", end: true },
+  { to: "/live", label: "Live" },
   { to: "/board", label: "Board" },
   { to: "/partners", label: "For partners" },
 ];
@@ -102,9 +103,6 @@ export function Header({ repoUrl }: { repoUrl?: string }) {
               <Button variant="ghost" size="icon" aria-label="GitHub"><GitHubIcon className="h-4 w-4" /></Button>
             </a>
           ) : null}
-          <Link to="/submit" className="hidden sm:block">
-            <Button variant="brand" size="sm"><Plus className="h-4 w-4" /> Submit</Button>
-          </Link>
           <Button variant="ghost" size="icon" className="md:hidden" onClick={() => setOpen((o) => !o)} aria-label="Menu">
             {open ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
           </Button>
@@ -131,9 +129,6 @@ export function Header({ repoUrl }: { repoUrl?: string }) {
                 ))}
               </div>
             ))}
-            <Link to="/submit" onClick={() => setOpen(false)} className="mt-2">
-              <Button variant="brand" className="w-full"><Plus className="h-4 w-4" /> Submit an issue</Button>
-            </Link>
           </div>
         </nav>
       ) : null}

--- a/web/src/components/shared/CommentFeed.tsx
+++ b/web/src/components/shared/CommentFeed.tsx
@@ -1,0 +1,128 @@
+import { Bot, GitPullRequest, MessageSquare } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { initials, relativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { ActiveActor, FeedComment } from "@/lib/types";
+
+// An actor is "active now" if we last saw them within this window.
+const ACTIVE_WINDOW_MS = 30 * 60 * 1000;
+
+function isRecent(iso: string) {
+  return Date.now() - new Date(iso).getTime() < ACTIVE_WINDOW_MS;
+}
+
+/** Overlapping avatars of who's been active recently; agents get a bot glyph
+ *  and a coloured ring, fresh activity gets a pulsing dot. */
+export function ActiveStrip({ actors }: { actors: ActiveActor[] }) {
+  if (!actors.length) return null;
+  const liveCount = actors.filter((a) => isRecent(a.at)).length;
+  const agentLive = actors.filter((a) => a.isAgent && isRecent(a.at)).length;
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex -space-x-2">
+        {actors.slice(0, 8).map((a) => {
+          const live = isRecent(a.at);
+          return (
+            <Tooltip key={a.login}>
+              <TooltipTrigger asChild>
+                <a href={`https://github.com/${a.login}`} target="_blank" rel="noreferrer" className="relative inline-block">
+                  <Avatar
+                    style={{ height: 30, width: 30 }}
+                    className={cn(
+                      "border-2 border-background ring-2",
+                      a.isAgent ? "ring-brand-cyan" : live ? "ring-emerald-400" : "ring-transparent",
+                    )}
+                  >
+                    {a.avatar ? <AvatarImage src={a.avatar} alt={a.login} /> : null}
+                    <AvatarFallback>{initials(a.login)}</AvatarFallback>
+                  </Avatar>
+                  {a.isAgent ? (
+                    <span className="absolute -bottom-0.5 -right-0.5 rounded-full bg-brand-cyan p-0.5 text-white ring-2 ring-background">
+                      <Bot className="h-2.5 w-2.5" />
+                    </span>
+                  ) : live ? (
+                    <span className="absolute -bottom-0.5 -right-0.5 flex h-3 w-3">
+                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                      <span className="relative inline-flex h-3 w-3 rounded-full bg-emerald-500 ring-2 ring-background" />
+                    </span>
+                  ) : null}
+                </a>
+              </TooltipTrigger>
+              <TooltipContent>
+                @{a.login}{a.isAgent ? " · agent" : ""} · {relativeTime(a.at)}
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+      <div className="text-xs text-muted-foreground">
+        {liveCount > 0 ? (
+          <span className="font-medium text-foreground">{liveCount} active now</span>
+        ) : (
+          <span>{actors.length} recently active</span>
+        )}
+        {agentLive > 0 ? <span className="text-brand-cyan"> · {agentLive} agent{agentLive > 1 ? "s" : ""} working</span> : null}
+      </div>
+    </div>
+  );
+}
+
+/** Newest-first stream of comments across every issue and PR. */
+export function CommentFeed({
+  comments,
+  limit,
+  compact = false,
+}: {
+  comments: FeedComment[];
+  limit?: number;
+  compact?: boolean;
+}) {
+  const items = limit ? comments.slice(0, limit) : comments;
+  if (!items.length) {
+    return <p className="py-6 text-center text-sm text-muted-foreground">No comments yet — the conversation starts here.</p>;
+  }
+  return (
+    <ul className="space-y-3">
+      {items.map((c) => (
+        // Keyed by comment identity so React animates genuinely new entries in
+        // on each poll rather than reusing a positional node.
+        <li key={`${c.url}-${c.createdAt}`} className="animate-fade-in">
+          <a
+            href={c.url}
+            target="_blank"
+            rel="noreferrer"
+            className="flex gap-3 rounded-xl border border-transparent p-2 transition-colors hover:border-border hover:bg-secondary/50"
+          >
+            <div className="relative shrink-0">
+              <Avatar style={{ height: 32, width: 32 }} className={cn("border border-border", c.isAgent && "ring-2 ring-brand-cyan/60")}>
+                {c.avatar ? <AvatarImage src={c.avatar} alt={c.author} /> : null}
+                <AvatarFallback>{initials(c.author)}</AvatarFallback>
+              </Avatar>
+              {c.isAgent ? (
+                <span className="absolute -bottom-1 -right-1 rounded-full bg-brand-cyan p-0.5 text-white ring-2 ring-background">
+                  <Bot className="h-2.5 w-2.5" />
+                </span>
+              ) : null}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <span className="font-medium text-foreground">{c.author}</span>
+                {c.isAgent ? <span className="rounded bg-brand-cyan/10 px-1 font-medium text-brand-cyan">agent</span> : null}
+                <span>· {relativeTime(c.createdAt)}</span>
+              </div>
+              {!compact ? <p className="mt-0.5 line-clamp-2 text-sm text-foreground/90">{c.body || <span className="italic text-muted-foreground">(no text)</span>}</p> : null}
+              <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                {c.isPR ? <GitPullRequest className="h-3 w-3" /> : <MessageSquare className="h-3 w-3" />}
+                <span className="truncate">
+                  {c.isPR ? "PR" : "issue"} #{c.issueNumber} · {c.issueTitle}
+                </span>
+              </div>
+            </div>
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/hooks/useSnapshot.ts
+++ b/web/src/hooks/useSnapshot.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import type { Snapshot } from "@/lib/types";
-import { loadSnapshot } from "@/lib/data";
+import { loadSnapshot, loadSnapshotFresh } from "@/lib/data";
 
-export function useSnapshot() {
+// Load the data snapshot. Pass `pollMs` to re-fetch a fresh copy on an interval
+// (used by the live feed) — the first paint still comes from the shared cache.
+export function useSnapshot(pollMs?: number) {
   const [data, setData] = useState<Snapshot | null>(null);
   const [error, setError] = useState<string | null>(null);
   useEffect(() => {
@@ -10,7 +12,13 @@ export function useSnapshot() {
     loadSnapshot()
       .then((d) => alive && setData(d))
       .catch((e) => alive && setError(e.message));
-    return () => { alive = false; };
-  }, []);
+    if (!pollMs) return () => { alive = false; };
+    const id = setInterval(() => {
+      loadSnapshotFresh()
+        .then((d) => alive && setData(d))
+        .catch(() => { /* keep last good data on a failed poll */ });
+    }, pollMs);
+    return () => { alive = false; clearInterval(id); };
+  }, [pollMs]);
   return { data, error, loading: !data && !error };
 }

--- a/web/src/lib/data.ts
+++ b/web/src/lib/data.ts
@@ -2,13 +2,23 @@ import type { Snapshot } from "./types";
 
 let cache: Promise<Snapshot> | null = null;
 
+const SNAPSHOT_URL = () => `${import.meta.env.BASE_URL}data/snapshot.json`;
+
 export function loadSnapshot(): Promise<Snapshot> {
   if (!cache) {
-    const url = `${import.meta.env.BASE_URL}data/snapshot.json`;
-    cache = fetch(url, { cache: "no-cache" }).then((r) => {
+    cache = fetch(SNAPSHOT_URL(), { cache: "no-cache" }).then((r) => {
       if (!r.ok) throw new Error(`Failed to load data (${r.status})`);
       return r.json() as Promise<Snapshot>;
     });
   }
   return cache;
+}
+
+// Bypass the module cache to pull a fresh snapshot — used by polling so the
+// live feed picks up comments as new builds deploy.
+export function loadSnapshotFresh(): Promise<Snapshot> {
+  return fetch(SNAPSHOT_URL(), { cache: "no-store" }).then((r) => {
+    if (!r.ok) throw new Error(`Failed to load data (${r.status})`);
+    return r.json() as Promise<Snapshot>;
+  });
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -12,6 +12,28 @@ export interface Comment {
   avatar: string;
   body: string;
   createdAt: string;
+  url?: string;
+}
+
+// A single comment in the cross-repo live feed (see /live).
+export interface FeedComment {
+  author: string;
+  avatar: string;
+  isAgent: boolean;
+  body: string;
+  createdAt: string;
+  url: string;
+  issueNumber: number;
+  issueTitle: string;
+  isPR: boolean;
+}
+
+// Someone seen active recently, powering the "active now" strip.
+export interface ActiveActor {
+  login: string;
+  avatar: string;
+  isAgent: boolean;
+  at: string;
 }
 
 export interface IssueLite {
@@ -117,6 +139,8 @@ export interface Snapshot {
   findings: Finding[];
   sources: SourceRef[];
   activity: ActivityItem[];
+  comments: FeedComment[];
+  activeActors: ActiveActor[];
   adrs?: Adr[];
 }
 

--- a/web/src/pages/Board.tsx
+++ b/web/src/pages/Board.tsx
@@ -81,7 +81,7 @@ export default function Board() {
       </div>
 
       {filtered.length === 0 ? (
-        <EmptyState icon={Inbox} title="Nothing matches">Try clearing a filter, or submit a new problem.</EmptyState>
+        <EmptyState icon={Inbox} title="Nothing matches">Try clearing a filter.</EmptyState>
       ) : view === "list" ? (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((i) => <IssueCard key={i.number} issue={i} />)}

--- a/web/src/pages/Contribute.tsx
+++ b/web/src/pages/Contribute.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { ArrowRight, Terminal, Users, ScanEye, GitMerge, Plus, BookOpen, Coins, Sparkles } from "lucide-react";
+import { ArrowRight, Terminal, Users, ScanEye, GitMerge, BookOpen, Coins, Sparkles } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { WorkflowDiagram } from "@/components/shared/WorkflowDiagram";
@@ -45,7 +45,7 @@ export default function Contribute() {
           </p>
           <ol className="mt-4 space-y-3 text-sm">
             {[
-              <><strong>Submit a real problem</strong> you've seen on the ground — every stream of work starts with one.</>,
+              <><strong>Bring a real problem</strong> you've seen on the ground — every stream of work starts with one.</>,
               <><strong>Steward a stream</strong>: read what the agents found, write the plain-language overview, and make the call — go deeper, pivot, or proceed. Nothing moves from research to solutions to building without a human gate.</>,
               <><strong>Sanity-check the findings</strong>: one comment from someone who knows the domain — "that's not how it works in practice" — can redirect weeks of agent output.</>,
               <>And yes, you can still claim an issue and do the work by hand if you want — the <Link to="/methodology" className="text-brand-cyan-dark hover:underline">method</Link> is the same for everyone.</>,
@@ -57,8 +57,8 @@ export default function Contribute() {
             ))}
           </ol>
           <div className="mt-5 flex flex-wrap gap-2">
-            <Link to="/submit"><Button variant="brand" size="sm"><Plus className="h-4 w-4" /> Submit a problem</Button></Link>
-            <Link to="/board"><Button variant="outline" size="sm">Browse the board</Button></Link>
+            <Link to="/board"><Button variant="brand" size="sm">Browse the board</Button></Link>
+            <Link to="/live"><Button variant="outline" size="sm">Watch it live</Button></Link>
           </div>
         </Card>
 
@@ -130,7 +130,7 @@ export default function Contribute() {
         <p className="mx-auto mt-2 max-w-xl text-white/85">Your spare tokens could be the thing that moves a genuine New Zealand problem forward.</p>
         <div className="mt-5 flex flex-wrap justify-center gap-3">
           <Link to="/board"><Button size="lg" className="bg-white text-brand-navy hover:bg-white/90">Explore the board</Button></Link>
-          <Link to="/submit"><Button size="lg" variant="outline" className="border-white/40 bg-transparent text-white hover:bg-white/10">Submit a problem</Button></Link>
+          <Link to="/live"><Button size="lg" variant="outline" className="border-white/40 bg-transparent text-white hover:bg-white/10">Watch the work live</Button></Link>
         </div>
       </div>
     </div>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -8,18 +8,19 @@ import { Loading, ErrorState } from "@/components/shared/States";
 import { StatCard } from "@/components/shared/StatCard";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { PersonAvatar } from "@/components/shared/PersonAvatar";
-import { StageBadge } from "@/components/shared/Badges";
+import { CommentFeed, ActiveStrip } from "@/components/shared/CommentFeed";
 import { STAGE_META, STAGE_ORDER, domainLabel } from "@/lib/meta";
-import { relativeTime } from "@/lib/format";
 import type { Stage } from "@/lib/types";
 
 export default function Dashboard() {
-  const { data, error, loading } = useSnapshot();
+  // Poll so the home page's live widget stays fresh without a manual refresh.
+  const { data, error, loading } = useSnapshot(60_000);
   if (loading) return <Loading />;
   if (error || !data) return <ErrorState message={error || "No data"} />;
 
-  const { stats, pipeline, activity, reviewQueue, repo } = data;
+  const { stats, pipeline, reviewQueue, repo } = data;
+  const comments = data.comments ?? [];
+  const activeActors = data.activeActors ?? [];
   const domainData = Object.entries(stats.byDomain).map(([k, v]) => ({ name: domainLabel(k), value: v }));
   const maxStage = Math.max(1, ...pipeline.map((p) => p.open + p.done));
 
@@ -42,7 +43,7 @@ export default function Dashboard() {
             ideating solutions, and building real things. Bring your spare tokens and pick up a piece.
           </p>
           <div className="mt-7 flex flex-wrap gap-3">
-            <Link to="/submit"><Button variant="brand" size="lg">Submit a problem <ArrowRight className="h-4 w-4" /></Button></Link>
+            <Link to="/live"><Button variant="brand" size="lg">Watch the work live <ArrowRight className="h-4 w-4" /></Button></Link>
             <Link to="/board"><Button variant="outline" size="lg">Explore the board</Button></Link>
             {repo.url ? <a href={`${repo.url}/blob/main/CONTRIBUTING.md`} target="_blank" rel="noreferrer"><Button variant="ghost" size="lg">Read the method</Button></a> : null}
           </div>
@@ -105,7 +106,7 @@ export default function Dashboard() {
           <CardHeader><CardTitle>Open work by domain</CardTitle></CardHeader>
           <CardContent>
             {domainData.length === 0 ? (
-              <p className="py-8 text-center text-sm text-muted-foreground">No open work yet — be the first to submit.</p>
+              <p className="py-8 text-center text-sm text-muted-foreground">No open work yet.</p>
             ) : (
               <div className="w-full min-w-0 overflow-hidden">
                 <ResponsiveContainer width="100%" height={240}>
@@ -123,20 +124,21 @@ export default function Dashboard() {
           </CardContent>
         </Card>
 
-        {/* Recent activity */}
+        {/* Live activity */}
         <Card className="min-w-0">
-          <CardHeader><CardTitle>Recent activity</CardTitle></CardHeader>
+          <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+            <CardTitle className="flex items-center gap-2">
+              <span className="relative flex h-2 w-2">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+              </span>
+              Live activity
+            </CardTitle>
+            <Link to="/live"><Button variant="ghost" size="sm">Open feed <ArrowRight className="h-4 w-4" /></Button></Link>
+          </CardHeader>
           <CardContent className="space-y-3">
-            {activity.slice(0, 7).map((a, i) => (
-              <a key={i} href={a.url} target="_blank" rel="noreferrer" className="flex items-start gap-3 rounded-lg p-1.5 transition-colors hover:bg-secondary/60">
-                <PersonAvatar login={a.actor} avatar={a.avatar} size={26} />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-sm font-medium">{a.title}</div>
-                  <div className="truncate text-xs text-muted-foreground">{a.type === "pr" ? "PR" : "issue"} · {a.meta} · {relativeTime(a.at)}</div>
-                </div>
-              </a>
-            ))}
-            {activity.length === 0 ? <p className="py-6 text-center text-sm text-muted-foreground">No activity yet.</p> : null}
+            {activeActors.length > 0 ? <ActiveStrip actors={activeActors} /> : null}
+            <CommentFeed comments={comments} limit={6} compact />
           </CardContent>
         </Card>
       </div>

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -1,0 +1,76 @@
+import { useMemo, useState } from "react";
+import { Radio, GitPullRequest, MessageSquare } from "lucide-react";
+import { useSnapshot } from "@/hooks/useSnapshot";
+import { Loading, ErrorState } from "@/components/shared/States";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CommentFeed, ActiveStrip } from "@/components/shared/CommentFeed";
+import { relativeTime } from "@/lib/format";
+
+// Poll for a fresh snapshot on the live page — comment-triggered rebuilds land
+// within a minute or two, so this keeps the feed close to real time.
+const POLL_MS = 45_000;
+
+type Filter = "all" | "issues" | "prs";
+
+export default function Live() {
+  const { data, error, loading } = useSnapshot(POLL_MS);
+  const [filter, setFilter] = useState<Filter>("all");
+
+  const comments = useMemo(() => {
+    const all = data?.comments ?? [];
+    if (filter === "issues") return all.filter((c) => !c.isPR);
+    if (filter === "prs") return all.filter((c) => c.isPR);
+    return all;
+  }, [data, filter]);
+
+  if (loading) return <Loading />;
+  if (error || !data) return <ErrorState message={error || "No data"} />;
+
+  const active = data.activeActors ?? [];
+
+  return (
+    <div>
+      <PageHeader title="Live activity">
+        The latest comments across every issue and pull request, as people and agents work the queue.
+        Updates automatically.
+      </PageHeader>
+
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+        <ActiveStrip actors={active} />
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+            </span>
+            <Radio className="h-3.5 w-3.5" /> Live
+          </span>
+          <span>· updated {relativeTime(data.generatedAt)}</span>
+        </div>
+      </div>
+
+      <div className="mb-4 flex gap-2">
+        {([
+          { k: "all", label: "All", icon: null },
+          { k: "issues", label: "Issues", icon: MessageSquare },
+          { k: "prs", label: "Pull requests", icon: GitPullRequest },
+        ] as const).map(({ k, label, icon: Icon }) => (
+          <Button key={k} variant={filter === k ? "brand" : "outline"} size="sm" onClick={() => setFilter(k)}>
+            {Icon ? <Icon className="h-3.5 w-3.5" /> : null} {label}
+          </Button>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Comment stream</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CommentFeed comments={comments} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a near-real-time activity surface to the dashboard, and disables on-site issue submission for now.

### Live comment feed
- `build-data.mjs` emits a flat, newest-first `comments[]` across every issue/PR plus an `activeActors[]` list.
- New **/live** page: active-now avatar strip, "Live · updated Xm ago" indicator, All/Issues/PRs filter, and a streaming comment feed. Polls a fresh snapshot every 45s.
- Reusable `CommentFeed` + `ActiveStrip` components — agent badge/glow, pulsing live dot, entries animate in on each poll.
- Dashboard "Recent activity" card → compact **"Live activity"** widget linking to /live (polls every 60s).
- Deploy workflow now rebuilds on `issue_comment` / `pull_request_review_comment` / `pull_request_review` events, so a new comment lands within ~1-2 min instead of waiting for the 30-min cron.

**Agents:** all non-bookkeeping-bot actors are flagged as agents for now — humans act as the judgement layer (review/steward), so the visible commit/comment volume is agent-produced. A comment in `build-data.mjs` notes how to restore per-actor detection later.

### Submission disabled
- Removed Submit buttons (header, footer, contribute page).
- Hero CTA now points at the live feed ("Watch the work live"); `/submit` redirects to `/live` so bookmarks don't 404. The Submit page is kept on disk for easy restore.

## Architecture note
Fully static — no backend, no client-side GitHub API calls. "Realtime" = comment → CI rebuild (~1-2 min) → client poll (≤45s).

## Verified
- `tsc -b && vite build` clean; oxlint clean for changed files.
- Screenshotted /live and the dashboard widget (agent badges render), no console errors.
- `/submit` → `/live` redirect confirmed; header Submit button gone; CTA points to /live.

Note: `web/public/data/snapshot.json` is intentionally not modified here — CI regenerates it on every deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zqfEBuNcyPkuzJBnDCar2