### PR TITLE
feat(web): two-tier Streams (light index → detail) + provenance sidebar

### DIFF
--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -188,6 +188,7 @@ async function main() {
         author: data.author || "unknown",
         agent: data.agent && data.agent !== "none" ? String(data.agent) : "",
         model: data.model ? String(data.model) : "",
+        issue: Number(String(data.issue ?? "").replace(/[^0-9]/g, "")) || null,
         date: data.date ? String(data.date) : "",
         url: `${repoMeta.html_url}/blob/${repoMeta.default_branch}/${rel}`,
         summary,
@@ -237,6 +238,57 @@ async function main() {
       });
     }
   }
+
+  // --- per-stream summary (light index layer) + provenance rollup ---
+  // Provenance comes from the .md frontmatter (agent = harness, model, author),
+  // plus GitHub actors (issue authors/assignees, PR authors). stream:<n> labels
+  // (applied to issues AND PRs by stream-sync) are the grouping key.
+  const streamLabelOf = (item) => {
+    const l = (item.labels || []).find((x) => /^stream:\d+$/i.test(x));
+    return l ? Number(l.replace(/stream:/i, "")) : null;
+  };
+  const issueStream = new Map();
+  for (const it of issues) { const s = streamLabelOf(it); if (s) issueStream.set(it.number, s); }
+  const streamAgg = new Map();
+  const ensureStream = (s) => {
+    if (!streamAgg.has(s)) streamAgg.set(s, { stream: s, title: "", domain: "", state: "", steward: "", updated: "",
+      issues: 0, openIssues: 0, mergedPRs: 0, findings: 0, agents: {}, models: {}, people: new Map() });
+    return streamAgg.get(s);
+  };
+  const addStreamPerson = (agg, p) => { if (p && p.login && !agg.people.has(p.login)) agg.people.set(p.login, { login: p.login, avatar: p.avatar, url: p.url }); };
+  for (const it of realIssues) {
+    const s = streamLabelOf(it); if (!s) continue;
+    const a = ensureStream(s);
+    a.issues++; if (it.state === "open") a.openIssues++;
+    if (it.updatedAt > a.updated) a.updated = it.updatedAt;
+    if (it.stage === "discover") { if (!a.title) a.title = it.title.replace(/^\[[^\]]+\]\s*/, ""); if (!a.state) a.state = it.status; }
+    if (!a.domain && it.domain) a.domain = it.domain;
+    addStreamPerson(a, it.author); (it.assignees || []).forEach((p) => addStreamPerson(a, p));
+  }
+  for (const p of prs) {
+    const s = streamLabelOf(p); if (!s) continue;
+    const a = ensureStream(s);
+    if (p.merged) a.mergedPRs++;
+    if (p.updatedAt > a.updated) a.updated = p.updatedAt;
+    addStreamPerson(a, p.author);
+  }
+  for (const f of findings) {
+    const s = f.issue ? issueStream.get(f.issue) : null; if (!s) continue;
+    const a = ensureStream(s);
+    a.findings++;
+    const harness = f.agent || "human";
+    a.agents[harness] = (a.agents[harness] || 0) + 1;
+    if (f.model) a.models[f.model] = (a.models[f.model] || 0) + 1;
+    const login = String(f.author || "").replace(/^@/, "");
+    if (login && login !== "unknown" && !a.people.has(login)) a.people.set(login, { login, avatar: `https://github.com/${login}.png`, url: `https://github.com/${login}` });
+  }
+  for (const d of streamDocs) { const a = ensureStream(d.stream); if (d.title) a.title = d.title; if (d.state) a.state = d.state; if (d.steward) a.steward = d.steward; if (!a.domain && d.domain) a.domain = d.domain; }
+  const streamsSummary = [...streamAgg.values()].map((a) => ({
+    stream: a.stream, title: a.title || `Stream #${a.stream}`, domain: a.domain, state: a.state, steward: a.steward, updated: a.updated,
+    issues: a.issues, openIssues: a.openIssues, mergedPRs: a.mergedPRs, findings: a.findings,
+    agents: a.agents, models: a.models, people: [...a.people.values()],
+    hasOverview: streamDocs.some((d) => d.stream === a.stream && (d.body || "").trim().length > 0),
+  })).sort((x, y) => (y.updated || "").localeCompare(x.updated || "") || x.stream - y.stream);
 
   // --- leaderboard ---
   const people = new Map();
