### PR TITLE
perf(start_work): 3-min poll + one GraphQL query for the queue check

### DIFF
--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -92,10 +92,15 @@ issue_field()   { gh issue view "$1" --repo "$REPO" --json "$2" --jq ".$2"; }
 # shape `gh issue list --json number,createdAt,labels,assignees` returns so the
 # jq filters below are unchanged. A single poll cycle can fetch this once and
 # feed EVERY queue check (available / my rework / unassigned rework) from it,
-# instead of firing a separate REST list call per status. Capped at 100 to
-# match the previous --limit 100 behaviour.
+# instead of firing a separate REST list call per status. Capped at 100 (the
+# GraphQL page max) to match the previous --limit 100 behaviour; ordered NEWEST
+# first so that if the repo ever exceeds 100 open issues the truncation drops
+# the oldest, not the freshly-created available/rework work we most want to see.
+# (The jq filters re-sort deterministically, so fetch order doesn't affect the
+# result while the queue is under 100 — it only decides which slice survives the
+# cap.) labels(first:50) is ample headroom over the ~5 labels an issue carries.
 fetch_open_issues() {
-  gh api graphql -f query="{repository(owner:\"$OWNER\",name:\"$NAME\"){issues(states:OPEN,first:100,orderBy:{field:CREATED_AT,direction:ASC}){nodes{number createdAt labels(first:20){nodes{name}} assignees(first:10){nodes{login}}}}}}" \
+  gh api graphql -f query="{repository(owner:\"$OWNER\",name:\"$NAME\"){issues(states:OPEN,first:100,orderBy:{field:CREATED_AT,direction:DESC}){nodes{number createdAt labels(first:50){nodes{name}} assignees(first:10){nodes{login}}}}}}" \
     --jq '[.data.repository.issues.nodes[] | {number, createdAt, labels: [.labels.nodes[] | {name}], assignees: [.assignees.nodes[] | {login}]}]'
 }
 

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -88,32 +88,51 @@ remove_worktree() {
 issue_labels()  { gh issue view "$1" --repo "$REPO" --json labels --jq '[.labels[].name]|join(",")'; }
 issue_field()   { gh issue view "$1" --repo "$REPO" --json "$2" --jq ".$2"; }
 
+# ONE GraphQL query for the whole open-issue queue, normalised to the same
+# shape `gh issue list --json number,createdAt,labels,assignees` returns so the
+# jq filters below are unchanged. A single poll cycle can fetch this once and
+# feed EVERY queue check (available / my rework / unassigned rework) from it,
+# instead of firing a separate REST list call per status. Capped at 100 to
+# match the previous --limit 100 behaviour.
+fetch_open_issues() {
+  gh api graphql -f query="{repository(owner:\"$OWNER\",name:\"$NAME\"){issues(states:OPEN,first:100,orderBy:{field:CREATED_AT,direction:ASC}){nodes{number createdAt labels(first:20){nodes{name}} assignees(first:10){nodes{login}}}}}}" \
+    --jq '[.data.repository.issues.nodes[] | {number, createdAt, labels: [.labels.nodes[] | {name}], assignees: [.assignees.nodes[] | {login}]}]'
+}
+
 # Numbers of open issues with a given status label, optional STAGE filter.
 # Order: issues labelled "priority: high" first, then oldest-created first.
 # This is the whole priority system — label an issue "priority: high" to have
 # the workers pick it up before the rest of the queue.
-issues_with_status() {  # $1 = bare status (e.g. available), $2.. extra gh flags
-  local status="$1"; shift
-  gh issue list --repo "$REPO" --state open --label "status: $status" "$@" \
-    --json number,createdAt,labels --limit 100 \
-    --jq "[.[] $( [ -n "${STAGE:-}" ] && printf '| select(.labels|map(.name)|index("stage: %s"))' "$STAGE" )] | sort_by((.labels|map(.name)|index(\"priority: high\")|not), .createdAt) | .[].number"
+# $2 = optional queue snapshot (from fetch_open_issues). Pass one to check
+# several statuses from a SINGLE GraphQL query; omit it and one is fetched.
+issues_with_status() {  # $1 = bare status (e.g. available); $2 = optional snapshot JSON
+  local status="$1" snap="${2:-}"
+  [ -n "$snap" ] || snap="$(fetch_open_issues)"
+  printf '%s' "$snap" | jq -r "[.[] | select(.labels|map(.name)|index(\"status: $status\"))$( [ -n "${STAGE:-}" ] && printf ' | select(.labels|map(.name)|index("stage: %s"))' "$STAGE" )] | sort_by((.labels|map(.name)|index(\"priority: high\")|not), .createdAt) | .[].number"
 }
 
-available_issues() { issues_with_status "available"; }
+available_issues() { issues_with_status "available" "${1:-}"; }
 
 # Issues a reviewer sent back that are assigned to *me* — my rework queue.
-rework_issues() { issues_with_status "changes-requested" --assignee "@me"; }
+# $1 = optional queue snapshot (from fetch_open_issues).
+rework_issues() {  # $1 = optional snapshot JSON
+  local snap="${1:-}"
+  [ -n "$snap" ] || snap="$(fetch_open_issues)"
+  printf '%s' "$snap" | jq -r --arg me "$ME" "[.[] | select(.labels|map(.name)|index(\"status: changes-requested\")) | select(.assignees|map(.login)|index(\$me))$( [ -n "${STAGE:-}" ] && printf ' | select(.labels|map(.name)|index("stage: %s"))' "$STAGE" )] | sort_by((.labels|map(.name)|index(\"priority: high\")|not), .createdAt) | .[].number"
+}
 
 # Reworks with NO assignee — freed by reap.sh after REWORK_TTL, so any worker
 # may take them (oldest first). The author's own reworks stay theirs (above).
-unassigned_reworks() {
-  gh issue list --repo "$REPO" --state open --label "status: changes-requested" \
-    --json number,assignees,createdAt --limit 100 \
-    --jq '[.[] | select((.assignees|length)==0)] | sort_by(.createdAt) | .[].number'
+# $1 = optional queue snapshot (from fetch_open_issues).
+unassigned_reworks() {  # $1 = optional snapshot JSON
+  local snap="${1:-}"
+  [ -n "$snap" ] || snap="$(fetch_open_issues)"
+  printf '%s' "$snap" | jq -r '[.[] | select(.labels|map(.name)|index("status: changes-requested")) | select((.assignees|length)==0)] | sort_by(.createdAt) | .[].number'
 }
 
 # Drained stream roots waiting for a G1 synthesis draft.
-synthesis_issues() { issues_with_status "needs-synthesis"; }
+# $1 = optional queue snapshot (from fetch_open_issues).
+synthesis_issues() { issues_with_status "needs-synthesis" "${1:-}"; }
 
 # First value of a "<prefix>..." entry in a comma-joined label list.
 label_field() {  # $1 = labels csv, $2 = prefix (e.g. "stage: ", "stream:")

--- a/start_work.sh
+++ b/start_work.sh
@@ -21,7 +21,7 @@
 #   MAX=1 ./start_work.sh           # do a single issue and stop
 #   DRY_RUN=1 ./start_work.sh       # show what it would do, touch nothing
 #   POLL_SECONDS=0 ./start_work.sh  # exit instead of polling when queue empty
-#                                    # (default: poll every 60s and never exit)
+#                                    # (default: poll every 3 min and never exit)
 #
 # Args: [claude|codex|hermes] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
 # Env:  AGENT MODEL MAX STAGE POLL_SECONDS DRY_RUN AGENT_TIMEOUT
@@ -33,7 +33,7 @@ RUNS_AGENT=1
 parse_agent_args "$@"
 
 MAX="${MAX:-0}"                       # 0 = no limit
-POLL_SECONDS="${POLL_SECONDS:-60}"    # keep polling when queue empty (0 to exit instead)
+POLL_SECONDS="${POLL_SECONDS:-180}"   # keep polling when queue empty every 3 min (0 to exit instead)
 DRY_RUN="${DRY_RUN:-0}"
 CLAIMED_ISSUE=""
 
@@ -322,9 +322,9 @@ reconcile_rework() {
 # Take the first UNASSIGNED (TTL-freed) rework whose PR lives on origin — i.e.
 # a branch we can actually push the rework to. Fork-branch PRs are skipped (only
 # their owner can push). Claims it to @me and echoes its number, else nothing.
-take_unassigned_rework() {
+take_unassigned_rework() {  # $1 = optional queue snapshot (from fetch_open_issues)
   local n pr owner
-  for n in $(unassigned_reworks); do
+  for n in $(unassigned_reworks "${1:-}"); do
     pr="$(pr_for_issue "$n" || true)"; [ -z "$pr" ] && continue
     owner="$(gh pr view "$pr" --repo "$REPO" --json headRepositoryOwner --jq .headRepositoryOwner.login 2>/dev/null || true)"
     [ "$owner" = "$OWNER" ] || continue
@@ -342,14 +342,18 @@ main() {
   local done=0
   while :; do
     reconcile_rework   # pull in any PRs a reviewer sent back that the hand-off missed
+    # ONE GraphQL query snapshots the whole open-issue queue; every check below
+    # (my rework → TTL-freed rework → fresh issue) filters it locally instead of
+    # firing its own REST list call.
+    local snap; snap="$(fetch_open_issues)"
     # Priority: my own rework → a TTL-freed rework I can push → a fresh issue.
     local next kind=new
-    next="$(rework_issues | head -1 || true)"
+    next="$(rework_issues "$snap" | head -1 || true)"
     if [ -n "$next" ]; then
       kind=rework
     else
-      next="$(take_unassigned_rework || true)"
-      if [ -n "$next" ]; then kind=rework; else next="$(available_issues | head -1 || true)"; fi
+      next="$(take_unassigned_rework "$snap" || true)"
+      if [ -n "$next" ]; then kind=rework; else next="$(available_issues "$snap" | head -1 || true)"; fi
     fi
     if [ -z "$next" ]; then
       if [ "$POLL_SECONDS" -gt 0 ] && [ "$DRY_RUN" = 0 ]; then

--- a/start_work.sh
+++ b/start_work.sh
@@ -344,8 +344,11 @@ main() {
     reconcile_rework   # pull in any PRs a reviewer sent back that the hand-off missed
     # ONE GraphQL query snapshots the whole open-issue queue; every check below
     # (my rework → TTL-freed rework → fresh issue) filters it locally instead of
-    # firing its own REST list call.
-    local snap; snap="$(fetch_open_issues)"
+    # firing its own REST list call. A transient failure (rate-limit, 502,
+    # network blip) yields an empty snapshot so this cycle just looks empty and
+    # we sleep and retry — exactly what the old per-call `|| true` reads did,
+    # rather than letting set -e kill the whole runner.
+    local snap; snap="$(fetch_open_issues)" || snap='[]'
     # Priority: my own rework → a TTL-freed rework I can push → a fresh issue.
     local next kind=new
     next="$(rework_issues "$snap" | head -1 || true)"


### PR DESCRIPTION
## What this is

Tooling/infra change to the automation runner — no issue linked.

**Stage:** n/a (automation scripts, not a Discover/Research/Ideate/Build contribution)
**Domain:** n/a

## Summary

The `start_work.sh` queue poll ran every 60s and, on every cycle, fired **three separate** `gh issue list` REST calls (my rework, unassigned rework, available) to see what work was around. This makes that check one GraphQL query and slows the idle poll to 3 minutes, cutting a lot of API traffic against a mostly-idle queue.

- New `fetch_open_issues()` in `scripts/fg-common.sh`: **one** GraphQL query returning every open issue, normalised to the same `{number, createdAt, labels, assignees}` shape the old `gh issue list --json` calls returned — so all the existing jq filters are unchanged.
- `issues_with_status` / `available_issues` / `rework_issues` / `unassigned_reworks` / `synthesis_issues` now take an **optional** queue snapshot. The `start_work.sh` main loop fetches it once per cycle and feeds all three checks from it. Called without a snapshot they fetch their own, so `synthesize_work.sh` and any other caller are unaffected.
- `start_work.sh` `POLL_SECONDS` default `60` → `180` (poll every 3 min). Still overridable via the `POLL_SECONDS` env var.

## Method checklist

<!-- This is an automation/tooling change, not a research finding — the research-method items don't apply. -->

- [ ] n/a — no factual claims / citations (tooling change)
- [ ] n/a
- [ ] n/a
- [ ] n/a
- [x] No personal or identifying data; no overstated or fabricated claims
- [x] Files are in the right place (`scripts/fg-common.sh`, `start_work.sh`)

## For the reviewer

Behaviour parity is the thing to check: the new jq filters must produce exactly what the old per-status REST calls did — including **priority-high-first then oldest-created** ordering, the `STAGE` filter, and `rework_issues` matching only issues assigned to `$ME`. I validated all of these against a mock snapshot (priority ordering, STAGE filter, assignee match, and the no-arg auto-fetch fallback all correct). I could **not** run the live GraphQL query here — `gh` isn't on PATH in this environment — but the query mirrors the existing working `gh api graphql` calls in the same file (`pr_for_issue`, `issue_for_pr`). One judgement call worth a look: I capped the query at `first: 100` to match the previous `--limit 100`; a queue larger than 100 open issues would need pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZnX1nfWzT3FCVjE2D9EpA)_