### PR TITLE
docs: how agents escalate to maintainers when write access is needed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,27 @@ review still counts toward the gate — it's just validated + merged by a mainta
 One hard rule: agents never apply or remove the `review: human-only` label — a PR
 carrying it is reviewed and merged by humans; leave it alone.
 
+**When only a maintainer can act.** Some steps need write access no matter how you
+route them: syncing status labels the automation missed, pushing rework to an
+upstream PR branch, dismissing a stale review, running `merge_ready.sh`, or anything
+touching `review: human-only`. Don't stall silently, don't retry the 403, and never
+work around the permission — hand it off so a maintainer can act in one paste:
+
+1. **Comment on the affected PR/issue** stating exactly what's needed, with
+   copy-paste commands. If it's rework you couldn't push, push the commit to your
+   fork first and include the `git fetch <your-fork> <branch> && git merge --ff-only
+   FETCH_HEAD && git push` line so it's a one-liner to land.
+2. **If it spans several threads** (or risks getting lost), open a tracking issue
+   titled `maintainer: <what's needed>` that tags a maintainer (currently
+   @adam91holt) and lists each action with links + commands — see
+   [#111](https://github.com/thecolab-ai/the-for-good-project/issues/111) for the
+   shape.
+3. **Say who you act for** — sign comments "posted by an agent on behalf of
+   @<your-human>" so the trust model stays legible.
+
+The escalation *is* the handoff: once it's posted, move on to other available work
+rather than waiting.
+
 ## What each stage needs from you
 
 - **🔍 Discover** — Take a broad problem and produce: a crisp problem statement, who it affects (with NZ figures + sources), what's already being done, and **3–6 specific researchable questions** you'd open as follow-up issues. Output goes in the issue itself (and you may open the child Research issues).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ review still counts toward the gate — it's just validated + merged by a mainta
 One hard rule: agents never apply or remove the `review: human-only` label — a PR
 carrying it is reviewed and merged by humans; leave it alone.
 
-**When only a maintainer can act.** Some steps need write access no matter how you
+**When only a maintainer can act** ([ADR-0009](docs/adr/0009-maintainer-escalation-handoff.md)).
+Some steps need write access no matter how you
 route them: syncing status labels the automation missed, pushing rework to an
 upstream PR branch, dismissing a stale review, running `merge_ready.sh`, or anything
 touching `review: human-only`. Don't stall silently, don't retry the 403, and never

--- a/docs/adr/0009-maintainer-escalation-handoff.md
+++ b/docs/adr/0009-maintainer-escalation-handoff.md
@@ -1,7 +1,7 @@
 # ADR-0009: Agents hand off write-gated actions to maintainers via a documented escalation path
 
 - **Status:** proposed (ratified by the human maintainer who reviews and merges PR #112)
-- **Date:** 2026-07-03
+- **Date:** 2026-07-02 (UTC; drafted 2026-07-03 NZST — no repo convention on ADR date timezones yet)
 - **Deciders:** human maintainer (on merge); drafted by an agent on behalf of @mcinteerj
 - **Discussion:** [PR #112](https://github.com/thecolab-ai/the-for-good-project/pull/112), [issue #111](https://github.com/thecolab-ai/the-for-good-project/issues/111)
 

--- a/docs/adr/0009-maintainer-escalation-handoff.md
+++ b/docs/adr/0009-maintainer-escalation-handoff.md
@@ -1,0 +1,53 @@
+# ADR-0009: Agents hand off write-gated actions to maintainers via a documented escalation path
+
+- **Status:** proposed (ratified by the human maintainer who reviews and merges PR #112)
+- **Date:** 2026-07-03
+- **Deciders:** human maintainer (on merge); drafted by an agent on behalf of @mcinteerj
+- **Discussion:** [PR #112](https://github.com/thecolab-ai/the-for-good-project/pull/112), [issue #111](https://github.com/thecolab-ai/the-for-good-project/issues/111)
+
+## Context
+
+Most contributors (human and agent) have no write or triage rights on this repo — by
+design. `AGENTS.md` already routes the common cases (claim by comment, PR from a fork),
+but some actions are write-gated no matter how they're routed: syncing a status label the
+automation missed, pushing rework to an upstream PR branch, dismissing a stale review,
+running `merge_ready.sh`. When an agent hit one of these there was no documented next
+step, producing three bad outcomes observed in practice: silent stalls (work done but
+never lands), 403 retry loops, or improvised workarounds. PR #109's rework (pushed to a
+fork with a fetch one-liner) and issue #111 (a consolidated `maintainer:` tracking issue)
+improvised a working pattern; this ADR makes it standing procedure. Because `AGENTS.md`
+is the binding operating manual for agents, adopting the pattern is a workflow decision
+and per `docs/adr/README.md` needs a decision record ratified by a human, not an agent
+review.
+
+## Decision
+
+We will document, in `AGENTS.md`, a three-step escalation for write-gated actions:
+
+1. **Comment on the affected PR/issue** stating exactly what's needed, with copy-paste
+   commands; unpushable rework goes to the contributor's fork first so landing it is a
+   `git fetch … && git merge --ff-only && git push` one-liner.
+2. **Open a `maintainer:` tracking issue** tagging a maintainer when the actions span
+   several threads or risk getting lost (shape: issue #111).
+3. **Sign as agent-on-behalf-of** the human contributor, then move on to other available
+   work — the escalation is the handoff, not a wait state.
+
+Options considered and rejected: granting write to whitelisted trusted reviewers
+(rejected here — a real option, but an access-policy decision for maintainers to take
+separately, not something this docs PR should smuggle in); leaving it undocumented
+(rejected — the failure modes above recur); a bot that relays fork commits automatically
+(rejected for now — more automation surface than the volume justifies; revisit if
+escalation issues become frequent).
+
+## Consequences
+
+- Blocked work becomes visible and one-paste landable instead of stalling in an agent's
+  session; maintainer effort per escalation drops to seconds.
+- A named maintainer (@adam91holt) is baked into the doc and must be updated if
+  maintainership changes — accepted cost, cheaper than an indirection layer today.
+- More `maintainer:` issues and on-behalf-of comments in the tracker — accepted as the
+  price of legibility.
+- Tripwire: if escalation issues arrive faster than maintainers clear them, or the same
+  contributor escalates the same class of action repeatedly, that's the signal to revisit
+  the rejected options (targeted write access, or relay automation) rather than scaling
+  this process.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,5 +44,6 @@ routine fixes, copy changes, or web styling.
 | [0005](0005-agent-execution-environment.md) | How & where we run the agents (containerise + sandboxed auto modes) | Accepted |
 | [0006](0006-fetch-proxy-browser-management.md) | Fetch, proxy & browser management for research + citation checks | Accepted |
 | [0007](0007-synthesis-drafts-candidate-outcomes.md) | Synthesis drafts candidate outcomes; the direction stays human | Accepted |
+| [0009](0009-maintainer-escalation-handoff.md) | Agents hand off write-gated actions to maintainers via a documented escalation path | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).


### PR DESCRIPTION
Part of #111.

**Proposal awaiting maintainer sign-off — not agent-adopted policy.** This PR changes the agent operating workflow (AGENTS.md), so per the governance guard it is framed as a proposal: the guidance is ratified by the human maintainer who reviews and merges it, via the included **ADR-0009** (status: proposed). An agent review can assess accuracy and clarity; adoption is the merging maintainer's call.

Adds a "When only a maintainer can act" subsection to AGENTS.md's *No write access?* section, so agents hitting a 403 wall (label sync, upstream branch push, review dismissal, merge) hand off cleanly instead of stalling, retrying, or working around the permission. The pattern is the one exercised on PR #109 (rework pushed to a fork + fetch one-liner in a comment) and issue #111 (consolidated `maintainer:` tracking issue): comment with copy-paste commands, escalate to a tracking issue when it spans threads, sign as agent-on-behalf-of, then move on to other work.

Numbering note: ADR-0008 is reserved by PR #109's proposed ADR (on its rework branch), hence 0009 here; the index row may need a trivial conflict resolution depending on merge order.

`npm run validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)