@@ -400,10 +452,14 @@ async function main() {
     activeActors,
     adrs,
     streamDocs,
+    streamsSummary,
   };
 
   mkdirSync(OUT_DIR, { recursive: true });
   writeFileSync(path.join(OUT_DIR, "snapshot.json"), JSON.stringify(snapshot, null, 2));
+  // Light, standalone streams index — the overview page can fetch this instead
+  // of the full snapshot as the number of streams grows.
+  writeFileSync(path.join(OUT_DIR, "streams-summary.json"), JSON.stringify({ generatedAt: snapshot.generatedAt, streams: streamsSummary }, null, 2));
   console.log(`Wrote snapshot: ${realIssues.length} issues, ${prs.length} PRs, ${findings.length} findings, ${leaderboard.length} contributors, ${snapshot.stats.sources} sources, ${recentComments.length} recent comments, ${activeActors.length} active actors.`);
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import Dashboard from "@/pages/Dashboard";
 import Live from "@/pages/Live";
 import Board from "@/pages/Board";
 import Streams from "@/pages/Streams";
+import StreamDetail from "@/pages/StreamDetail";
 // Submit page kept on disk but unrouted — on-site submission is disabled for
 // now; /submit redirects to the live feed (see below).
 import IssueDetail from "@/pages/IssueDetail";
