### PR TITLE
fix: unstick rework pipeline and make Ctrl-C exit the runner scripts

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -72,6 +72,13 @@ has pushed to the same branch — flips the issue back to `status: in-review` so
 a reviewer picks it up again. If the agent pushed nothing, the issue stays
 `changes-requested` and is retried next loop.
 
+Each loop also **reconciles the rework queue** first (ADR-0008): any open PR
+you authored whose *current* latest review is a change-request (no commits
+pushed after it) but whose worked issue still sits `in-review` gets flipped to
+`changes-requested` — so reviews posted outside `review_work.sh` (a human,
+another bot) or a hand-off lost to a reviewer crash still route back to you.
+A freshly reworked PR awaiting re-review is left alone.
+
 ## `review_work.sh` — review before merge
 
 **Every PR must pass an adversarial review, and the review may NOT be done by the
@@ -81,10 +88,17 @@ method, then posts the review and sets the required
 `for-good/adversarial-review` status check.
 
 On **NEEDS_WORK** it requests changes on the PR *and* flips the linked issue to
-`status: changes-requested`, sending it back to the author's own work loop. A
-PR that already failed review at its current revision is skipped until the
-author pushes rework (`FORCE=1` to re-review anyway); once new commits land,
-the next reviewer loop picks it up again.
+`status: changes-requested`, sending it back to the author's own work loop. The
+issue is resolved via the PR's closing ref **or** its `Closes`/`Part of #n`
+body link (ADR-0008), so discover PRs — which deliberately have no closing ref
+— are routed too. A PR that already failed review at its current revision is
+skipped until the author pushes rework (`FORCE=1` to re-review anyway); once
+new commits land, the next reviewer loop picks it up again.
+
+If the review agent **crashes before writing a review**, that's a reviewer
+tooling failure, not a PR verdict: the merge check is left unset (merge is
+still blocked — the check never went green) so a later loop simply retries,
+and at most one diagnostic comment is posted per head SHA (ADR-0008).
 
 ```bash
 REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh              # review all open PRs
@@ -248,6 +262,8 @@ collective keeps itself unblocked.
   trust, not arbitrary input. Use `HERMES_PROFILE` to run a named Hermes profile,
   override additional Hermes options with `HERMES_FLAGS`, and use `MODEL` /
   `PROVIDER` to select a model or provider where supported.
-- The reviewer fails **closed**: if the agent doesn't return a clear
-  `VERDICT: PASS`, the check is set to failure.
+- The reviewer fails **closed**: a review whose verdict isn't a clear
+  `VERDICT: PASS` sets the check to failure. (A reviewer *crash* that produces
+  no review at all leaves the check unset so a later loop retries — merge is
+  still blocked either way; ADR-0008.)
 - Set `AGENT_TIMEOUT` (seconds) to cap a runaway agent; `MODEL` to pick a model.

--- a/docs/adr/0008-rework-handoff-and-runner-interrupts.md
+++ b/docs/adr/0008-rework-handoff-and-runner-interrupts.md
@@ -1,0 +1,72 @@
+# ADR-0008: Rework hand-off routes by worked issue; reviewer crashes retry; runner interrupts stop the run
+
+- **Status:** proposed (ratified by the human maintainer who reviews and merges PR #109)
+- **Date:** 2026-07-03
+- **Deciders:** human maintainer (on merge); drafted by an agent on behalf of @mcinteerj
+- **Discussion:** [PR #109](https://github.com/thecolab-ai/the-for-good-project/pull/109)
+
+## Context
+
+The rework half of the pipeline had silently stalled: seven open PRs carried a
+`CHANGES_REQUESTED` review while **zero** open issues carried
+`status: changes-requested` — so no author's `start_work.sh` loop ever picked
+the rework up. Three independent gaps caused this: (1) the hand-off resolved
+the issue via GitHub *closing* refs only, and discover PRs deliberately have
+none (`Part of #n`, the stream root stays open — ADR-0001); (2) a reviewer
+crash (no review body) set the merge check to `failure`, which the review loop
+reads as "author's turn" and skips forever, while the author was never flipped
+— a deadlock (PR #55); (3) reviews posted outside `review_work.sh` (a human,
+another bot) never trigger the flip at all. Separately, the runners trapped
+`INT`/`TERM` with a non-exiting cleanup handler, so Ctrl-C ran cleanup and then
+*resumed* the loop.
+
+These are contracts of the automation scripts, so per `docs/adr/README.md`
+the fix needs a decision record, and per `docs/AUTOMATION.md` the change
+itself is ratified by a human maintainer, not an agent review.
+
+## Decision
+
+We will:
+
+1. **Route status hand-offs by the issue a PR *works*, not the issue it
+   *closes*.** A new `issue_addressed_by_pr` resolves a closing ref first,
+   else the `Closes`/`Fixes`/`Resolves`/`Part of #n` link in the PR body.
+   `issue_for_pr` stays closing-ref-only and remains the function for the
+   merge → `done` path, so a discover PR can never wrongly mark its stream
+   root done. Considered instead: giving discover PRs a closing ref (rejected
+   — the root must stay open, ADR-0001); parsing only `Part of` (rejected —
+   authors also write `Closes` in bodies GitHub fails to link cross-fork).
+2. **Treat a reviewer crash as a tooling failure, not a PR verdict.** If the
+   review agent produces no review body, the merge check is left **unset**
+   (merge stays blocked — the check never went green) so a later loop simply
+   re-reviews, and at most one diagnostic comment is posted per head SHA.
+   Considered instead: keeping `failure` (rejected — deadlocks the PR);
+   setting `pending` (rejected — still special-cases the retry path and
+   misstates what happened). A review body with a missing/unclear verdict
+   still fails closed (NEEDS_WORK).
+3. **Self-heal the rework queue.** Each `start_work.sh` loop first reconciles:
+   any open PR the runner authored whose *current* latest review is a
+   change-request (no commits pushed after it) but whose worked issue still
+   sits `in-review` is flipped to `changes-requested`. Skipping
+   already-reworked PRs prevents rework↔review ping-pong. This catches all
+   three gap classes without depending on who posted the review.
+4. **Make interrupts actually stop the run.** `cleanup` runs on `EXIT` only;
+   `INT`/`TERM` handlers `exit 130`/`exit 143` (re-firing the `EXIT` trap
+   once). Every `run_agent` call site checks `was_interrupted` (exit 130/143)
+   and stops the whole runner; an agent `timeout` (124) deliberately fails
+   only that item and the loop continues.
+
+## Consequences
+
+- The rework queue becomes self-healing: a missed flip — whatever missed it —
+  is repaired on the author's next loop, and Ctrl-C means stop.
+- The reconciler adds a few `gh` calls per loop, and a deterministic reviewer
+  crash now retries each loop instead of parking the PR; the cost is bounded
+  (one diagnostic per head SHA, merge still gated on a green check).
+- We accept that body-link parsing (`Part of #n`) is a convention, not a
+  GitHub-verified relationship — a typo'd issue number routes the wrong
+  issue. The merge → `done` path is unaffected by construction.
+- Tripwire: if a PR's review check is observed re-crashing on the same head
+  SHA across many loops, or the reconciler ever flips an issue while its PR's
+  rework is mid-flight (ping-pong), revisit — add a retry cap or move the
+  hand-off into CI.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,5 +44,6 @@ routine fixes, copy changes, or web styling.
 | [0005](0005-agent-execution-environment.md) | How & where we run the agents (containerise + sandboxed auto modes) | Accepted |
 | [0006](0006-fetch-proxy-browser-management.md) | Fetch, proxy & browser management for research + citation checks | Accepted |
 | [0007](0007-synthesis-drafts-candidate-outcomes.md) | Synthesis drafts candidate outcomes; the direction stays human | Accepted |
