### PR TITLE
feat(runner): TTL so abandoned claims/reworks return to the pool

### DIFF
--- a/reap.sh
+++ b/reap.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# reap.sh — release stale work back to the pool so nothing stays stuck on a
+# worker who wandered off. Run it on a cron, or by hand.
+#
+#   ./reap.sh              # free anything past its TTL
+#   DRY_RUN=1 ./reap.sh    # show what it would free, change nothing
+#
+# Two cases:
+#   - CLAIMED but no PR opened within CLAIM_TTL  → back to `status: available`.
+#   - CHANGES-REQUESTED but untouched within REWORK_TTL → unassigned, so any
+#     worker's start_work.sh can pick the rework up (it keeps the label).
+#
+# Env: CLAIM_TTL REWORK_TTL DRY_RUN FOR_GOOD_REPO REPO_DIR
+set -euo pipefail
+cd "$(dirname "$0")"
+source "scripts/fg-common.sh"
+DRY_RUN="${DRY_RUN:-0}"
+
+hrs() { echo $(( ${1:-0} / 3600 )); }
+
+# 1) Claimed but never delivered a PR → back to available.
+reap_claims() {
+  local n who
+  for n in $(gh issue list --repo "$REPO" --state open --label "status: claimed" \
+      --json number,updatedAt --limit 100 \
+      --jq "[.[] | select((.updatedAt|fromdateiso8601) < (now - $CLAIM_TTL))] | .[].number"); do
+    if [ -n "$(pr_for_issue "$n")" ]; then log "#$n is claimed but has a PR — leaving it."; continue; fi
+    if [ "$DRY_RUN" = 1 ]; then info "[dry-run] would release claimed #$n → available"; continue; fi
+    who="$(gh issue view "$n" --repo "$REPO" --json assignees --jq '.assignees[].login' 2>/dev/null | head -1 || true)"
+    set_status_label "$n" "available" "claimed" 2>/dev/null || true
+    [ -n "$who" ] && gh issue edit "$n" --repo "$REPO" --remove-assignee "$who" >/dev/null 2>&1 || true
+    gh issue comment "$n" --repo "$REPO" --body "⏱ Claimed with no PR for over $(hrs "$CLAIM_TTL")h — released back to **available** for anyone to pick up." >/dev/null 2>&1 || true
+    ok "Released claimed #$n → available"
+  done
+}
+
+# 2) Rework sent back but untouched → unassign so any worker can take it.
+reap_reworks() {
+  local n a who
+  for n in $(gh issue list --repo "$REPO" --state open --label "status: changes-requested" \
+      --json number,updatedAt,assignees --limit 100 \
+      --jq "[.[] | select((.assignees|length)>0) | select((.updatedAt|fromdateiso8601) < (now - $REWORK_TTL))] | .[].number"); do
+    if [ "$DRY_RUN" = 1 ]; then info "[dry-run] would free stale rework #$n (unassign)"; continue; fi
+    who="$(gh issue view "$n" --repo "$REPO" --json assignees --jq '.assignees[].login' 2>/dev/null || true)"
+    for a in $who; do gh issue edit "$n" --repo "$REPO" --remove-assignee "$a" >/dev/null 2>&1 || true; done
+    gh issue comment "$n" --repo "$REPO" --body "⏱ Rework untouched for over $(hrs "$REWORK_TTL")h — unassigned and released to the pool; any worker's \`start_work.sh\` can pick it up." >/dev/null 2>&1 || true
+    ok "Freed stale rework #$n (unassigned)"
+  done
+}
+
+main() {
+  preflight
+  info "reap.sh · repo=$REPO · claim-ttl=$(hrs "$CLAIM_TTL")h · rework-ttl=$(hrs "$REWORK_TTL")h$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"
+  reap_claims
+  reap_reworks
+  ok "Reap complete."
+}
+main "$@"

--- a/review_work.sh
+++ b/review_work.sh
@@ -50,7 +50,7 @@ RUNS_AGENT=1
 parse_agent_args "$@"
 
 DRY_RUN="${DRY_RUN:-0}"
-AUTO_MERGE="${AUTO_MERGE:-0}"
+AUTO_MERGE="${AUTO_MERGE:-1}"          # merge on PASS by default (a non-author review is the gate); AUTO_MERGE=0 to just review
 POLL_SECONDS="${POLL_SECONDS:-60}"    # keep polling when queue empty (0 to exit instead)
 MAX="${MAX:-0}"
 ONLY_PR="${PR:-}"

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -10,6 +10,8 @@ MODEL="${MODEL:-}"                       # optional model override
 PROVIDER="${PROVIDER:-}"                 # optional provider override (Hermes only)
 HERMES_PROFILE="${HERMES_PROFILE:-}"     # optional Hermes profile override
 AGENT_TIMEOUT="${AGENT_TIMEOUT:-2400}"   # seconds per agent run (0 = none)