@@ -26,6 +27,7 @@ export const router = createBrowserRouter([
       { path: "/live", element: <Live /> },
       { path: "/board", element: <Board /> },
       { path: "/streams", element: <Streams /> },
+      { path: "/streams/:stream", element: <StreamDetail /> },
       { path: "/issue/:number", element: <IssueDetail /> },
       { path: "/findings", element: <Findings /> },
       { path: "/findings/*", element: <FindingDetail /> },

--- a/web/src/lib/streams.ts
+++ b/web/src/lib/streams.ts
@@ -1,0 +1,39 @@
+import type { IssueLite, Finding } from "./types";
+
+// issue number -> stream number, from the stream:<n> label.
+export function issueStreamMap(issues: IssueLite[]): Map<number, number> {
+  const m = new Map<number, number>();
+  for (const it of issues) {
+    const l = it.labels.find((x) => /^stream:\d+$/i.test(x));
+    if (l) m.set(it.number, Number(l.replace(/stream:/i, "")));
+  }
+  return m;
+}
+
+export function findingsForStream(stream: number, findings: Finding[], issues: IssueLite[]): Finding[] {
+  const m = issueStreamMap(issues);
+  return findings.filter((f) => f.issue != null && m.get(f.issue) === stream);
+}
+
+export function streamStateStyle(state: string): { bg: string; color: string } {
+  const s = (state || "").toLowerCase();
+  const color =
+    s.includes("ship") ? "#0E8A16" :
+    s.includes("build") ? "#C2410C" :
+    s.includes("ideat") ? "#0EA5E9" :
+    s.includes("synth") || s.includes("direction") ? "#8250DF" :
+    s.includes("research") ? "#2E4057" :
+    s.includes("fram") || s.includes("discover") ? "#8B5CF6" :
+    "#6B7280";
+  return { bg: `${color}1A`, color };
+}
+
+// The agent frontmatter value → a human harness label.
+export function harnessLabel(agent: string): string {
+  const a = (agent || "").toLowerCase();
+  if (a === "claude") return "Claude Code";
+  if (a === "codex") return "Codex";
+  if (a === "hermes") return "Hermes";
+  if (a === "human" || a === "" || a === "none") return "Human";
+  return agent;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -88,11 +88,29 @@ export interface Finding {
   author: string;
   agent: string;
   model: string;
+  issue: number | null;
   date: string;
   url: string;
   summary: string;
   body: string;
   sources: FindingSource[];
+}
+
+export interface StreamSummary {
+  stream: number;
+  title: string;
+  domain: string;
+  state: string;
+  steward: string;
+  updated: string;
+  issues: number;
+  openIssues: number;
+  mergedPRs: number;
+  findings: number;
+  agents: Record<string, number>;
+  models: Record<string, number>;
+  people: Person[];
+  hasOverview: boolean;
 }
 
 export interface SourceRef {
@@ -143,6 +161,7 @@ export interface Snapshot {
   activeActors: ActiveActor[];
   adrs?: Adr[];
   streamDocs?: StreamDoc[];
+  streamsSummary?: StreamSummary[];
 }
 
 export interface StreamDoc {

--- a/web/src/pages/StreamDetail.tsx
+++ b/web/src/pages/StreamDetail.tsx
@@ -1,0 +1,157 @@
+import { useMemo } from "react";
+import { Link, useParams } from "react-router-dom";
+import { ArrowLeft, FileText, Network, Users, Cpu, Wrench, ScrollText, ExternalLink } from "lucide-react";
+import { useSnapshot } from "@/hooks/useSnapshot";
+import { Loading, ErrorState } from "@/components/shared/States";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { Card } from "@/components/ui/card";
+import { Markdown } from "@/components/shared/Markdown";
+import { ChainTree } from "@/components/shared/ChainTree";
+import { PersonAvatar } from "@/components/shared/PersonAvatar";
+import { DomainBadge } from "@/components/shared/Badges";
+import { buildStreamChains } from "@/lib/lineage";
+import { findingsForStream, streamStateStyle, harnessLabel } from "@/lib/streams";
+
+const alwaysMatches = () => true;
+
+function Chips({ counts, tint }: { counts: Record<string, number>; tint?: boolean }) {
+  const entries = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  if (entries.length === 0) return <p className="text-xs text-muted-foreground">None recorded yet.</p>;
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {entries.map(([k, n]) => (
+        <span key={k} className={tint ? "inline-flex items-center gap-1 rounded-full bg-brand-indigo/10 px-2 py-0.5 text-[11px] font-medium text-brand-indigo" : "inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-foreground/80"}>
+          {k}{n > 1 ? <span className="opacity-60">×{n}</span> : null}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function StreamDetail() {
+  const { stream } = useParams();
+  const streamNum = Number(stream);
+  const { data, error, loading } = useSnapshot();
+
+  const group = useMemo(() => (data ? buildStreamChains(data.issues).find((g) => g.stream === streamNum) : undefined), [data, streamNum]);
+
+  if (loading) return <Loading />;
+  if (error || !data) return <ErrorState message={error || "No data"} />;
+
+  const summary = data.streamsSummary?.find((s) => s.stream === streamNum);
+  const doc = data.streamDocs?.find((d) => d.stream === streamNum);
+  const findings = findingsForStream(streamNum, data.findings, data.issues);
+
+  if (!summary && !group && !doc) {
+    return (
+      <div>
+        <Link to="/streams" className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"><ArrowLeft className="h-4 w-4" /> All streams</Link>
+        <EmptyState icon={Network} title={`Stream #${streamNum} not found`}>It may not exist yet, or the data hasn't rebuilt. Head back to all streams.</EmptyState>
+      </div>
+    );
+  }
+
+  const title = doc?.title || summary?.title || group?.roots[0]?.issue.title.replace(/^\[[^\]]+\]\s*/, "") || `Stream #${streamNum}`;
+  const state = doc?.state || summary?.state || "";
+  const domain = summary?.domain || doc?.domain || group?.roots[0]?.issue.domain || null;
+  const people = summary?.people ?? [];
+  const steward = doc?.steward?.replace(/^@/, "") || summary?.steward?.replace(/^@/, "") || "";
+
+  return (
+    <div>
+      <Link to="/streams" className="mb-3 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"><ArrowLeft className="h-4 w-4" /> All streams</Link>
+
+      <div className="mb-6 flex flex-wrap items-center gap-2">
+        <span className="font-mono text-xs text-muted-foreground">Stream #{streamNum}</span>
+        <h1 className="font-serif text-2xl font-bold text-brand-navy dark:text-foreground md:text-3xl">{title}</h1>
+        {state ? <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize" style={{ backgroundColor: streamStateStyle(state).bg, color: streamStateStyle(state).color }}>{state}</span> : null}
+        <DomainBadge domain={domain} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Main: overview + DAG */}
+        <div className="space-y-6 lg:col-span-2">
+          {doc?.body?.trim() ? (
+            <Card className="border-l-2 border-l-brand-cyan p-6">
+              <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground"><FileText className="h-3.5 w-3.5" /> Stream overview</div>
+              <Markdown>{doc.body}</Markdown>
+              {doc.url ? <a href={doc.url} target="_blank" rel="noreferrer" className="mt-3 inline-flex items-center gap-1 text-xs text-brand-cyan-dark hover:underline">Overview source <ExternalLink className="h-3 w-3" /></a> : null}
+            </Card>
+          ) : (
+            <Card className="p-6 text-sm text-muted-foreground">No synthesised overview yet — this stream is still being researched. The lineage below is the live audit trail.</Card>
+          )}
+
+          <div>
+            <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground"><Network className="h-3.5 w-3.5" /> Lineage</div>
+            {group ? (
+              <div className="space-y-3">{group.roots.map((r) => <ChainTree key={r.issue.number} root={r} matches={alwaysMatches} />)}</div>
+            ) : <p className="text-sm text-muted-foreground">No linked issues found for this stream.</p>}
+          </div>
+        </div>
+
+        {/* Sidebar: provenance (sticky) */}
+        <aside className="lg:sticky lg:top-20 lg:self-start">
+          <Card className="p-5">
+            <div className="mb-3 font-serif text-base font-semibold">Provenance</div>
+
+            <div className="grid grid-cols-3 gap-2 border-b border-border pb-3 text-center">
+              <div><div className="text-lg font-bold tabular-nums">{summary?.issues ?? 0}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">issues</div></div>
+              <div><div className="text-lg font-bold tabular-nums">{summary?.mergedPRs ?? 0}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">merged</div></div>
+              <div><div className="text-lg font-bold tabular-nums">{summary?.findings ?? findings.length}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">findings</div></div>
+            </div>
+
+            {steward ? (
+              <div className="mt-3">
+                <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Steward</div>
+                <a href={`https://github.com/${steward}`} target="_blank" rel="noreferrer" className="inline-flex items-center gap-2 text-sm hover:text-brand-cyan-dark">
+                  <PersonAvatar login={steward} avatar={`https://github.com/${steward}.png`} size={22} /> @{steward}
+                </a>
+              </div>
+            ) : null}
+
+            <div className="mt-4">
+              <div className="mb-1.5 flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"><Wrench className="h-3 w-3" /> Harness</div>
+              <Chips counts={Object.fromEntries(Object.entries(summary?.agents ?? {}).map(([k, v]) => [harnessLabel(k), v]))} />
+            </div>
+
+            <div className="mt-4">
+              <div className="mb-1.5 flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"><Cpu className="h-3 w-3" /> Models</div>
+              <Chips counts={summary?.models ?? {}} tint />
+            </div>
+
+            <div className="mt-4">
+              <div className="mb-1.5 flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"><Users className="h-3 w-3" /> Contributors ({people.length})</div>
+              <div className="space-y-1.5">
+                {people.length === 0 ? <p className="text-xs text-muted-foreground">None yet.</p> : people.map((p) => (
+                  <a key={p.login} href={p.url} target="_blank" rel="noreferrer" className="flex items-center gap-2 text-sm hover:text-brand-cyan-dark">
+                    <PersonAvatar login={p.login} avatar={p.avatar} size={20} /> @{p.login}
+                  </a>
+                ))}
+              </div>
+            </div>
+          </Card>
+
+          {/* Per-finding provenance */}
+          {findings.length > 0 ? (
+            <Card className="mt-4 p-5">
+              <div className="mb-3 flex items-center gap-1 font-serif text-base font-semibold"><ScrollText className="h-4 w-4" /> Findings</div>
+              <div className="space-y-3">
+                {findings.map((f) => (
+                  <div key={f.path} className="border-b border-border/50 pb-3 last:border-0 last:pb-0">
+                    <a href={f.url} target="_blank" rel="noreferrer" className="text-sm font-medium hover:text-brand-cyan-dark">{f.title}</a>
+                    <div className="mt-1 flex flex-wrap items-center gap-1 text-[11px]">
+                      <span className="rounded-full bg-secondary px-2 py-0.5 text-muted-foreground">{harnessLabel(f.agent)}</span>
+                      {f.model ? <span className="rounded-full bg-brand-indigo/10 px-2 py-0.5 text-brand-indigo">{f.model}</span> : null}
+                      {f.author && f.author !== "unknown" ? <span className="text-muted-foreground">· @{f.author.replace(/^@/, "")}</span> : null}
+                      {f.confidence ? <span className="text-muted-foreground">· {f.confidence}</span> : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Card>
+          ) : null}
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Streams.tsx
+++ b/web/src/pages/Streams.tsx
@@ -1,107 +1,114 @@
-import { GitBranch, FileText, Users, GitMerge, ExternalLink, Network } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { GitBranch, GitMerge, FileText, Network, Search, Cpu, ArrowRight } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { Card } from "@/components/ui/card";
-import { Markdown } from "@/components/shared/Markdown";
-import { ChainTree } from "@/components/shared/ChainTree";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { PersonAvatar } from "@/components/shared/PersonAvatar";
 import { DomainBadge } from "@/components/shared/Badges";
-import { buildStreamChains, chainSize, chainMergedPrCount, collectActors } from "@/lib/lineage";
-import type { StreamDoc } from "@/lib/types";
+import { streamStateStyle, harnessLabel } from "@/lib/streams";
+import { relativeTime } from "@/lib/format";
+import type { StreamSummary } from "@/lib/types";
 
-const alwaysMatches = () => true;
+function StatePill({ state }: { state: string }) {
+  if (!state) return null;
+  return <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium capitalize" style={{ backgroundColor: streamStateStyle(state).bg, color: streamStateStyle(state).color }}>{state}</span>;
+}
 
-function statePill(state: string) {
-  const s = state.toLowerCase();
-  const color =
-    s.includes("ship") ? "#0E8A16" :
-    s.includes("build") ? "#C2410C" :
-    s.includes("ideat") ? "#0EA5E9" :
-    s.includes("synth") || s.includes("direction") ? "#8250DF" :
-    s.includes("research") ? "#2E4057" : "#8B5CF6";
-  return { backgroundColor: `${color}1A`, color };
+function StreamCard({ s }: { s: StreamSummary }) {
+  const harnesses = Object.keys(s.agents || {});
+  const models = Object.keys(s.models || {});
+  return (
+    <Link to={`/streams/${s.stream}`}>
+      <Card className="group flex h-full flex-col p-5 transition-all hover:-translate-y-0.5 hover:shadow-md">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-xs text-muted-foreground">#{s.stream}</span>
+          <StatePill state={s.state} />
+          <DomainBadge domain={s.domain || null} />
+          {s.hasOverview ? <FileText className="ml-auto h-3.5 w-3.5 text-brand-cyan-dark" aria-label="Has overview" /> : null}
+        </div>
+        <div className="mt-2 line-clamp-2 font-serif text-base font-semibold leading-snug group-hover:text-brand-cyan-dark">{s.title}</div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1"><GitBranch className="h-3.5 w-3.5" /> {s.issues}</span>
+          <span className="inline-flex items-center gap-1"><GitMerge className="h-3.5 w-3.5" /> {s.mergedPRs}</span>
+          <span className="inline-flex items-center gap-1"><FileText className="h-3.5 w-3.5" /> {s.findings}</span>
+        </div>
+
+        {(harnesses.length > 0 || models.length > 0) ? (
+          <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            {harnesses.map((h) => <span key={h} className="rounded-full bg-secondary px-2 py-0.5 text-[10px] font-medium text-muted-foreground">{harnessLabel(h)}</span>)}
+            {models.length > 0 ? <span className="inline-flex items-center gap-1 rounded-full bg-brand-indigo/10 px-2 py-0.5 text-[10px] font-medium text-brand-indigo"><Cpu className="h-3 w-3" />{models.length} model{models.length === 1 ? "" : "s"}</span> : null}
+          </div>
+        ) : null}
+
+        <div className="mt-auto flex items-center justify-between gap-2 pt-4">
+          {s.people.length > 0 ? (
+            <div className="flex -space-x-2">
+              {s.people.slice(0, 5).map((p) => <PersonAvatar key={p.login} login={p.login} avatar={p.avatar} size={22} />)}
+              {s.people.length > 5 ? <span className="flex h-[22px] items-center pl-3 text-[11px] text-muted-foreground">+{s.people.length - 5}</span> : null}
+            </div>
+          ) : <span className="text-[11px] text-muted-foreground">No contributors yet</span>}
+          <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">{s.updated ? relativeTime(s.updated) : ""} <ArrowRight className="h-3 w-3 opacity-0 transition-opacity group-hover:opacity-100" /></span>
+        </div>
+      </Card>
+    </Link>
+  );
 }
 
 export default function Streams() {
   const { data, error, loading } = useSnapshot();
+  const [q, setQ] = useState("");
+  const [state, setState] = useState("all");
+  const streams = useMemo(() => data?.streamsSummary ?? [], [data]);
+  const states = useMemo(() => [...new Set(streams.map((s) => s.state).filter(Boolean))], [streams]);
+
   if (loading) return <Loading />;
   if (error || !data) return <ErrorState message={error || "No data"} />;
 
-  const groups = buildStreamChains(data.issues);
-  const docByStream = new Map<number, StreamDoc>((data.streamDocs ?? []).map((d) => [d.stream, d]));
+  const filtered = streams.filter((s) => {
+    if (state !== "all" && s.state !== state) return false;
+    if (q && !s.title.toLowerCase().includes(q.toLowerCase()) && !String(s.stream).includes(q)) return false;
+    return true;
+  });
 
   return (
     <div>
       <PageHeader title="Streams">
-        Every stream, start to finish. A problem enters as one Discover issue, fans out into researchable questions, and each is answered, reviewed and merged — the full lineage and audit trail of who did what, like a DAG. When a stream drains, a human synthesises it into the plain-language overview shown here.
+        Every problem we're working, start to finish. Each stream begins as one Discover issue and fans out into researched, reviewed, merged work. Open one to see its overview, full lineage DAG, and the models, harnesses and people behind it.
       </PageHeader>
 
-      {groups.length === 0 ? (
+      {streams.length === 0 ? (
         <EmptyState icon={Network} title="No streams yet">Submit a problem to start the first one.</EmptyState>
       ) : (
-        <div className="space-y-8">
-          {groups.map((group) => {
-            const root = group.roots[0];
-            const doc = docByStream.get(group.stream);
-            const issueCount = group.roots.reduce((t, r) => t + chainSize(r), 0);
-            const mergedCount = group.roots.reduce((t, r) => t + chainMergedPrCount(r), 0);
-            const actors = group.roots.flatMap((r) => collectActors(r))
-              .filter((a, i, arr) => arr.findIndex((x) => x.login === a.login) === i);
-            const title = doc?.title || root?.issue.title.replace(/^\[[^\]]+\]\s*/, "") || `Stream #${group.stream}`;
-            const state = doc?.state || root?.issue.status || "";
+        <>
+          <div className="mb-6 flex flex-wrap items-center gap-2">
+            <div className="relative min-w-[180px] flex-1">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input placeholder="Search streams…" value={q} onChange={(e) => setQ(e.target.value)} className="pl-9" />
+            </div>
+            <Select value={state} onValueChange={setState}>
+              <SelectTrigger className="w-[180px]"><SelectValue placeholder="State" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All states</SelectItem>
+                {states.map((s) => <SelectItem key={s} value={s} className="capitalize">{s}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            <span className="text-xs text-muted-foreground">{filtered.length} stream{filtered.length === 1 ? "" : "s"}</span>
+          </div>
 
-            return (
-              <section key={group.stream}>
-                {/* Stream header */}
-                <div className="mb-3 flex flex-wrap items-center gap-2">
-                  <span className="font-mono text-xs text-muted-foreground">Stream #{group.stream}</span>
-                  <h2 className="font-serif text-xl font-bold text-brand-navy dark:text-foreground">{title}</h2>
-                  {state ? (
-                    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium capitalize" style={statePill(state)}>{state}</span>
-                  ) : null}
-                  {root ? <DomainBadge domain={root.issue.domain} /> : null}
-                </div>
-
-                {/* Stats + contributors */}
-                <div className="mb-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-muted-foreground">
-                  <span className="inline-flex items-center gap-1"><GitBranch className="h-3.5 w-3.5" /> {issueCount} issue{issueCount === 1 ? "" : "s"}</span>
-                  <span className="inline-flex items-center gap-1"><GitMerge className="h-3.5 w-3.5" /> {mergedCount} merged</span>
-                  {actors.length > 0 ? (
-                    <span className="inline-flex items-center gap-1.5">
-                      <Users className="h-3.5 w-3.5" />
-                      <span className="flex -space-x-2">
-                        {actors.slice(0, 8).map((a) => <PersonAvatar key={a.login} login={a.login} avatar={a.avatar} size={22} />)}
-                      </span>
-                      {actors.length > 8 ? <span>+{actors.length - 8}</span> : null}
-                    </span>
-                  ) : null}
-                  {doc ? (
-                    <a href={doc.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-brand-cyan-dark hover:underline">Overview source <ExternalLink className="h-3 w-3" /></a>
-                  ) : null}
-                </div>
-
-                {/* The output: plain-language overview (if the stream has been synthesised) */}
-                {doc?.body?.trim() ? (
-                  <Card className="mb-3 border-l-2 border-l-brand-cyan p-5">
-                    <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                      <FileText className="h-3.5 w-3.5" /> Stream overview
-                    </div>
-                    <Markdown>{doc.body}</Markdown>
-                  </Card>
-                ) : (
-                  <p className="mb-3 text-sm text-muted-foreground">No synthesised overview yet — this stream is still being researched. The lineage below is the live audit trail.</p>
-                )}
-
-                {/* The DAG: full lineage fan-out */}
-                <div className="space-y-3">
-                  {group.roots.map((r) => <ChainTree key={r.issue.number} root={r} matches={alwaysMatches} />)}
-                </div>
-              </section>
-            );
-          })}
-        </div>
+          {filtered.length === 0 ? (
+            <EmptyState icon={Network} title="Nothing matches">Clear the filter to see all streams.</EmptyState>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {filtered.map((s) => <StreamCard key={s.stream} s={s} />)}
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
Per Adam — the Streams page was heavy and won't scale; split it into a light **overview index → click into detail**, and add a proper **provenance** read (models / harness / users).

Your calls, applied: **(1)** provenance from the `.md` frontmatter (`agent`=harness, `model`, `author`); **(2)** both — in-snapshot `streamsSummary` *and* a standalone `streams-summary.json`; **(3)** per-issue **and** per-finding; **(4)** sidebar.

## Tier 1 — `/streams` (light)
Card grid with **search + state filter**, scales to 50+ streams. Each card: #, title, state pill, domain, counts (issues / merged / findings), **harness + model chips**, contributor avatars, last-updated. No DAG on the index → cheap to render.

## Tier 2 — `/streams/:stream` (detail)
- **Main column:** synthesised **overview** + the **full lineage DAG** (reused `ChainTree`).
- **Sticky Provenance sidebar:** counts, **steward**, **harnesses** (Claude Code / Codex / Hermes / Human ×count), **models** (×count), **contributors** list — and a **per-finding** provenance list (harness / model / author / confidence).

## Data
- `build-data.mjs` precomputes `streamsSummary` (light) + emits `streams-summary.json`; findings now carry `issue` so they map to their stream via the `stream:<n>` labels.

`tsc + vite build` clean; `node --check` on build-data. Populates on the next deploy.

Merging per Adam.