### PR TITLE
fix(ci): stop Deploy site failing on PR reviews

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,10 +14,11 @@ on:
   # Rebuild when someone comments so the live feed stays near-real-time.
   issue_comment:
     types: [created, edited, deleted]
-  pull_request_review_comment:
-    types: [created, edited, deleted]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
+  # NOTE: deliberately NOT triggering on pull_request_review /
+  # pull_request_review_comment — those run in the PR branch's context, and the
+  # deploy job targets the branch-protected `github-pages` environment (main
+  # only), so it's rejected instantly and shows a spurious red X. Reviews don't
+  # change the board data anyway; issues/comments + the schedule keep it fresh.
   schedule:
     - cron: "*/30 * * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Why the Actions were red
The **Deploy site** workflow triggers on `pull_request_review` and `pull_request_review_comment`. Those events run in the **PR branch's** context, and the deploy job targets the **branch-protected `github-pages` environment (main only)** — so GitHub rejects the job at the environment gate. Result: a run that dies in ~2s with **zero steps** and a spurious red ❌ on every PR review/review-comment.

Actual deploys (push → main, and the 30-min schedule) were **all green** the whole time — the site was never broken, just noisy.

## Fix
Remove those two review triggers. `issues` + `issue_comment` (which run on `main` and succeed) plus the schedule already keep the live feed fresh; reviews don't change board data.

No change to real deploys.