### PR TITLE
feat(web): Streams page — full lineage DAG + audit trail

### DIFF
--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -218,6 +218,26 @@ async function main() {
     adrs.sort((a, b) => a.number.localeCompare(b.number));
   }
 
+  // --- stream overview docs (the plain-language "output" of a stream) ---
+  const streamsDir = path.join(REPO_ROOT, "streams");
+  const streamDocs = [];
+  if (existsSync(streamsDir)) {
+    for (const entry of readdirSync(streamsDir).sort()) {
+      if (!entry.endsWith(".md") || ["README.md", "TEMPLATE.md"].includes(entry)) continue;
+      const { data, content } = matter(readFileSync(path.join(streamsDir, entry), "utf8"));
+      streamDocs.push({
+        stream: Number(data.stream ?? (entry.match(/^(\d+)/) || [])[1] ?? 0),
+        title: data.title || "",
+        state: data.state || "",
+        steward: data.steward || "",
+        domain: data.domain || "",
+        updated: data.updated ? String(data.updated) : "",
+        body: content,
+        url: `${repoMeta.html_url}/blob/${repoMeta.default_branch}/streams/${entry}`,
+      });
+    }
+  }
+
   // --- leaderboard ---
   const people = new Map();
   const newPerson = (login, avatar, url) => ({ login, avatar, url, issuesAssigned: 0, prsMerged: 0, prsOpened: 0, findingsAuthored: 0, commits: 0, reviewsGiven: 0, score: 0, lastActivity: null, domains: new Set() });
@@ -379,6 +399,7 @@ async function main() {
     comments: recentComments,
     activeActors,
     adrs,
+    streamDocs,
   };
 
   mkdirSync(OUT_DIR, { recursive: true });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from "@/components/layout/AppLayout";
 import Dashboard from "@/pages/Dashboard";
 import Live from "@/pages/Live";
 import Board from "@/pages/Board";
+import Streams from "@/pages/Streams";
 // Submit page kept on disk but unrouted — on-site submission is disabled for
 // now; /submit redirects to the live feed (see below).
 import IssueDetail from "@/pages/IssueDetail";
@@ -24,6 +25,7 @@ export const router = createBrowserRouter([
       { path: "/", element: <Dashboard /> },
       { path: "/live", element: <Live /> },
       { path: "/board", element: <Board /> },
+      { path: "/streams", element: <Streams /> },
       { path: "/issue/:number", element: <IssueDetail /> },
       { path: "/findings", element: <Findings /> },
       { path: "/findings/*", element: <FindingDetail /> },

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -14,6 +14,7 @@ const LINKS: NavItem[] = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/live", label: "Live" },
   { to: "/board", label: "Board" },
+  { to: "/streams", label: "Streams" },
   { to: "/partners", label: "For partners" },
 ];
 

--- a/web/src/lib/lineage.ts
+++ b/web/src/lib/lineage.ts
@@ -95,6 +95,31 @@ export function chainUpdatedAt(node: ChainNode, seen = new Set<number>()): strin
   return latest;
 }
 