+CLAIM_TTL="${CLAIM_TTL:-7200}"           # secs a claimed-but-undelivered issue is held before reap.sh frees it
+REWORK_TTL="${REWORK_TTL:-7200}"         # secs a sent-back rework is held for its author before reap.sh frees it
 REVIEW_CHECK_CONTEXT="for-good/adversarial-review"
 RUNS_AGENT="${RUNS_AGENT:-0}"             # scripts that call run_agent set this to 1
 
@@ -101,6 +103,14 @@ available_issues() { issues_with_status "available"; }
 
 # Issues a reviewer sent back that are assigned to *me* — my rework queue.
 rework_issues() { issues_with_status "changes-requested" --assignee "@me"; }
+
+# Reworks with NO assignee — freed by reap.sh after REWORK_TTL, so any worker
+# may take them (oldest first). The author's own reworks stay theirs (above).
+unassigned_reworks() {
+  gh issue list --repo "$REPO" --state open --label "status: changes-requested" \
+    --json number,assignees,createdAt --limit 100 \
+    --jq '[.[] | select((.assignees|length)==0)] | sort_by(.createdAt) | .[].number'
+}
 
 # Drained stream roots waiting for a G1 synthesis draft.
 synthesis_issues() { issues_with_status "needs-synthesis"; }

--- a/start_work.sh
+++ b/start_work.sh
@@ -319,19 +319,37 @@ reconcile_rework() {
   done
 }
 
+# Take the first UNASSIGNED (TTL-freed) rework whose PR lives on origin — i.e.
+# a branch we can actually push the rework to. Fork-branch PRs are skipped (only
+# their owner can push). Claims it to @me and echoes its number, else nothing.
+take_unassigned_rework() {
+  local n pr owner
+  for n in $(unassigned_reworks); do
+    pr="$(pr_for_issue "$n" || true)"; [ -z "$pr" ] && continue
+    owner="$(gh pr view "$pr" --repo "$REPO" --json headRepositoryOwner --jq .headRepositoryOwner.login 2>/dev/null || true)"
+    [ "$owner" = "$OWNER" ] || continue
+    if [ "$DRY_RUN" = 1 ]; then echo "$n"; return 0; fi
+    gh issue edit "$n" --repo "$REPO" --add-assignee "@me" >/dev/null 2>&1 || true
+    gh issue comment "$n" --repo "$REPO" --body "🤝 @$ME is picking up abandoned rework #$n (freed by TTL)." >/dev/null 2>&1 || true
+    echo "$n"; return 0
+  done
+  return 0
+}
+
 main() {
   preflight
   info "start_work.sh · repo=$REPO · agent=$AGENT${STAGE:+ · stage=$STAGE}$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"
   local done=0
   while :; do
     reconcile_rework   # pull in any PRs a reviewer sent back that the hand-off missed
-    # Rework a reviewer sent back to ME takes priority over fresh issues.
+    # Priority: my own rework → a TTL-freed rework I can push → a fresh issue.
     local next kind=new
     next="$(rework_issues | head -1 || true)"
     if [ -n "$next" ]; then
       kind=rework
     else
-      next="$(available_issues | head -1 || true)"
+      next="$(take_unassigned_rework || true)"
+      if [ -n "$next" ]; then kind=rework; else next="$(available_issues | head -1 || true)"; fi
     fi
     if [ -z "$next" ]; then
       if [ "$POLL_SECONDS" -gt 0 ] && [ "$DRY_RUN" = 0 ]; then


### PR DESCRIPTION
Per Adam — *"a worker might start an issue but then never do the rework … some sense of TTL, time to claim otherwise someone else picks it up."*

## What
- **`reap.sh`** (new; run on a cron or by hand):
  - **Claimed but no PR** past `CLAIM_TTL` → back to `status: available`.
  - **Changes-requested but untouched** past `REWORK_TTL` → **unassigned** (keeps the label) so it's up for grabs.
  - `DRY_RUN=1` to preview.
- **`start_work.sh`**: after a worker's own reworks, it now also picks up **TTL-freed (unassigned) reworks** — but only where the PR branch is on **origin** (so it can actually push the rework; fork-branch PRs are left for their owner, which would otherwise 403).
- `CLAIM_TTL` / `REWORK_TTL` default **2h**, env-overridable.

## Verified
- `bash -n` clean on `reap.sh`, `start_work.sh`, `fg-common.sh`.
- Staleness + unassigned jq filters unit-tested.

Suggest wiring `reap.sh` into a scheduled Action later so it runs itself; for now it's an opt-in tool.