+| [0008](0008-rework-handoff-and-runner-interrupts.md) | Rework hand-off routes by worked issue; reviewer crashes retry; runner interrupts stop the run | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/review_work.sh
+++ b/review_work.sh
@@ -60,9 +60,15 @@ REVIEW_CLAIMING_LABEL="status: reviewing"
 HUMAN_ONLY_LABEL="review: human-only"  # PRs carrying this are reviewed by a human maintainer, never by this loop
 REVIEW_CLAIM_TTL="${REVIEW_CLAIM_TTL:-1800}"  # secs a 'status: reviewing' claim is honoured before it's treated as stale
 
-# Release any claim we hold, then clean up the worktree — on normal exit or interrupt.
+# Release any claim we hold, then clean up the worktree. cleanup runs on ANY
+# exit via the EXIT trap; the INT/TERM handlers must call `exit` themselves,
+# otherwise bash runs the handler and then RESUMES the loop — which is exactly
+# why Ctrl-C used to do nothing here. exit re-triggers the EXIT trap, so cleanup
+# still runs exactly once.
 cleanup() { [ -n "${CLAIMED_PR:-}" ] && release_pr "$CLAIMED_PR" || true; remove_worktree || true; }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # Use a distinct reviewer identity if provided (recommended).
 if [ -n "${REVIEW_GITHUB_TOKEN:-}" ]; then export GH_TOKEN="$REVIEW_GITHUB_TOKEN"; fi