+type Actor = { login: string; avatar: string; url: string };
+
+// Everyone who touched a chain — issue authors + assignees + PR authors — for
+// the "who did what" audit trail. Deduped by login, order of first appearance.
+export function collectActors(node: ChainNode, acc = new Map<string, Actor>(), seen = new Set<number>()): Actor[] {
+  if (!seen.has(node.issue.number)) {
+    seen.add(node.issue.number);
+    const add = (p: Actor | null | undefined) => { if (p && p.login && !acc.has(p.login)) acc.set(p.login, p); };
+    add(node.issue.author);
+    node.issue.assignees.forEach(add);
+    node.prs.forEach((pr) => add(pr.author));
+    node.children.forEach((child) => collectActors(child, acc, seen));
+  }
+  return [...acc.values()];
+}
+
+// Count of MERGED PRs across a chain — a stream's shipped outputs.
+export function chainMergedPrCount(node: ChainNode, seenI = new Set<number>(), seenP = new Set<number>()): number {
+  if (seenI.has(node.issue.number)) return seenP.size;
+  seenI.add(node.issue.number);
+  for (const pr of node.prs) if (pr.merged) seenP.add(pr.number);
+  for (const child of node.children) chainMergedPrCount(child, seenI, seenP);
+  return seenP.size;
+}
+
 export function chainSize(node: ChainNode, seen = new Set<number>()): number {
   if (seen.has(node.issue.number)) return 0;
   seen.add(node.issue.number);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -142,6 +142,18 @@ export interface Snapshot {
   comments: FeedComment[];
   activeActors: ActiveActor[];
   adrs?: Adr[];
+  streamDocs?: StreamDoc[];
+}
+
+export interface StreamDoc {
+  stream: number;
+  title: string;
+  state: string;
+  steward: string;
+  domain: string;
+  updated: string;
+  body: string;
+  url: string;
 }
 
 export interface Adr {

--- a/web/src/pages/Streams.tsx
+++ b/web/src/pages/Streams.tsx
@@ -1,0 +1,108 @@
+import { GitBranch, FileText, Users, GitMerge, ExternalLink, Network } from "lucide-react";
+import { useSnapshot } from "@/hooks/useSnapshot";
+import { Loading, ErrorState } from "@/components/shared/States";
+import { PageHeader } from "@/components/shared/PageHeader";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { Card } from "@/components/ui/card";
+import { Markdown } from "@/components/shared/Markdown";
+import { ChainTree } from "@/components/shared/ChainTree";
+import { PersonAvatar } from "@/components/shared/PersonAvatar";
+import { DomainBadge } from "@/components/shared/Badges";
+import { buildStreamChains, chainSize, chainMergedPrCount, collectActors } from "@/lib/lineage";
+import type { StreamDoc } from "@/lib/types";
+
+const alwaysMatches = () => true;
+
+function statePill(state: string) {
+  const s = state.toLowerCase();
+  const color =
+    s.includes("ship") ? "#0E8A16" :
+    s.includes("build") ? "#C2410C" :
+    s.includes("ideat") ? "#0EA5E9" :
+    s.includes("synth") || s.includes("direction") ? "#8250DF" :
+    s.includes("research") ? "#2E4057" : "#8B5CF6";
+  return { backgroundColor: `${color}1A`, color };
+}
+
+export default function Streams() {
+  const { data, error, loading } = useSnapshot();
+  if (loading) return <Loading />;
+  if (error || !data) return <ErrorState message={error || "No data"} />;
+
+  const groups = buildStreamChains(data.issues);
+  const docByStream = new Map<number, StreamDoc>((data.streamDocs ?? []).map((d) => [d.stream, d]));
+
+  return (
+    <div>
+      <PageHeader title="Streams">
+        Every stream, start to finish. A problem enters as one Discover issue, fans out into researchable questions, and each is answered, reviewed and merged — the full lineage and audit trail of who did what, like a DAG. When a stream drains, a human synthesises it into the plain-language overview shown here.
+      </PageHeader>
+
+      {groups.length === 0 ? (
+        <EmptyState icon={Network} title="No streams yet">Submit a problem to start the first one.</EmptyState>
+      ) : (
+        <div className="space-y-8">
+          {groups.map((group) => {
+            const root = group.roots[0];
+            const doc = docByStream.get(group.stream);
+            const issueCount = group.roots.reduce((t, r) => t + chainSize(r), 0);
+            const mergedCount = group.roots.reduce((t, r) => t + chainMergedPrCount(r), 0);
+            const actors = group.roots.flatMap((r) => collectActors(r))
+              .filter((a, i, arr) => arr.findIndex((x) => x.login === a.login) === i);
+            const title = doc?.title || root?.issue.title.replace(/^\[[^\]]+\]\s*/, "") || `Stream #${group.stream}`;
+            const state = doc?.state || root?.issue.status || "";
+
+            return (
+              <section key={group.stream}>
+                {/* Stream header */}
+                <div className="mb-3 flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-xs text-muted-foreground">Stream #{group.stream}</span>
+                  <h2 className="font-serif text-xl font-bold text-brand-navy dark:text-foreground">{title}</h2>
+                  {state ? (
+                    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium capitalize" style={statePill(state)}>{state}</span>
+                  ) : null}
+                  {root ? <DomainBadge domain={root.issue.domain} /> : null}
+                </div>
+
+                {/* Stats + contributors */}
+                <div className="mb-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-muted-foreground">
+                  <span className="inline-flex items-center gap-1"><GitBranch className="h-3.5 w-3.5" /> {issueCount} issue{issueCount === 1 ? "" : "s"}</span>
+                  <span className="inline-flex items-center gap-1"><GitMerge className="h-3.5 w-3.5" /> {mergedCount} merged</span>
+                  {actors.length > 0 ? (
+                    <span className="inline-flex items-center gap-1.5">
+                      <Users className="h-3.5 w-3.5" />
+                      <span className="flex -space-x-2">
+                        {actors.slice(0, 8).map((a) => <PersonAvatar key={a.login} login={a.login} avatar={a.avatar} size={22} />)}
+                      </span>
+                      {actors.length > 8 ? <span>+{actors.length - 8}</span> : null}
+                    </span>
+                  ) : null}
+                  {doc ? (
+                    <a href={doc.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-brand-cyan-dark hover:underline">Overview source <ExternalLink className="h-3 w-3" /></a>
+                  ) : null}
+                </div>
+
+                {/* The output: plain-language overview (if the stream has been synthesised) */}
+                {doc?.body?.trim() ? (
+                  <Card className="mb-3 border-l-2 border-l-brand-cyan p-5">
+                    <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                      <FileText className="h-3.5 w-3.5" /> Stream overview
+                    </div>
+                    <Markdown>{doc.body}</Markdown>
+                  </Card>
+                ) : (
+                  <p className="mb-3 text-sm text-muted-foreground">No synthesised overview yet — this stream is still being researched. The lineage below is the live audit trail.</p>
+                )}
+
+                {/* The DAG: full lineage fan-out */}
+                <div className="space-y-3">
+                  {group.roots.map((r) => <ChainTree key={r.issue.number} root={r} matches={alwaysMatches} />)}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Per Adam — a dedicated website area for **stream outputs** with the **full lineage from the first step fanning out** ("think a DAG in a data warehouse"), so we can see **who did what** and the full audit trail.

## What it adds (`/streams`, new top-level nav)
Per stream, top to bottom:
1. **Header** — Stream #, plain-language title, lifecycle state, domain.
2. **Stats + contributors** — issue count, merged-output count, and an avatar strip of *everyone who touched the stream* (issue authors + assignees + PR authors, deduped).
3. **The output** — the synthesised plain-language **overview** (surfaced from `streams/*.md`), shown when a stream has passed G1; otherwise a note that it's still researching.
4. **The DAG** — the full fan-out lineage (reuses the existing `ChainTree`): Discover root → research children → their PRs, each node showing stage/status/assignees and linking to the issue/PR. The audit trail.

## Under the hood
- `build-data.mjs` now emits `streamDocs` (parsed from `streams/*.md`) — populates on deploy.
- New lineage helpers `collectActors` + `chainMergedPrCount`; page reuses `buildStreamChains`/`ChainTree`.

## Verified
- `tsc + vite build` clean; `node --check` on build-data.

First two streams (#2 charities, #60 credit) already have overview docs, so they'll render fully; the rest show their live lineage. Easy to iterate on the layout — shout with tweaks.