### PR TITLE
feat(web): streams landing groups in-progress vs shipped + journey-ordered detail

### DIFF
--- a/web/src/components/shared/StreamProgress.tsx
+++ b/web/src/components/shared/StreamProgress.tsx
@@ -1,0 +1,58 @@
+import { Fragment } from "react";
+import { Check } from "lucide-react";
+import { STREAM_STAGES, streamStageIndex, streamStateStyle } from "@/lib/streams";
+import { cn } from "@/lib/utils";
+
+// A lifecycle stepper for a stream: Framing → Research → Synthesis → Ideate →
+// Build → Shipped. `compact` renders a thin segmented bar for cards; the full
+// variant renders labelled, connected steps for the detail header.
+export function StreamProgress({ state, compact = false, className }: { state: string; compact?: boolean; className?: string }) {
+  const current = streamStageIndex(state);
+  const accent = streamStateStyle(state).color;
+
+  if (compact) {
+    return (
+      <div className={cn("flex items-center gap-1", className)} aria-label={`Stage ${current + 1} of ${STREAM_STAGES.length}: ${STREAM_STAGES[current]}`}>
+        {STREAM_STAGES.map((_, i) => (
+          <span
+            key={i}
+            className="h-1.5 flex-1 rounded-full"
+            style={{ backgroundColor: i <= current ? accent : undefined }}
+            data-done={i <= current}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex items-center gap-0", className)}>
+      {STREAM_STAGES.map((label, i) => {
+        const done = i < current;
+        const active = i === current;
+        return (
+          <Fragment key={label}>
+            {i > 0 ? <div className="h-px flex-1" style={{ backgroundColor: i <= current ? accent : undefined }} data-done={i <= current} /> : null}
+            <div className="flex flex-col items-center gap-1.5">
+              <span
+                className={cn(
+                  "flex h-6 w-6 items-center justify-center rounded-full border text-[11px] font-semibold tabular-nums",
+                  !done && !active && "border-border bg-background text-muted-foreground",
+                )}
+                style={done || active ? { backgroundColor: active ? accent : `${accent}26`, borderColor: accent, color: active ? "#fff" : accent } : undefined}
+              >
+                {done ? <Check className="h-3.5 w-3.5" /> : i + 1}
+              </span>
+              <span
+                className={cn("whitespace-nowrap text-[10px] font-medium uppercase tracking-wide", active ? "text-foreground" : "text-muted-foreground")}
+                style={active ? { color: accent } : undefined}
+              >
+                {label}
+              </span>
+            </div>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/shared/StreamProgress.tsx
+++ b/web/src/components/shared/StreamProgress.tsx
@@ -16,8 +16,8 @@ export function StreamProgress({ state, compact = false, className }: { state: s
         {STREAM_STAGES.map((_, i) => (
           <span
             key={i}
-            className="h-1.5 flex-1 rounded-full"
-            style={{ backgroundColor: i <= current ? accent : undefined }}
+            className="h-1.5 flex-1 rounded-full bg-border"
+            style={i <= current ? { backgroundColor: accent } : undefined}
             data-done={i <= current}
           />
         ))}
@@ -32,7 +32,7 @@ export function StreamProgress({ state, compact = false, className }: { state: s
         const active = i === current;
         return (
           <Fragment key={label}>
-            {i > 0 ? <div className="h-px flex-1" style={{ backgroundColor: i <= current ? accent : undefined }} data-done={i <= current} /> : null}
+            {i > 0 ? <div className="h-px flex-1 bg-border" style={i <= current ? { backgroundColor: accent } : undefined} data-done={i <= current} /> : null}
             <div className="flex flex-col items-center gap-1.5">
               <span
                 className={cn(

--- a/web/src/lib/streams.ts
+++ b/web/src/lib/streams.ts
@@ -34,14 +34,18 @@ export const STREAM_STAGES = ["Framing", "Research", "Synthesis", "Ideate", "Bui
 export type StreamStage = (typeof STREAM_STAGES)[number];
 
 // Map a stream's free-text `state` onto a stage index (0..5). Unknown → Framing.
+// `state` is the stream doc's lifecycle state when a doc exists (framing →
+// shipped), otherwise the originating Discover issue's status label
+// (available / claimed / needs-synthesis / awaiting-direction / in-review / …,
+// see build-data.mjs) — so this handles both vocabularies.
 export function streamStageIndex(state: string): number {
   const s = (state || "").toLowerCase();
   if (s.includes("ship")) return 5;
   if (s.includes("build")) return 4;
   if (s.includes("ideat")) return 3;
-  if (s.includes("synth") || s.includes("direction")) return 2;
-  if (s.includes("research")) return 1;
-  return 0; // framing / discover / unknown
+  if (s.includes("synth") || s.includes("direction")) return 2; // (needs-)synthesis, awaiting-direction
+  if (s.includes("research") || s.includes("review")) return 1; // researching, in-review, changes-requested
+  return 0; // framing / discover / available / claimed / unknown
 }
 
 // A stream is "finished" only once it has shipped; everything else is in progress.

--- a/web/src/lib/streams.ts
+++ b/web/src/lib/streams.ts
@@ -35,17 +35,19 @@ export type StreamStage = (typeof STREAM_STAGES)[number];
 
 // Map a stream's free-text `state` onto a stage index (0..5). Unknown → Framing.
 // `state` is the stream doc's lifecycle state when a doc exists (framing →
-// shipped), otherwise the originating Discover issue's status label
-// (available / claimed / needs-synthesis / awaiting-direction / in-review / …,
-// see build-data.mjs) — so this handles both vocabularies.
+// shipped), otherwise the originating Discover issue's status label (available /
+// claimed / needs-synthesis / awaiting-direction / in-review / …, see
+// build-data.mjs). Only keywords that mean the same thing in BOTH vocabularies
+// are mapped forward — notably a root status of `in-review` (framing PR under
+// review, per docs/STREAMS.md) is still Framing, so we do NOT match "review".
 export function streamStageIndex(state: string): number {
   const s = (state || "").toLowerCase();
   if (s.includes("ship")) return 5;
   if (s.includes("build")) return 4;
   if (s.includes("ideat")) return 3;
   if (s.includes("synth") || s.includes("direction")) return 2; // (needs-)synthesis, awaiting-direction
-  if (s.includes("research") || s.includes("review")) return 1; // researching, in-review, changes-requested
-  return 0; // framing / discover / available / claimed / unknown
+  if (s.includes("research")) return 1; // researching (doc lifecycle state)
+  return 0; // framing / discover / available / claimed / in-review / unknown
 }
 
 // A stream is "finished" only once it has shipped; everything else is in progress.

--- a/web/src/lib/streams.ts
+++ b/web/src/lib/streams.ts
@@ -28,6 +28,27 @@ export function streamStateStyle(state: string): { bg: string; color: string } {
   return { bg: `${color}1A`, color };
 }
 
+// The ordered lifecycle a stream moves through, framing → shipped. Mirrors the
+// pipeline in docs/STREAMS.md. Used by the progress stepper on cards + detail.
+export const STREAM_STAGES = ["Framing", "Research", "Synthesis", "Ideate", "Build", "Shipped"] as const;
+export type StreamStage = (typeof STREAM_STAGES)[number];
+
+// Map a stream's free-text `state` onto a stage index (0..5). Unknown → Framing.
+export function streamStageIndex(state: string): number {
+  const s = (state || "").toLowerCase();
+  if (s.includes("ship")) return 5;
+  if (s.includes("build")) return 4;
+  if (s.includes("ideat")) return 3;
+  if (s.includes("synth") || s.includes("direction")) return 2;
+  if (s.includes("research")) return 1;
+  return 0; // framing / discover / unknown
+}
+
+// A stream is "finished" only once it has shipped; everything else is in progress.
+export function isStreamShipped(state: string): boolean {
+  return streamStageIndex(state) === 5;
+}
+
 // The agent frontmatter value → a human harness label.
 export function harnessLabel(agent: string): string {
   const a = (agent || "").toLowerCase();

--- a/web/src/pages/StreamDetail.tsx
+++ b/web/src/pages/StreamDetail.tsx
@@ -21,7 +21,7 @@ function excerpt(body: string, max = 320): string {
   const text = (body || "")
     .replace(/```[\s\S]*?```/g, " ")
     .replace(/^#{1,6}\s+/gm, "")
-    .replace(/^\s*(?:part of|stream|closes|fixes|resolves)\s*#\d+.*$/gim, "")
+    .replace(/^\s*(?:part of|stream|closes|fixes|resolves)\s*#\d+\s*$/gim, "")
     .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
     .replace(/[*_>`]/g, "")
     .replace(/\s+/g, " ")
@@ -77,7 +77,15 @@ export default function StreamDetail() {
   }
 
   const roots: ChainNode[] = group?.roots ?? [];
-  const rootIssue = (roots.find((r) => r.issue.stage === "discover") ?? roots[0])?.issue;
+  // The originating issue is the Discover root; a stream's number IS its Discover
+  // issue number. Roots are sorted by recency, so fall back to the root matching
+  // the stream number, then the lowest-numbered root — never "most recent".
+  const rootIssue = (
+    roots.find((r) => r.issue.stage === "discover") ??
+    roots.find((r) => r.issue.number === streamNum) ??
+    [...roots].sort((a, b) => a.issue.number - b.issue.number)[0]
+  )?.issue;
+  const rootExcerpt = rootIssue ? excerpt(rootIssue.body) : "";
   const title = doc?.title || summary?.title || rootIssue?.title.replace(/^\[[^\]]+\]\s*/, "") || `Stream #${streamNum}`;
   const state = doc?.state || summary?.state || "";
   const domain = summary?.domain || doc?.domain || rootIssue?.domain || null;
@@ -112,7 +120,7 @@ export default function StreamDetail() {
                 <Link to={`/issue/${rootIssue.number}`} className="font-serif text-lg font-semibold leading-snug hover:text-brand-cyan-dark">
                   {rootIssue.title.replace(/^\[[^\]]+\]\s*/, "")}
                 </Link>
-                {excerpt(rootIssue.body) ? <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{excerpt(rootIssue.body)}</p> : null}
+                {rootExcerpt ? <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{rootExcerpt}</p> : null}
                 <div className="mt-4 flex flex-wrap items-center gap-4 text-xs">
                   <Link to={`/issue/${rootIssue.number}`} className="inline-flex items-center gap-1 font-medium text-brand-cyan-dark hover:underline">Open the original issue <ArrowRight className="h-3 w-3" /></Link>
                   <a href={rootIssue.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground">#{rootIssue.number} on GitHub <ExternalLink className="h-3 w-3" /></a>

--- a/web/src/pages/StreamDetail.tsx
+++ b/web/src/pages/StreamDetail.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, FileText, Network, Users, Cpu, Wrench, ScrollText, ExternalLink } from "lucide-react";
+import { ArrowLeft, FileText, Network, Users, Cpu, Wrench, ScrollText, ExternalLink, Lightbulb, ArrowRight } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { EmptyState } from "@/components/shared/EmptyState";
@@ -9,10 +9,35 @@ import { Markdown } from "@/components/shared/Markdown";
 import { ChainTree } from "@/components/shared/ChainTree";
 import { PersonAvatar } from "@/components/shared/PersonAvatar";
 import { DomainBadge } from "@/components/shared/Badges";
-import { buildStreamChains } from "@/lib/lineage";
+import { StreamProgress } from "@/components/shared/StreamProgress";
+import { buildStreamChains, type ChainNode } from "@/lib/lineage";
 import { findingsForStream, streamStateStyle, harnessLabel } from "@/lib/streams";
 
 const alwaysMatches = () => true;
+
+// A short plain-language excerpt of an issue body for the "problem" card —
+// drops markdown headings/links/formatting, keeps the first couple of sentences.
+function excerpt(body: string, max = 320): string {
+  const text = (body || "")
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^\s*(?:part of|stream|closes|fixes|resolves)\s*#\d+.*$/gim, "")
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[*_>`]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
+}
+
+function StepHeader({ n, icon: Icon, label }: { n: number; icon: typeof FileText; label: string }) {
+  return (
+    <div className="mb-3 flex items-center gap-2">
+      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-navy text-[11px] font-bold text-white dark:bg-brand-cyan-dark">{n}</span>
+      <Icon className="h-4 w-4 text-muted-foreground" />
+      <h2 className="font-serif text-lg font-semibold">{label}</h2>
+    </div>
+  );
+}
 
 function Chips({ counts, tint }: { counts: Record<string, number>; tint?: boolean }) {
   const entries = Object.entries(counts).sort((a, b) => b[1] - a[1]);
@@ -51,42 +76,97 @@ export default function StreamDetail() {
     );
   }
 
-  const title = doc?.title || summary?.title || group?.roots[0]?.issue.title.replace(/^\[[^\]]+\]\s*/, "") || `Stream #${streamNum}`;
+  const roots: ChainNode[] = group?.roots ?? [];
+  const rootIssue = (roots.find((r) => r.issue.stage === "discover") ?? roots[0])?.issue;
+  const title = doc?.title || summary?.title || rootIssue?.title.replace(/^\[[^\]]+\]\s*/, "") || `Stream #${streamNum}`;
   const state = doc?.state || summary?.state || "";
-  const domain = summary?.domain || doc?.domain || group?.roots[0]?.issue.domain || null;
+  const domain = summary?.domain || doc?.domain || rootIssue?.domain || null;
   const people = summary?.people ?? [];
   const steward = doc?.steward?.replace(/^@/, "") || summary?.steward?.replace(/^@/, "") || "";
+  const hasOverview = !!doc?.body?.trim();
 
   return (
     <div>
       <Link to="/streams" className="mb-3 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"><ArrowLeft className="h-4 w-4" /> All streams</Link>
 
-      <div className="mb-6 flex flex-wrap items-center gap-2">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
         <span className="font-mono text-xs text-muted-foreground">Stream #{streamNum}</span>
         <h1 className="font-serif text-2xl font-bold text-brand-navy dark:text-foreground md:text-3xl">{title}</h1>
         {state ? <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize" style={{ backgroundColor: streamStateStyle(state).bg, color: streamStateStyle(state).color }}>{state}</span> : null}
         <DomainBadge domain={domain} />
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        {/* Main: overview + DAG */}
-        <div className="space-y-6 lg:col-span-2">
-          {doc?.body?.trim() ? (
-            <Card className="border-l-2 border-l-brand-cyan p-6">
-              <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground"><FileText className="h-3.5 w-3.5" /> Stream overview</div>
-              <Markdown>{doc.body}</Markdown>
-              {doc.url ? <a href={doc.url} target="_blank" rel="noreferrer" className="mt-3 inline-flex items-center gap-1 text-xs text-brand-cyan-dark hover:underline">Overview source <ExternalLink className="h-3 w-3" /></a> : null}
-            </Card>
-          ) : (
-            <Card className="p-6 text-sm text-muted-foreground">No synthesised overview yet — this stream is still being researched. The lineage below is the live audit trail.</Card>
-          )}
+      {/* Lifecycle stepper — where this stream is in its journey */}
+      <Card className="mb-6 overflow-x-auto p-5">
+        <StreamProgress state={state} className="min-w-[560px]" />
+      </Card>
 
-          <div>
-            <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground"><Network className="h-3.5 w-3.5" /> Lineage</div>
-            {group ? (
-              <div className="space-y-3">{group.roots.map((r) => <ChainTree key={r.issue.number} root={r} matches={alwaysMatches} />)}</div>
-            ) : <p className="text-sm text-muted-foreground">No linked issues found for this stream.</p>}
-          </div>
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Main: the journey — problem → research → synthesis */}
+        <div className="space-y-8 lg:col-span-2">
+          {/* 1 — the original problem */}
+          <section>
+            <StepHeader n={1} icon={FileText} label="The problem" />
+            {rootIssue ? (
+              <Card className="border-l-2 border-l-brand-cyan p-6">
+                <Link to={`/issue/${rootIssue.number}`} className="font-serif text-lg font-semibold leading-snug hover:text-brand-cyan-dark">
+                  {rootIssue.title.replace(/^\[[^\]]+\]\s*/, "")}
+                </Link>
+                {excerpt(rootIssue.body) ? <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{excerpt(rootIssue.body)}</p> : null}
+                <div className="mt-4 flex flex-wrap items-center gap-4 text-xs">
+                  <Link to={`/issue/${rootIssue.number}`} className="inline-flex items-center gap-1 font-medium text-brand-cyan-dark hover:underline">Open the original issue <ArrowRight className="h-3 w-3" /></Link>
+                  <a href={rootIssue.url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground">#{rootIssue.number} on GitHub <ExternalLink className="h-3 w-3" /></a>
+                </div>
+              </Card>
+            ) : (
+              <Card className="p-6 text-sm text-muted-foreground">The originating Discover issue isn't linked yet.</Card>
+            )}
+          </section>
+
+          {/* 2 — the research */}
+          <section>
+            <StepHeader n={2} icon={ScrollText} label="The research" />
+            {findings.length > 0 ? (
+              <Card className="p-5">
+                <div className="space-y-3">
+                  {findings.map((f) => (
+                    <div key={f.path} className="border-b border-border/50 pb-3 last:border-0 last:pb-0">
+                      <a href={f.url} target="_blank" rel="noreferrer" className="text-sm font-medium hover:text-brand-cyan-dark">{f.title}</a>
+                      {f.summary ? <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{f.summary}</p> : null}
+                      <div className="mt-1.5 flex flex-wrap items-center gap-1 text-[11px]">
+                        <span className="rounded-full bg-secondary px-2 py-0.5 text-muted-foreground">{harnessLabel(f.agent)}</span>
+                        {f.model ? <span className="rounded-full bg-brand-indigo/10 px-2 py-0.5 text-brand-indigo">{f.model}</span> : null}
+                        {f.author && f.author !== "unknown" ? <span className="text-muted-foreground">· @{f.author.replace(/^@/, "")}</span> : null}
+                        {f.confidence ? <span className="text-muted-foreground">· {f.confidence} confidence</span> : null}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            ) : (
+              <Card className="p-6 text-sm text-muted-foreground">No merged findings yet — the research tasks below are still in flight.</Card>
+            )}
+
+            <div className="mt-4">
+              <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-muted-foreground"><Network className="h-3.5 w-3.5" /> Research tasks &amp; full lineage</div>
+              {group ? (
+                <div className="space-y-3">{roots.map((r) => <ChainTree key={r.issue.number} root={r} matches={alwaysMatches} />)}</div>
+              ) : <p className="text-sm text-muted-foreground">No linked issues found for this stream.</p>}
+            </div>
+          </section>
+
+          {/* 3 — the synthesis */}
+          <section>
+            <StepHeader n={3} icon={Lightbulb} label="The synthesised stream" />
+            {hasOverview ? (
+              <Card className="border-l-2 border-l-brand-cyan p-6">
+                <Markdown>{doc?.body ?? ""}</Markdown>
+                {doc?.url ? <a href={doc.url} target="_blank" rel="noreferrer" className="mt-3 inline-flex items-center gap-1 text-xs text-brand-cyan-dark hover:underline">Overview source <ExternalLink className="h-3 w-3" /></a> : null}
+              </Card>
+            ) : (
+              <Card className="p-6 text-sm text-muted-foreground">Not synthesised yet — this stream is still gathering research. Once a human steward reviews the findings above, the plain-language answer lands here.</Card>
+            )}
+          </section>
         </div>
 
         {/* Sidebar: provenance (sticky) */}
@@ -130,26 +210,6 @@ export default function StreamDetail() {
               </div>
             </div>
           </Card>
-
-          {/* Per-finding provenance */}
-          {findings.length > 0 ? (
-            <Card className="mt-4 p-5">
-              <div className="mb-3 flex items-center gap-1 font-serif text-base font-semibold"><ScrollText className="h-4 w-4" /> Findings</div>
-              <div className="space-y-3">
-                {findings.map((f) => (
-                  <div key={f.path} className="border-b border-border/50 pb-3 last:border-0 last:pb-0">
-                    <a href={f.url} target="_blank" rel="noreferrer" className="text-sm font-medium hover:text-brand-cyan-dark">{f.title}</a>
-                    <div className="mt-1 flex flex-wrap items-center gap-1 text-[11px]">
-                      <span className="rounded-full bg-secondary px-2 py-0.5 text-muted-foreground">{harnessLabel(f.agent)}</span>
-                      {f.model ? <span className="rounded-full bg-brand-indigo/10 px-2 py-0.5 text-brand-indigo">{f.model}</span> : null}
-                      {f.author && f.author !== "unknown" ? <span className="text-muted-foreground">· @{f.author.replace(/^@/, "")}</span> : null}
-                      {f.confidence ? <span className="text-muted-foreground">· {f.confidence}</span> : null}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </Card>
-          ) : null}
         </aside>
       </div>
     </div>

--- a/web/src/pages/Streams.tsx
+++ b/web/src/pages/Streams.tsx
@@ -1,18 +1,21 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { GitBranch, GitMerge, FileText, Network, Search, Cpu, ArrowRight } from "lucide-react";
+import { GitBranch, GitMerge, FileText, Network, Search, Cpu, ArrowRight, Loader2, CheckCircle2 } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { PersonAvatar } from "@/components/shared/PersonAvatar";
 import { DomainBadge } from "@/components/shared/Badges";
-import { streamStateStyle, harnessLabel } from "@/lib/streams";
+import { StreamProgress } from "@/components/shared/StreamProgress";
+import { streamStateStyle, harnessLabel, isStreamShipped } from "@/lib/streams";
 import { relativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
 import type { StreamSummary } from "@/lib/types";
+
+type Filter = "all" | "progress" | "shipped";
 
 function StatePill({ state }: { state: string }) {
   if (!state) return null;
@@ -33,10 +36,14 @@ function StreamCard({ s }: { s: StreamSummary }) {
         </div>
         <div className="mt-2 line-clamp-2 font-serif text-base font-semibold leading-snug group-hover:text-brand-cyan-dark">{s.title}</div>
 
+        <div className="mt-3">
+          <StreamProgress state={s.state} compact />
+        </div>
+
         <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
-          <span className="inline-flex items-center gap-1"><GitBranch className="h-3.5 w-3.5" /> {s.issues}</span>
-          <span className="inline-flex items-center gap-1"><GitMerge className="h-3.5 w-3.5" /> {s.mergedPRs}</span>
-          <span className="inline-flex items-center gap-1"><FileText className="h-3.5 w-3.5" /> {s.findings}</span>
+          <span className="inline-flex items-center gap-1" title="Issues (open / total)"><GitBranch className="h-3.5 w-3.5" /> {s.openIssues}/{s.issues}</span>
+          <span className="inline-flex items-center gap-1" title="Merged outputs"><GitMerge className="h-3.5 w-3.5" /> {s.mergedPRs}</span>
+          <span className="inline-flex items-center gap-1" title="Findings"><FileText className="h-3.5 w-3.5" /> {s.findings}</span>
         </div>
 
         {(harnesses.length > 0 || models.length > 0) ? (
@@ -60,52 +67,93 @@ function StreamCard({ s }: { s: StreamSummary }) {
   );
 }
 
+function CardGrid({ streams }: { streams: StreamSummary[] }) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {streams.map((s) => <StreamCard key={s.stream} s={s} />)}
+    </div>
+  );
+}
+
+function SectionHeader({ icon: Icon, label, count, tint }: { icon: typeof Loader2; label: string; count: number; tint: string }) {
+  return (
+    <div className="mb-3 flex items-center gap-2">
+      <Icon className="h-4 w-4" style={{ color: tint }} />
+      <h2 className="font-serif text-lg font-semibold">{label}</h2>
+      <span className="rounded-full px-2 py-0.5 text-xs font-medium tabular-nums" style={{ backgroundColor: `${tint}1A`, color: tint }}>{count}</span>
+    </div>
+  );
+}
+
+function FilterButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+        active ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
 export default function Streams() {
   const { data, error, loading } = useSnapshot();
   const [q, setQ] = useState("");
-  const [state, setState] = useState("all");
+  const [filter, setFilter] = useState<Filter>("all");
   const streams = useMemo(() => data?.streamsSummary ?? [], [data]);
-  const states = useMemo(() => [...new Set(streams.map((s) => s.state).filter(Boolean))], [streams]);
 
   if (loading) return <Loading />;
   if (error || !data) return <ErrorState message={error || "No data"} />;
 
-  const filtered = streams.filter((s) => {
-    if (state !== "all" && s.state !== state) return false;
-    if (q && !s.title.toLowerCase().includes(q.toLowerCase()) && !String(s.stream).includes(q)) return false;
-    return true;
-  });
+  const matchesText = (s: StreamSummary) => !q || s.title.toLowerCase().includes(q.toLowerCase()) || String(s.stream).includes(q);
+  const inProgress = streams.filter((s) => !isStreamShipped(s.state) && matchesText(s));
+  const shipped = streams.filter((s) => isStreamShipped(s.state) && matchesText(s));
+  const showProgress = filter !== "shipped" && inProgress.length > 0;
+  const showShipped = filter !== "progress" && shipped.length > 0;
+  const nothing = !showProgress && !showShipped;
 
   return (
     <div>
       <PageHeader title="Streams">
-        Every problem we're working, start to finish. Each stream begins as one Discover issue and fans out into researched, reviewed, merged work. Open one to see its overview, full lineage DAG, and the models, harnesses and people behind it.
+        Every problem we're working, start to finish. Each stream begins as one Discover issue and fans out into researched, reviewed, merged work. Open one to see the original problem, the research behind it, the synthesised answer, and the models, harnesses and people involved.
       </PageHeader>
 
       {streams.length === 0 ? (
         <EmptyState icon={Network} title="No streams yet">Submit a problem to start the first one.</EmptyState>
       ) : (
         <>
-          <div className="mb-6 flex flex-wrap items-center gap-2">
+          <div className="mb-6 flex flex-wrap items-center gap-3">
             <div className="relative min-w-[180px] flex-1">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input placeholder="Search streams…" value={q} onChange={(e) => setQ(e.target.value)} className="pl-9" />
             </div>
-            <Select value={state} onValueChange={setState}>
-              <SelectTrigger className="w-[180px]"><SelectValue placeholder="State" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All states</SelectItem>
-                {states.map((s) => <SelectItem key={s} value={s} className="capitalize">{s}</SelectItem>)}
-              </SelectContent>
-            </Select>
-            <span className="text-xs text-muted-foreground">{filtered.length} stream{filtered.length === 1 ? "" : "s"}</span>
+            <div className="inline-flex items-center gap-1 rounded-lg bg-secondary p-1">
+              <FilterButton active={filter === "all"} onClick={() => setFilter("all")}>All <span className="tabular-nums opacity-60">{inProgress.length + shipped.length}</span></FilterButton>
+              <FilterButton active={filter === "progress"} onClick={() => setFilter("progress")}><Loader2 className="h-3.5 w-3.5" /> In progress <span className="tabular-nums opacity-60">{inProgress.length}</span></FilterButton>
+              <FilterButton active={filter === "shipped"} onClick={() => setFilter("shipped")}><CheckCircle2 className="h-3.5 w-3.5" /> Shipped <span className="tabular-nums opacity-60">{shipped.length}</span></FilterButton>
+            </div>
           </div>
 
-          {filtered.length === 0 ? (
-            <EmptyState icon={Network} title="Nothing matches">Clear the filter to see all streams.</EmptyState>
+          {nothing ? (
+            <EmptyState icon={Network} title="Nothing matches">Clear the search or filter to see all streams.</EmptyState>
           ) : (
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {filtered.map((s) => <StreamCard key={s.stream} s={s} />)}
+            <div className="space-y-10">
+              {showProgress ? (
+                <section>
+                  <SectionHeader icon={Loader2} label="In progress" count={inProgress.length} tint="#2E4057" />
+                  <CardGrid streams={inProgress} />
+                </section>
+              ) : null}
+              {showShipped ? (
+                <section>
+                  <SectionHeader icon={CheckCircle2} label="Shipped" count={shipped.length} tint="#0E8A16" />
+                  <CardGrid streams={shipped} />
+                </section>
+              ) : null}
             </div>
           )}
         </>


### PR DESCRIPTION
## What this is

Refs #120

**Stage:** 🔨 Build
**Domain:** other (docs/tooling — the site)

## Summary

Iterates on the two-tier Streams area (from #121) so a stream's **state and shape read at a glance**. The `/streams` landing now splits streams into **In progress** vs **Shipped** sections with a segmented filter, and each card shows a compact lifecycle progress bar. The `/streams/:stream` detail is reordered into the actual journey a stream travels — **the original problem → the research → the synthesised answer** — beneath a lifecycle stepper.

## What changed

**Landing (`Streams.tsx`)**
- Streams are grouped into **In progress** and **Shipped** sections (only shipped counts as finished), with an `All / In progress / Shipped` segmented filter carrying live counts — so unfinished vs finished work is obvious without reading each state pill.
- Each `StreamCard` gains a compact `StreamProgress` bar and now shows issues as `open/total`.

**Detail (`StreamDetail.tsx`)**
- New **lifecycle stepper** (Framing → Research → Synthesis → Ideate → Build → Shipped) showing where the stream is, coloured by state.
- Main column reordered into a numbered narrative: **1) The problem** — the originating Discover issue surfaced as its own card with links into the issue and GitHub; **2) The research** — the findings list (moved out of the sidebar into the flow) plus the full fan-out lineage DAG; **3) The synthesised stream** — the overview doc.
- Sidebar slimmed to pure provenance (stats, steward, harnesses, models, contributors). Clear empty states for streams without findings/synthesis yet.

**Shared (`StreamProgress.tsx`, `lib/streams.ts`)**
- New `StreamProgress` stepper component (compact + full variants) and `STREAM_STAGES` / `streamStageIndex` / `isStreamShipped` helpers, all driven by the stream `state` already in the snapshot.

Reuses `ChainTree`, `buildStreamChains`, `PersonAvatar`, `Markdown`, `Card` and the existing `streamsSummary` data layer — no changes to the build script or data schema.

## Method checklist

Web/tooling change, not a research finding — the citation/confidence checklist doesn't apply.

- [x] `tsc -b && vite build` clean; no new lint warnings in touched files
- [x] Verified across light/dark themes, desktop + mobile, and all lifecycle states (framing → shipped, incl. empty-state streams) via a local fixture
- [x] No personal or identifying data; no schema or data-layer changes

## For the reviewer

Push hardest on the lifecycle mapping in `streamStageIndex` (`lib/streams.ts`) — it maps free-text `state` strings onto the six-stage pipeline, and `needs-synthesis` / `awaiting-direction` both map to *Synthesis*. Also worth a look: on the detail page the "original problem" is resolved as the Discover-stage root of the chain (falling back to the first root) — confirm that's the right anchor for streams with unusual root shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAADRycMMEP9DyDtbiGYsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAADRycMMEP9DyDtbiGYsQ)_