@@ -325,28 +331,42 @@ review_one() {  # $1 = PR number
   verdict="$( { cat "$tmp"; [ -n "$body_file" ] && cat "$body_file"; } | grep -Eo 'VERDICT:[[:space:]]*(PASS|NEEDS_WORK)' | tail -1 | grep -Eo 'PASS|NEEDS_WORK' || true)"
 
   if [ -z "$body_file" ]; then
-    local diag; diag="$(mktemp)"
-    {
-      echo "Adversarial review failed before writing feedback."
-      echo
-      echo "No review body was produced at:"
-      echo
-      echo '```text'
-      echo "$REVIEW_FILE"
-      echo '```'
-      echo
-      echo "Tail of agent output:"
-      echo
-      echo '```text'
-      tail -80 "$tmp"
-      echo '```'
-      echo
-      echo "Re-run with \`FORCE=1 PR=$pr ./review_work.sh\` after fixing the agent/file-output problem."
-    } >"$diag"
-    warn "No review file produced for PR #$pr; posting diagnostic comment instead of a request-changes review."
-    gh pr comment "$pr" --repo "$REPO" --body-file "$diag" >/dev/null || true
-    set_check "$sha" failure "Adversarial review failed before writing feedback" "$url"
-    rm -f "$tmp" "$diag" "$fallback_review_file"
+    # The REVIEWER (not the author) failed to produce a review — a TOOLING
+    # failure, not a defect in the PR. Do NOT set the merge check to `failure`:
+    # this loop reads `failure` as "author's turn to rework" and skips the PR
+    # forever, while the author only ever picks up "changes-requested" — which we
+    # never set. That combination is a deadlock (it's why PR #55 wedged). Leave
+    # the check UNSET so a later loop simply RE-REVIEWS (merge is still blocked
+    # because the check never went green), and post at most ONE diagnostic per
+    # head SHA so a deterministic crash doesn't spam the PR.
+    local marker="<!-- fg-review-crash:$sha -->"
+    if gh pr view "$pr" --repo "$REPO" --json comments --jq '.comments[].body' 2>/dev/null | grep -qF "$marker"; then
+      warn "Review of PR #$pr crashed again at $sha (diagnostic already posted) — will retry next loop."
+    else
+      local diag; diag="$(mktemp)"
+      {
+        echo "$marker"
+        echo "Adversarial review failed before writing feedback (reviewer tooling problem, not a defect in this PR)."
+        echo
+        echo "No review body was produced at:"
+        echo
+        echo '```text'
+        echo "$REVIEW_FILE"
+        echo '```'
+        echo
+        echo "Tail of agent output:"
+        echo
+        echo '```text'
+        tail -80 "$tmp"
+        echo '```'
+        echo
+        echo "The review loop will retry automatically. To force a retry now: \`FORCE=1 PR=$pr ./review_work.sh\`."
+      } >"$diag"
+      warn "No review file produced for PR #$pr; posting a diagnostic (check left unset so a later loop retries)."
+      gh pr comment "$pr" --repo "$REPO" --body-file "$diag" >/dev/null || true
+      rm -f "$diag"
+    fi
+    rm -f "$tmp" "$fallback_review_file"
     release_pr "$pr"; CLAIMED_PR=""
     remove_worktree
     git -C "$REPO_DIR" update-ref -d "refs/fg/pr-$pr" 2>/dev/null || true
@@ -376,8 +396,11 @@ review_one() {  # $1 = PR number
       || gh pr comment "$pr" --repo "$REPO" "${body_flag[@]}" >/dev/null || true
     set_check "$sha" failure "Adversarial review found problems" "$url"
     # Route the rework back to the author: flip the linked issue to
-    # "changes-requested" so THEIR next start_work.sh loop picks it up.
-    local iss; iss="$(issue_for_pr "$pr" || true)"
+    # "changes-requested" so THEIR next start_work.sh loop picks it up. Use
+    # issue_addressed_by_pr (not issue_for_pr) so DISCOVER PRs — which have no
+    # closing ref, only "Part of #n" — are routed too, instead of silently
+    # dropping the hand-off.
+    local iss; iss="$(issue_addressed_by_pr "$pr" || true)"
     if [ -n "$iss" ]; then
       if set_status_label "$iss" "changes-requested" "in-review" 2>/dev/null; then
         gh issue comment "$iss" --repo "$REPO" --body "🔁 Adversarial review of PR #$pr found problems — sending back to @$author for rework (**status: changes-requested**). Their next \`start_work.sh\` loop will pick this up." >/dev/null || true
@@ -410,7 +433,8 @@ main() {
       rule; ok "No open PRs needing review."; break
     fi
     for pr in $prs; do
-      review_one "$pr" || true
+      set +e; review_one "$pr"; local rc=$?; set -e
+      was_interrupted "$rc" && { rule; warn "Interrupted — stopping."; exit 130; }
       done=$((done+1))
       [ "$MAX" -gt 0 ] && [ "$done" -ge "$MAX" ] && { rule; ok "Reached MAX=$MAX. Stopping."; exit 0; }
     done

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -176,10 +176,26 @@ pr_review_kind() {  # $1 = pr number
   fi
 }
 
-# Issue closed by a PR (first closing ref).
+# Issue closed by a PR (first closing ref). Use this ONLY when you specifically
+# mean "the issue merging this PR will CLOSE" (e.g. marking it done) — discover
+# PRs have no closing ref by design, so this is empty for them.
 issue_for_pr() {
   gh api graphql -f query="{repository(owner:\"$OWNER\",name:\"$NAME\"){pullRequest(number:$1){closingIssuesReferences(first:5){nodes{number}}}}}" \
     --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[0].number // empty'
+}
+
+# The issue a PR is WORKING (for routing rework/status back to the author): a
+# closing ref if there is one, else the "Closes/Part of #n" link in the PR body.
+# Unlike issue_for_pr this resolves DISCOVER PRs, which intentionally do NOT
+# close their stream-root issue (it must stay open for the stream's life) and so
+# carry only a "Part of #n" link. Use this for status hand-offs.
+issue_addressed_by_pr() {  # $1 = pr number
+  local n
+  n="$(issue_for_pr "$1")"
+  [ -n "$n" ] && { echo "$n"; return 0; }
+  gh pr view "$1" --repo "$REPO" --json body --jq .body 2>/dev/null \
+    | grep -oiE '(closes|fixes|resolves|part of)[[:space:]]*#[0-9]+' \
+    | grep -oE '[0-9]+' | head -1
 }
 
 set_status_label() {  # $1 issue, $2 new-status (bare, e.g. in-review), $3.. old statuses to remove
@@ -187,6 +203,16 @@ set_status_label() {  # $1 issue, $2 new-status (bare, e.g. in-review), $3.. old
   local args=(--add-label "status: $new")
   for old in "$@"; do args+=(--remove-label "status: $old"); done
   gh issue edit "$n" --repo "$REPO" "${args[@]}" >/dev/null
+}
+
+# True if an exit status means the agent was INTERRUPTED by the user (Ctrl-C) or
+# killed — the whole runner should stop, not move on to the next item. Note a
+# `timeout` (124) is deliberately NOT here: that fails one item but the loop
+# should carry on to the next. An agent that catches SIGINT itself and exits
+# 130/143 won't trip bash's own INT trap, so callers must check this after every
+# run_agent to stop reliably.
+was_interrupted() {  # $1 = exit status
+  case "$1" in 130|143) return 0 ;; *) return 1 ;; esac
 }
 
 # ---- agent runner ----

--- a/start_work.sh
+++ b/start_work.sh
@@ -245,7 +245,9 @@ work_one() {  # $1 = issue number
   fi
   make_worktree origin/main
   info "Handing #$n to $AGENT (worktree: $WORKTREE)..."
-  if run_agent "$(work_prompt "$n")" "$WORKTREE"; then ok "Agent run complete for #$n"; else err "Agent run failed/aborted for #$n"; fi
+  set +e; run_agent "$(work_prompt "$n")" "$WORKTREE"; local rc=$?; set -e
+  was_interrupted "$rc" && release_on_interrupt   # Ctrl-C the agent → stop the whole run, don't roll to the next issue
+  if [ "$rc" -eq 0 ]; then ok "Agent run complete for #$n"; else err "Agent run failed/aborted for #$n (exit $rc)"; fi
   remove_worktree
   finish_issue "$n"
 }
@@ -271,7 +273,9 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
   before="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"
   make_worktree "origin/$branch"
   info "Handing PR #$pr rework to $AGENT (worktree: $WORKTREE)..."
-  if run_agent "$(rework_prompt "$n" "$pr" "$branch")" "$WORKTREE"; then ok "Rework agent run complete for #$n"; else err "Rework agent run failed/aborted for #$n"; fi
+  set +e; run_agent "$(rework_prompt "$n" "$pr" "$branch")" "$WORKTREE"; local rc=$?; set -e
+  was_interrupted "$rc" && release_on_interrupt   # Ctrl-C the agent → stop the whole run
+  if [ "$rc" -eq 0 ]; then ok "Rework agent run complete for #$n"; else err "Rework agent run failed/aborted for #$n (exit $rc)"; fi
   remove_worktree
   after="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"
   if [ "$after" != "$before" ]; then
@@ -283,11 +287,44 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
   fi
 }
 
+# Self-heal the rework queue: any open PR I authored that a reviewer sent back
+# but whose linked issue is still sitting "in-review" gets flipped to
+# "changes-requested" so the queue below actually picks it up. This closes the
+# gaps where the normal hand-off never fired: a reviewer crash, a discover PR
+# with no closing ref, or a review posted OUTSIDE review_work.sh (a human, or
+# another bot). We only act when the change-request is CURRENT — no commits were
+# pushed after it — so a freshly reworked PR awaiting re-review is left alone.
+reconcile_rework() {
+  [ "$DRY_RUN" = 1 ] && return 0
+  local prs pr iss labels lastcr headcommit
+  prs="$(gh pr list --repo "$REPO" --state open --author "@me" --json number,reviewDecision \
+          --jq '.[]|select(.reviewDecision=="CHANGES_REQUESTED")|.number' 2>/dev/null || true)"
+  for pr in $prs; do
+    lastcr="$(gh pr view "$pr" --repo "$REPO" --json reviews --jq '[.reviews[]|select(.state=="CHANGES_REQUESTED")]|last|.submittedAt // ""' 2>/dev/null || true)"
+    [ -z "$lastcr" ] && continue
+    headcommit="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate // ""' 2>/dev/null || true)"
+    # ISO-8601 timestamps compare lexically: a commit newer than the review means
+    # it's already been reworked and is awaiting RE-review, not rework — skip it.
+    [ -n "$headcommit" ] && [[ "$headcommit" > "$lastcr" ]] && continue
+    iss="$(issue_addressed_by_pr "$pr" || true)"
+    [ -z "$iss" ] && continue
+    labels="$(issue_labels "$iss" 2>/dev/null || true)"
+    case ",$labels," in
+      *",status: changes-requested,"*) continue ;;   # already routed
+      *",status: in-review,"*)
+        gh issue edit "$iss" --repo "$REPO" --add-assignee "@me" >/dev/null 2>&1 || true
+        set_status_label "$iss" "changes-requested" "in-review" 2>/dev/null \
+          && ok "Reconciled #$iss → changes-requested (unrouted review on PR #$pr)" || true ;;
+    esac
+  done
+}
+
 main() {
   preflight
   info "start_work.sh · repo=$REPO · agent=$AGENT${STAGE:+ · stage=$STAGE}$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"
   local done=0
   while :; do
+    reconcile_rework   # pull in any PRs a reviewer sent back that the hand-off missed
     # Rework a reviewer sent back to ME takes priority over fresh issues.
     local next kind=new
     next="$(rework_issues | head -1 || true)"

--- a/synthesize_work.sh
+++ b/synthesize_work.sh
@@ -29,7 +29,11 @@ cd "$(dirname "$0")"
 source "scripts/fg-common.sh"
 RUNS_AGENT=1
 parse_agent_args "$@"
-trap 'remove_worktree || true' EXIT INT TERM
+# cleanup runs on ANY exit; INT/TERM must `exit` themselves or bash resumes the
+# loop after Ctrl-C instead of stopping. exit re-fires the EXIT trap.
+trap 'remove_worktree || true' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 MAX="${MAX:-0}"
 POLL_SECONDS="${POLL_SECONDS:-60}"    # keep polling when queue empty (0 to exit instead)
@@ -196,10 +200,12 @@ synthesize_one() {  # $1 = stream root issue number
 
   info "Evidence ($(printf '%s\n' "$evidence" | wc -l | tr -d ' ') file(s)):"; log "$evidence"
   info "Handing stream #$n to $AGENT (worktree: $WORKTREE)..."
-  if run_agent "$(synthesis_prompt "$n" "$path" "$evidence" "$branch" "$resynth")" "$WORKTREE"; then
+  set +e; run_agent "$(synthesis_prompt "$n" "$path" "$evidence" "$branch" "$resynth")" "$WORKTREE"; local rc=$?; set -e
+  was_interrupted "$rc" && { remove_worktree; warn "Interrupted — stopping."; exit 130; }
+  if [ "$rc" -eq 0 ]; then
     ok "Synthesis agent run complete for stream #$n"
   else
-    err "Synthesis agent run failed/aborted for stream #$n"
+    err "Synthesis agent run failed/aborted for stream #$n (exit $rc)"
   fi
   remove_worktree
 


### PR DESCRIPTION
## Why

The rework pipeline had silently stalled: every PR with changes requested sat untouched. `start_work.sh`'s rework queue reads issues labelled `status: changes-requested`, but that label was on **zero** open issues despite 7 PRs having `CHANGES_REQUESTED` reviews — the hand-off that flips the linked issue never fired.

## What was broken

1. **Discover PRs never routed.** `issue_for_pr` only reads GitHub *closing* refs, but discover PRs use `Part of #n` (the stream root must stay open), so it returned empty and the flip in `review_work.sh` no-op'd for all of them (#79, #72, #51, #49).
2. **Reviewer crashes deadlocked the PR.** A crashed review (no body) set the merge check to `failure`, which the next loop reads as "author's turn" and skips forever — but the issue was never flipped, so the author never engages either (#55).
3. **Direct reviews bypassed the flip.** Reviews from humans/other bots that don't run `review_work.sh` never flip the issue at all.
4. **Ctrl-C didn't work.** `review_work.sh` / `synthesize_work.sh` used `trap cleanup EXIT INT TERM` with a non-exiting handler, so SIGINT ran cleanup then *resumed* the loop.

## What this does

- Adds `issue_addressed_by_pr` (closing ref **or** `Closes`/`Part of #n` body link) and uses it for the hand-off; keeps `issue_for_pr` closing-only for the merge→done path so discover roots are never wrongly marked done.
- On a reviewer-tooling failure, leaves the merge check **unset** (retryable next loop; merge still blocked) and posts one diagnostic per head SHA instead of spamming.
- Adds a self-healing `reconcile_rework()` to `start_work.sh` that flips `in-review` issues whose PR has a **current** change-request (skips PRs already reworked and awaiting re-review, so no rework↔review ping-pong).
- Splits the traps (cleanup on `EXIT`; `INT`/`TERM` call `exit`) and checks `run_agent`'s exit status at every call site (new `was_interrupted` helper) so an agent that catches SIGINT and exits non-zero still stops the whole run.

## Verification

- All four scripts pass `bash -n`.
- `issue_addressed_by_pr` resolves discover PRs (#79→61, #72→60, #51→3, #49→2) where `issue_for_pr` returned empty; research PR #92→77 unchanged.
- Reconciler staleness check correctly routes current change-requests and skips already-reworked PRs (verified against live PR timestamps).
- `start_work.sh` dry-run runs end to end through the new path.
- Trap fix proven with a foreground-SIGINT reproduction: old pattern resumes the loop (force-killed), new pattern exits on the first SIGINT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)