### PR TITLE
fix: route synthesis rework to synthesize_work.sh; block generic runners from synthesis PRs (ADR-0011)

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -70,7 +70,10 @@ For **rework** it checks out the PR branch in a fresh worktree, feeds the agent
 the reviewer's feedback (review bodies + inline comments), and — once the agent
 has pushed to the same branch — flips the issue back to `status: in-review` so
 a reviewer picks it up again. If the agent pushed nothing, the issue stays
-`changes-requested` and is retried next loop.
+`changes-requested` and is retried next loop. **Synthesis draft PRs (branch
+`synthesis/*`) are never reworked here** — they belong to
+`synthesize_work.sh`, which keeps the synthesis rules in its prompt
+(ADR-0011); this loop unassigns itself and leaves them.
 
 Each loop also **reconciles the rework queue** first (ADR-0008): any open PR
 you authored whose *current* latest review is a change-request (no commits
@@ -177,6 +180,14 @@ The judgement stays human, structurally:
   dated direction entries.
 - If there are **no merged findings on disk** it refuses to draft a hollow doc
   and asks a human on the root instead.
+- If a reviewer **sends a draft back**, the rework comes back HERE, not to
+  `start_work.sh` (ADR-0011): each loop first reconciles (any open
+  `synthesis/*` PR with a current change-request whose root still sits
+  `awaiting-direction` is flipped to `changes-requested`), then reworks
+  sent-back drafts — with the synthesis rules still binding (steward text
+  preserved verbatim, neutral candidate outcomes, edit only the overview) —
+  before drafting new overviews. On push the root returns to
+  `awaiting-direction`.
 
 The steward finishes the gate by hand: edit the takeaways, fix any overreach,
 **write the direction decision**, set `steward:`, merge — and if proceeding,

--- a/docs/adr/0011-synthesis-rework-routing.md
+++ b/docs/adr/0011-synthesis-rework-routing.md
@@ -29,30 +29,39 @@ the fix needs a decision record ratified by a human maintainer.
 
 ## Decision
 
-1. **Synthesis PRs are identified by their head branch.**
+1. **Synthesis PRs are identified by their head branch, failing CLOSED.**
    `synthesize_work.sh` always creates `synthesis/<slug>`; a shared
-   `pr_is_synthesis` helper keys off that prefix. Considered instead: a label
-   on the PR (rejected — agents are forbidden from managing labels, and a
-   label can be dropped; the branch name is set by the script itself and
-   immutable for the PR's life).
+   `pr_is_synthesis` helper keys off that prefix and distinguishes "not
+   synthesis" from "couldn't read the branch" (gh error) — guards treat the
+   unknown case as don't-touch, so a transient API blip can never route a
+   synthesis draft back to a generic runner. Considered instead: a label on
+   the PR (rejected — agents are forbidden from managing labels, and a label
+   can be dropped; the branch name is set by the script itself and immutable
+   for the PR's life).
 2. **Generic runners refuse synthesis rework.** `start_work.sh` skips
-   synthesis PRs in all three rework entry points — its own rework queue
-   (unassigning itself so the synthesis runner can claim), the TTL-freed
-   unassigned queue, and its reconciler.
+   synthesis PRs (and unknown-branch PRs) in all three rework entry points —
+   its own rework queue (unassigning itself so the synthesis runner can
+   claim), the TTL-freed unassigned queue, and its reconciler.
 3. **`synthesize_work.sh` gains the rework path.** Each loop first reconciles
    (any open `synthesis/*` PR whose *current* latest review requests changes
-   but whose root sits `awaiting-direction` is flipped to
+   but whose root sits `awaiting-direction` — or wedged at `in-review`, the
+   poison state a pre-ADR-0011 runner leaves — is flipped to
    `changes-requested`), then works sent-back drafts before drafting new
-   overviews — a blocked G1 gate beats new work. The rework runs a
+   overviews — a blocked G1 gate beats new work. Targets are only unassigned
+   roots or ones assigned to this runner (an assignment is another runner's
+   live claim; contesting it would let the tie-break steal mid-flight work),
+   and a draft already reworked after its latest change-request gets its
+   status repaired rather than a fresh agent run. The rework runs a
    synthesis-specific prompt (review feedback + the standing synthesis rules:
    steward text preserved verbatim, neutral candidate outcomes, edit only the
    overview file, push to the same branch), and on push the script flips the
    root `changes-requested → awaiting-direction` (also stripping any stray
    `in-review`).
-4. **The review hand-off strips both park statuses.** `review_work.sh` now
-   removes `in-review` *and* `awaiting-direction` when flipping to
-   `changes-requested`, and its comment names the runner that will actually
-   pick the rework up (`synthesize_work.sh` for synthesis PRs).
+4. **The review hand-off strips the right park status.** `review_work.sh`
+   removes `awaiting-direction` when flipping a synthesis PR's root to
+   `changes-requested` (and only then — a generic PR that merely body-links a
+   parked root must not yank it out of G1), and its comment names the runner
+   that will actually pick the rework up.
 
 ## Consequences
 

--- a/docs/adr/0011-synthesis-rework-routing.md
+++ b/docs/adr/0011-synthesis-rework-routing.md
@@ -1,0 +1,70 @@
+# ADR-0011: Synthesis draft rework belongs to synthesize_work.sh; generic runners must not touch synthesis PRs
+
+- **Status:** proposed (ratified by the human maintainer who reviews and merges the PR)
+- **Date:** 2026-07-03
+- **Deciders:** human maintainer (on merge); drafted by an agent on behalf of the maintainer
+
+## Context
+
+When an adversarial review sent a synthesis draft PR back (PR #140, stream
+#61), the rework never reached the synthesis agent — because
+`synthesize_work.sh` had **no rework path at all**: its only queue was
+`status: needs-synthesis`, and after opening a draft it parks the root at
+`awaiting-direction`. Two compounding gaps:
+
+1. **The hand-off missed the root's real status.** `review_work.sh` flipped
+   the worked issue `in-review → changes-requested`, but a synthesis root
+   parks at `awaiting-direction` while its draft is reviewed — so the stale
+   label stayed on, leaving the root carrying two status labels at once.
+2. **The wrong runner did the rework.** With the root at
+   `changes-requested`, a generic `start_work.sh` loop picked it up and ran
+   the *research* rework prompt — which has none of the synthesis rules
+   (steward-preservation, neutral candidate outcomes, evidence-only,
+   touch-one-file) — then flipped the root to `in-review`: a status a stream
+   root must never hold, and one nothing ever clears, because synthesis PRs
+   have no closing ref (ADR-0001) so the merge → `done` path never fires.
+
+These are contracts of the automation scripts, so per `docs/adr/README.md`
+the fix needs a decision record ratified by a human maintainer.
+
+## Decision
+
+1. **Synthesis PRs are identified by their head branch.**
+   `synthesize_work.sh` always creates `synthesis/<slug>`; a shared
+   `pr_is_synthesis` helper keys off that prefix. Considered instead: a label
+   on the PR (rejected — agents are forbidden from managing labels, and a
+   label can be dropped; the branch name is set by the script itself and
+   immutable for the PR's life).
+2. **Generic runners refuse synthesis rework.** `start_work.sh` skips
+   synthesis PRs in all three rework entry points — its own rework queue
+   (unassigning itself so the synthesis runner can claim), the TTL-freed
+   unassigned queue, and its reconciler.
+3. **`synthesize_work.sh` gains the rework path.** Each loop first reconciles
+   (any open `synthesis/*` PR whose *current* latest review requests changes
+   but whose root sits `awaiting-direction` is flipped to
+   `changes-requested`), then works sent-back drafts before drafting new
+   overviews — a blocked G1 gate beats new work. The rework runs a
+   synthesis-specific prompt (review feedback + the standing synthesis rules:
+   steward text preserved verbatim, neutral candidate outcomes, edit only the
+   overview file, push to the same branch), and on push the script flips the
+   root `changes-requested → awaiting-direction` (also stripping any stray
+   `in-review`).
+4. **The review hand-off strips both park statuses.** `review_work.sh` now
+   removes `in-review` *and* `awaiting-direction` when flipping to
+   `changes-requested`, and its comment names the runner that will actually
+   pick the rework up (`synthesize_work.sh` for synthesis PRs).
+
+## Consequences
+
+- A sent-back synthesis draft is now picked up by the synthesis agent, with
+  the right prompt and the right status cycle
+  (`awaiting-direction → changes-requested → awaiting-direction`), and a
+  stream root can no longer be parked at `in-review`.
+- Rework priority means one persistent reviewer objection can starve fresh
+  synthesis in a single-runner setup; acceptable because the no-new-commits
+  case leaves the root `changes-requested` and moves on rather than spinning.
+- The branch-prefix convention becomes load-bearing: a hand-opened synthesis
+  PR on a differently-named branch falls back to the generic path. Tripwire:
+  if that happens in practice, or the reconciler ever ping-pongs a draft
+  that's mid-rework, revisit — consider a PR label applied by the script or
+  moving the routing into CI.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,5 +47,6 @@ routine fixes, copy changes, or web styling.
 | [0008](0008-rework-handoff-and-runner-interrupts.md) | Rework hand-off routes by worked issue; reviewer crashes retry; runner interrupts stop the run | Proposed |
 | [0009](0009-maintainer-escalation-handoff.md) | Agents hand off write-gated actions to maintainers via a documented escalation path | Proposed |
 | [0010](0010-partner-network.md) | Track the partner / SME / advisory network in the open, behind a consent gate | Proposed |
+| [0011](0011-synthesis-rework-routing.md) | Synthesis draft rework belongs to synthesize_work.sh; generic runners must not touch synthesis PRs | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/reap.sh
+++ b/reap.sh
@@ -44,7 +44,7 @@ reap_reworks() {
     if [ "$DRY_RUN" = 1 ]; then info "[dry-run] would free stale rework #$n (unassign)"; continue; fi
     who="$(gh issue view "$n" --repo "$REPO" --json assignees --jq '.assignees[].login' 2>/dev/null || true)"
     for a in $who; do gh issue edit "$n" --repo "$REPO" --remove-assignee "$a" >/dev/null 2>&1 || true; done
-    gh issue comment "$n" --repo "$REPO" --body "⏱ Rework untouched for over $(hrs "$REWORK_TTL")h — unassigned and released to the pool; any worker's \`start_work.sh\` can pick it up." >/dev/null 2>&1 || true
+    gh issue comment "$n" --repo "$REPO" --body "⏱ Rework untouched for over $(hrs "$REWORK_TTL")h — unassigned and released to the pool; any worker's \`start_work.sh\` (or \`synthesize_work.sh\`, for a synthesis draft) can pick it up." >/dev/null 2>&1 || true
     ok "Freed stale rework #$n (unassigned)"
   done
 }

--- a/review_work.sh
+++ b/review_work.sh
@@ -404,13 +404,15 @@ review_one() {  # $1 = PR number
     # issue_addressed_by_pr (not issue_for_pr) so DISCOVER PRs — which have no
     # closing ref, only "Part of #n" — are routed too, instead of silently
     # dropping the hand-off. A SYNTHESIS draft's root parks at
-    # "awaiting-direction" (not "in-review") while under review, so that label
-    # is stripped too, and the rework belongs to synthesize_work.sh (ADR-0011).
+    # "awaiting-direction" (not "in-review") while under review, so for
+    # synthesis PRs — and ONLY those; a generic PR that body-links a parked
+    # root must not yank it out of G1 — that label is stripped instead, and
+    # the rework belongs to synthesize_work.sh (ADR-0011).
     local iss; iss="$(issue_addressed_by_pr "$pr" || true)"
     if [ -n "$iss" ]; then
-      local picker="start_work.sh"
-      pr_is_synthesis "$pr" && picker="synthesize_work.sh"
-      if set_status_label "$iss" "changes-requested" "in-review" "awaiting-direction" 2>/dev/null; then
+      local picker="start_work.sh" old_park="in-review"
+      if pr_is_synthesis "$pr"; then picker="synthesize_work.sh"; old_park="awaiting-direction"; fi
+      if set_status_label "$iss" "changes-requested" "in-review" "$old_park" 2>/dev/null; then
         gh issue comment "$iss" --repo "$REPO" --body "🔁 Adversarial review of PR #$pr found problems — sending back to @$author for rework (**status: changes-requested**). Their next \`$picker\` loop will pick this up." >/dev/null || true
         ok "Issue #$iss → changes-requested (back to @$author)"
       else

--- a/review_work.sh
+++ b/review_work.sh
@@ -400,14 +400,18 @@ review_one() {  # $1 = PR number
       || gh pr comment "$pr" --repo "$REPO" "${body_flag[@]}" >/dev/null || true
     set_check "$sha" failure "Adversarial review found problems" "$url"
     # Route the rework back to the author: flip the linked issue to
-    # "changes-requested" so THEIR next start_work.sh loop picks it up. Use
+    # "changes-requested" so THEIR next work loop picks it up. Use
     # issue_addressed_by_pr (not issue_for_pr) so DISCOVER PRs — which have no
     # closing ref, only "Part of #n" — are routed too, instead of silently
-    # dropping the hand-off.
+    # dropping the hand-off. A SYNTHESIS draft's root parks at
+    # "awaiting-direction" (not "in-review") while under review, so that label
+    # is stripped too, and the rework belongs to synthesize_work.sh (ADR-0011).
     local iss; iss="$(issue_addressed_by_pr "$pr" || true)"
     if [ -n "$iss" ]; then
-      if set_status_label "$iss" "changes-requested" "in-review" 2>/dev/null; then
-        gh issue comment "$iss" --repo "$REPO" --body "🔁 Adversarial review of PR #$pr found problems — sending back to @$author for rework (**status: changes-requested**). Their next \`start_work.sh\` loop will pick this up." >/dev/null || true
+      local picker="start_work.sh"
+      pr_is_synthesis "$pr" && picker="synthesize_work.sh"
+      if set_status_label "$iss" "changes-requested" "in-review" "awaiting-direction" 2>/dev/null; then
+        gh issue comment "$iss" --repo "$REPO" --body "🔁 Adversarial review of PR #$pr found problems — sending back to @$author for rework (**status: changes-requested**). Their next \`$picker\` loop will pick this up." >/dev/null || true
         ok "Issue #$iss → changes-requested (back to @$author)"
       else
         warn "Couldn't flip issue #$iss to changes-requested (needs triage/write access) — the review itself is recorded."

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -220,6 +220,19 @@ pr_review_kind() {  # $1 = pr number
   fi
 }
 
+# True if a PR is a SYNTHESIS DRAFT — synthesize_work.sh always creates its
+# branch as synthesis/<slug>, so the head branch is the marker. Synthesis
+# rework belongs to synthesize_work.sh ONLY: the generic start_work.sh rework
+# path uses the research rework prompt (no steward-preservation rules) and
+# parks the stream root at "in-review" — a status a root must never hold,
+# because a synthesis PR has no closing ref so nothing ever clears it.
+pr_is_synthesis() {  # $1 = pr number
+  case "$(gh pr view "$1" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null)" in
+    synthesis/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Issue closed by a PR (first closing ref). Use this ONLY when you specifically
 # mean "the issue merging this PR will CLOSE" (e.g. marking it done) — discover
 # PRs have no closing ref by design, so this is empty for them.

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -220,14 +220,21 @@ pr_review_kind() {  # $1 = pr number
   fi
 }
 
-# True if a PR is a SYNTHESIS DRAFT — synthesize_work.sh always creates its
-# branch as synthesis/<slug>, so the head branch is the marker. Synthesis
-# rework belongs to synthesize_work.sh ONLY: the generic start_work.sh rework
-# path uses the research rework prompt (no steward-preservation rules) and
-# parks the stream root at "in-review" — a status a root must never hold,
-# because a synthesis PR has no closing ref so nothing ever clears it.
+# Is a PR a SYNTHESIS DRAFT? synthesize_work.sh always creates its branch as
+# synthesis/<slug>, so the head branch is the marker. Synthesis rework belongs
+# to synthesize_work.sh ONLY: the generic start_work.sh rework path uses the
+# research rework prompt (no steward-preservation rules) and parks the stream
+# root at "in-review" — a status a root must never hold, because a synthesis
+# PR has no closing ref so nothing ever clears it.
+# Returns 0 = synthesis, 1 = not synthesis, 2 = UNKNOWN (gh failed). Callers
+# guarding the generic path must fail CLOSED: treat 2 as "don't touch it this
+# loop", never as "not synthesis" — or a transient API blip re-opens the very
+# routing bug this helper exists to prevent (ADR-0011).
 pr_is_synthesis() {  # $1 = pr number
-  case "$(gh pr view "$1" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null)" in
+  local head
+  head="$(gh pr view "$1" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null)" || head=""
+  [ -z "$head" ] && return 2
+  case "$head" in
     synthesis/*) return 0 ;;
     *) return 1 ;;
   esac

--- a/start_work.sh
+++ b/start_work.sh
@@ -276,6 +276,18 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
     fi
     return 0
   fi
+  # A SYNTHESIS draft (branch synthesis/*) is reworked by synthesize_work.sh
+  # ONLY (ADR-0011): this generic loop would feed it the research rework prompt
+  # (no steward-preservation rules) and then park the stream root at
+  # "in-review" — a status a root must never hold. Unassign so the synthesis
+  # runner can claim it; drop it from MY queue.
+  if pr_is_synthesis "$pr"; then
+    log "#$n's PR #$pr is a synthesis draft — its rework belongs to synthesize_work.sh. Unassigning @me."
+    if [ "$DRY_RUN" = 0 ]; then
+      gh issue edit "$n" --repo "$REPO" --remove-assignee "@me" >/dev/null 2>&1 || true
+    fi
+    return 0
+  fi
   # A fork PR's branch lives on the contributor's fork, not origin — we can
   # neither check it out as origin/$branch nor push a rework to it (only its
   # author can). Drop it from MY rework queue so the loop doesn't spin on it
@@ -325,6 +337,7 @@ reconcile_rework() {
   prs="$(gh pr list --repo "$REPO" --state open --author "@me" --json number,reviewDecision \
           --jq '.[]|select(.reviewDecision=="CHANGES_REQUESTED")|.number' 2>/dev/null || true)"
   for pr in $prs; do
+    pr_is_synthesis "$pr" && continue   # routed by synthesize_work.sh's own reconciler (ADR-0011)
     lastcr="$(gh pr view "$pr" --repo "$REPO" --json reviews --jq '[.reviews[]|select(.state=="CHANGES_REQUESTED")]|last|.submittedAt // ""' 2>/dev/null || true)"
     [ -z "$lastcr" ] && continue
     headcommit="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate // ""' 2>/dev/null || true)"
@@ -351,6 +364,7 @@ take_unassigned_rework() {  # $1 = optional queue snapshot (from fetch_open_issu
   local n pr owner
   for n in $(unassigned_reworks "${1:-}"); do
     pr="$(pr_for_issue "$n" || true)"; [ -z "$pr" ] && continue
+    pr_is_synthesis "$pr" && continue   # synthesis reworks belong to synthesize_work.sh (ADR-0011)
     owner="$(gh pr view "$pr" --repo "$REPO" --json headRepositoryOwner --jq .headRepositoryOwner.login 2>/dev/null || true)"
     [ "$owner" = "$OWNER" ] || continue
     if [ "$DRY_RUN" = 1 ]; then echo "$n"; return 0; fi

--- a/start_work.sh
+++ b/start_work.sh
@@ -280,12 +280,17 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
   # ONLY (ADR-0011): this generic loop would feed it the research rework prompt
   # (no steward-preservation rules) and then park the stream root at
   # "in-review" — a status a root must never hold. Unassign so the synthesis
-  # runner can claim it; drop it from MY queue.
-  if pr_is_synthesis "$pr"; then
+  # runner can claim it; drop it from MY queue. FAIL CLOSED: if we can't read
+  # the head branch (rc 2), do NOT rework — leave the issue for a future loop.
+  local synth_rc; pr_is_synthesis "$pr" && synth_rc=0 || synth_rc=$?
+  if [ "$synth_rc" -eq 0 ]; then
     log "#$n's PR #$pr is a synthesis draft — its rework belongs to synthesize_work.sh. Unassigning @me."
     if [ "$DRY_RUN" = 0 ]; then
       gh issue edit "$n" --repo "$REPO" --remove-assignee "@me" >/dev/null 2>&1 || true
     fi
+    return 0
+  elif [ "$synth_rc" -eq 2 ]; then
+    warn "Couldn't read PR #$pr's head branch — leaving #$n for a future loop."
     return 0
   fi
   # A fork PR's branch lives on the contributor's fork, not origin — we can
@@ -333,11 +338,14 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
 # pushed after it — so a freshly reworked PR awaiting re-review is left alone.
 reconcile_rework() {
   [ "$DRY_RUN" = 1 ] && return 0
-  local prs pr iss labels lastcr headcommit
+  local prs pr iss labels lastcr headcommit synth_rc
   prs="$(gh pr list --repo "$REPO" --state open --author "@me" --json number,reviewDecision \
           --jq '.[]|select(.reviewDecision=="CHANGES_REQUESTED")|.number' 2>/dev/null || true)"
   for pr in $prs; do
-    pr_is_synthesis "$pr" && continue   # routed by synthesize_work.sh's own reconciler (ADR-0011)
+    # Routed by synthesize_work.sh's own reconciler (ADR-0011). FAIL CLOSED:
+    # rc 2 (couldn't read the head branch) also skips this loop.
+    pr_is_synthesis "$pr" && synth_rc=0 || synth_rc=$?
+    [ "$synth_rc" -ne 1 ] && continue
     lastcr="$(gh pr view "$pr" --repo "$REPO" --json reviews --jq '[.reviews[]|select(.state=="CHANGES_REQUESTED")]|last|.submittedAt // ""' 2>/dev/null || true)"
     [ -z "$lastcr" ] && continue
     headcommit="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate // ""' 2>/dev/null || true)"
@@ -361,10 +369,13 @@ reconcile_rework() {
 # a branch we can actually push the rework to. Fork-branch PRs are skipped (only
 # their owner can push). Claims it to @me and echoes its number, else nothing.
 take_unassigned_rework() {  # $1 = optional queue snapshot (from fetch_open_issues)
-  local n pr owner
+  local n pr owner synth_rc
   for n in $(unassigned_reworks "${1:-}"); do
     pr="$(pr_for_issue "$n" || true)"; [ -z "$pr" ] && continue
-    pr_is_synthesis "$pr" && continue   # synthesis reworks belong to synthesize_work.sh (ADR-0011)
+    # Synthesis reworks belong to synthesize_work.sh (ADR-0011). FAIL CLOSED:
+    # rc 2 (couldn't read the head branch) also skips — never adopt blind.
+    pr_is_synthesis "$pr" && synth_rc=0 || synth_rc=$?
+    [ "$synth_rc" -ne 1 ] && continue
     owner="$(gh pr view "$pr" --repo "$REPO" --json headRepositoryOwner --jq .headRepositoryOwner.login 2>/dev/null || true)"
     [ "$owner" = "$OWNER" ] || continue
     if [ "$DRY_RUN" = 1 ]; then echo "$n"; return 0; fi

--- a/synthesize_work.sh
+++ b/synthesize_work.sh
@@ -159,6 +159,124 @@ When finished, print the PR URL.
 EOF
 }
 
+synthesis_rework_prompt() {  # $1 root, $2 pr, $3 overview path, $4 branch
+  local n="$1" pr="$2" path="$3" branch="$4" title feedback
+  title="$(gh pr view "$pr" --repo "$REPO" --json title --jq .title)"
+  feedback="$(review_feedback "$pr")"
+  cat <<EOF
+You are the SYNTHESIS agent for The For Good Project (github.com/$REPO). Your
+draft PR #$pr ("$title") — the G1 stream overview for stream #$n — was sent
+back by an adversarial reviewer. Your job now is to address that review.
+
+You are inside a dedicated git worktree with the PR branch '$branch' checked
+out (detached HEAD at origin/$branch, freshly fetched).
+
+== REVIEW FEEDBACK ==
+$feedback
+== END REVIEW FEEDBACK ==
+
+The synthesis rules still bind you (docs/STREAMS.md, ADR-0003, ADR-0007):
+- Edit ONLY $path. Plain language, evidence-only — every takeaway keeps its
+  finding's confidence; never launder a Low into a confident claim; never
+  import outside facts.
+- Candidate outcomes stay NEUTRAL: no ranking, no recommendation, no "we
+  should". The direction decision is the steward's, never yours.
+- PRESERVE, verbatim: any 'steward:' frontmatter value, the 'Feedback log'
+  table, every dated entry under 'Where this is heading', and any text a
+  human steward has written. The TODO(steward) placeholder stays unless a
+  steward already replaced it.
+
+Do this:
+1. Address EVERY point in the feedback. Where you believe the reviewer is
+   wrong, leave the draft as-is and prepare a short, evidence-backed rebuttal
+   for step 3 instead.
+2. Commit ONLY $path and push to the SAME branch:
+   git push origin HEAD:$branch
+3. Comment on the PR summarising what you changed and any rebuttals:
+   gh pr comment $pr --repo $REPO --body "..."
+
+IMPORTANT: do NOT open a new PR, do NOT close anything, and do NOT touch
+labels or assignees — the runner manages status. Work only on PR #$pr.
+EOF
+}
+
+# Self-heal the synthesis rework queue (mirror of start_work.sh's reconciler,
+# scoped to synthesis drafts — ADR-0011): any open synthesis/* PR whose CURRENT
+# latest review is a change-request (no commits pushed after it) but whose
+# stream root still sits "awaiting-direction" gets flipped to
+# "changes-requested" so the rework pass below picks it up. This catches
+# reviews posted outside review_work.sh and hand-offs from older runners.
+reconcile_synthesis_rework() {
+  [ "$DRY_RUN" = 1 ] && return 0
+  local prs pr iss labels lastcr headcommit
+  prs="$(gh pr list --repo "$REPO" --state open --json number,headRefName,reviewDecision \
+          --jq '.[]|select(.reviewDecision=="CHANGES_REQUESTED")|select(.headRefName|startswith("synthesis/"))|.number' 2>/dev/null || true)"
+  for pr in $prs; do
+    lastcr="$(gh pr view "$pr" --repo "$REPO" --json reviews --jq '[.reviews[]|select(.state=="CHANGES_REQUESTED")]|last|.submittedAt // ""' 2>/dev/null || true)"
+    [ -z "$lastcr" ] && continue
+    headcommit="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate // ""' 2>/dev/null || true)"
+    # ISO-8601 compares lexically: a commit newer than the review means the
+    # draft was already reworked and awaits RE-review — leave it alone.
+    [ -n "$headcommit" ] && [[ "$headcommit" > "$lastcr" ]] && continue
+    iss="$(issue_addressed_by_pr "$pr" || true)"
+    [ -z "$iss" ] && continue
+    labels="$(issue_labels "$iss" 2>/dev/null || true)"
+    case ",$labels," in
+      *",status: changes-requested,"*) continue ;;   # already routed
+      *",status: awaiting-direction,"*)
+        set_status_label "$iss" "changes-requested" "awaiting-direction" "in-review" 2>/dev/null \
+          && ok "Reconciled stream #$iss → changes-requested (unrouted review on synthesis PR #$pr)" || true ;;
+    esac
+  done
+}
+
+# Stream roots whose synthesis draft was sent back: "status: changes-requested"
+# plus an open synthesis/* PR. Echoes "<issue> <pr>" pairs, oldest root first.
+synthesis_rework_targets() {
+  local snap n pr
+  snap="$(fetch_open_issues)" || snap='[]'
+  printf '%s' "$snap" \
+    | jq -r '[.[] | select(.labels|map(.name)|index("status: changes-requested"))] | sort_by(.createdAt) | .[].number' \
+    | while IFS= read -r n; do
+        [ -z "$n" ] && continue
+        pr="$(pr_for_issue "$n" || true)"; [ -z "$pr" ] && continue
+        pr_is_synthesis "$pr" && printf '%s %s\n' "$n" "$pr"
+      done
+}
+
+resynthesize_one() {  # $1 = stream root issue number, $2 = synthesis PR number
+  local n="$1" pr="$2" branch
+  rule; info "${c_bold}Stream #$n${c_reset} (synthesis rework, PR #$pr) — $(issue_field "$n" title)"
+  branch="$(gh pr view "$pr" --repo "$REPO" --json headRefName --jq .headRefName)"
+  if [ "$DRY_RUN" = 1 ]; then
+    info "[dry-run] would rework synthesis PR #$pr (branch $branch) against the review feedback, push, and move #$n → awaiting-direction"
+    return 0
+  fi
+  # Claim: several synthesis runners may race a sent-back draft. Same
+  # assign-settle-tie-break as start_work.sh's claims.
+  gh issue edit "$n" --repo "$REPO" --add-assignee "@me" >/dev/null 2>&1 || true
+  resolve_claim_race "$n" || return 0
+  local before after
+  before="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"
+  make_worktree "origin/$branch" || { err "Couldn't create worktree for PR #$pr (branch $branch) — leaving #$n for a future loop."; return 1; }
+  local path; path="$(overview_path "$n" "$WORKTREE" "$(issue_field "$n" title)")"
+  info "Handing synthesis rework for stream #$n to $AGENT (worktree: $WORKTREE)..."
+  set +e; run_agent "$(synthesis_rework_prompt "$n" "$pr" "$path" "$branch")" "$WORKTREE"; local rc=$?; set -e
+  was_interrupted "$rc" && { remove_worktree; warn "Interrupted — stopping."; exit 130; }
+  if [ "$rc" -eq 0 ]; then ok "Synthesis rework run complete for stream #$n"; else err "Synthesis rework run failed/aborted for stream #$n (exit $rc)"; fi
+  remove_worktree
+  after="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"
+  if [ "$after" != "$before" ]; then
+    # Back to the review gate; the root parks at awaiting-direction (its normal
+    # status while a draft PR exists) — also strips any stray in-review.
+    set_status_label "$n" "awaiting-direction" "changes-requested" "in-review"
+    gh issue comment "$n" --repo "$REPO" --body "🔁 Synthesis rework pushed to PR #$pr — back to **awaiting-direction** pending a fresh adversarial review and the steward's decision." >/dev/null || true
+    ok "Stream #$n → awaiting-direction (rework pushed to PR #$pr)"
+  else
+    warn "Agent pushed no new commits to PR #$pr — leaving #$n as 'changes-requested' for a future loop."
+  fi
+}
+
 synthesize_one() {  # $1 = stream root issue number
   local n="$1"
   rule; info "${c_bold}Stream #$n${c_reset} — $(issue_field "$n" title)"
@@ -228,6 +346,17 @@ main() {
   info "synthesize_work.sh · repo=$REPO · agent=$AGENT${ONLY_STREAM:+ · stream=$ONLY_STREAM}$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"
   local done=0
   while :; do
+    reconcile_synthesis_rework   # pull in sent-back drafts the hand-off missed (ADR-0011)
+    # Rework FIRST: a sent-back draft blocks its stream's G1 gate, so it beats
+    # drafting new overviews. Each pair is "<root> <pr>".
+    local n pr
+    while IFS=' ' read -r n pr; do
+      [ -z "$n" ] && continue
+      [ -n "$ONLY_STREAM" ] && [ "$n" != "$ONLY_STREAM" ] && continue
+      resynthesize_one "$n" "$pr" || true
+      done=$((done+1))
+      [ "$MAX" -gt 0 ] && [ "$done" -ge "$MAX" ] && { rule; ok "Reached MAX=$MAX. Stopping."; exit 0; }
+    done <<< "$(synthesis_rework_targets || true)"
     local roots
     if [ -n "$ONLY_STREAM" ]; then roots="$ONLY_STREAM"; else roots="$(synthesis_issues || true)"; fi
     if [ -z "$roots" ]; then
@@ -236,7 +365,6 @@ main() {
       fi
       rule; ok "No streams waiting for synthesis."; break
     fi
-    local n
     for n in $roots; do
       synthesize_one "$n" || true
       done=$((done+1))

--- a/synthesize_work.sh
+++ b/synthesize_work.sh
@@ -203,7 +203,8 @@ EOF
 # Self-heal the synthesis rework queue (mirror of start_work.sh's reconciler,
 # scoped to synthesis drafts — ADR-0011): any open synthesis/* PR whose CURRENT
 # latest review is a change-request (no commits pushed after it) but whose
-# stream root still sits "awaiting-direction" gets flipped to
+# stream root still sits "awaiting-direction" — or wedged at "in-review", the
+# poison state a pre-ADR-0011 generic runner leaves behind — gets flipped to
 # "changes-requested" so the rework pass below picks it up. This catches
 # reviews posted outside review_work.sh and hand-offs from older runners.
 reconcile_synthesis_rework() {
@@ -223,7 +224,7 @@ reconcile_synthesis_rework() {
     labels="$(issue_labels "$iss" 2>/dev/null || true)"
     case ",$labels," in
       *",status: changes-requested,"*) continue ;;   # already routed
-      *",status: awaiting-direction,"*)
+      *",status: awaiting-direction,"*|*",status: in-review,"*)
         set_status_label "$iss" "changes-requested" "awaiting-direction" "in-review" 2>/dev/null \
           && ok "Reconciled stream #$iss → changes-requested (unrouted review on synthesis PR #$pr)" || true ;;
     esac
@@ -231,12 +232,16 @@ reconcile_synthesis_rework() {
 }
 
 # Stream roots whose synthesis draft was sent back: "status: changes-requested"
-# plus an open synthesis/* PR. Echoes "<issue> <pr>" pairs, oldest root first.
+# plus an open synthesis/* PR. Only UNASSIGNED roots or ones assigned to ME —
+# an assignment is another runner's live claim, and contesting it would let
+# the deterministic tie-break STEAL mid-flight work (resolve_claim_race
+# adjudicates simultaneous claims, not established ones). "priority: high"
+# first, then oldest. Echoes "<issue> <pr>" pairs.
 synthesis_rework_targets() {
   local snap n pr
   snap="$(fetch_open_issues)" || snap='[]'
   printf '%s' "$snap" \
-    | jq -r '[.[] | select(.labels|map(.name)|index("status: changes-requested"))] | sort_by(.createdAt) | .[].number' \
+    | jq -r --arg me "$ME" '[.[] | select(.labels|map(.name)|index("status: changes-requested")) | select((.assignees|length)==0 or (.assignees|map(.login)|index($me)))] | sort_by((.labels|map(.name)|index("priority: high")|not), .createdAt) | .[].number' \
     | while IFS= read -r n; do
         [ -z "$n" ] && continue
         pr="$(pr_for_issue "$n" || true)"; [ -z "$pr" ] && continue
@@ -247,12 +252,26 @@ synthesis_rework_targets() {
 resynthesize_one() {  # $1 = stream root issue number, $2 = synthesis PR number
   local n="$1" pr="$2" branch
   rule; info "${c_bold}Stream #$n${c_reset} (synthesis rework, PR #$pr) — $(issue_field "$n" title)"
-  branch="$(gh pr view "$pr" --repo "$REPO" --json headRefName --jq .headRefName)"
+  branch="$(gh pr view "$pr" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null || true)"
+  [ -z "$branch" ] && { warn "Couldn't read PR #$pr's head branch — leaving #$n for a future loop."; return 1; }
+  # Currency check: commits newer than the latest change-request mean the
+  # draft was ALREADY reworked and awaits re-review — the "changes-requested"
+  # label is just a flip that failed or was raced. Repair the label instead of
+  # burning a full agent run re-answering addressed feedback every loop.
+  local lastcr headcommit
+  lastcr="$(gh pr view "$pr" --repo "$REPO" --json reviews --jq '[.reviews[]|select(.state=="CHANGES_REQUESTED")]|last|.submittedAt // ""' 2>/dev/null || true)"
+  headcommit="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate // ""' 2>/dev/null || true)"
+  if [ -n "$lastcr" ] && [ -n "$headcommit" ] && [[ "$headcommit" > "$lastcr" ]]; then
+    log "PR #$pr was already reworked after its last change-request — repairing #$n's status instead of re-running."
+    [ "$DRY_RUN" = 1 ] || set_status_label "$n" "awaiting-direction" "changes-requested" "in-review" 2>/dev/null || true
+    return 0
+  fi
   if [ "$DRY_RUN" = 1 ]; then
     info "[dry-run] would rework synthesis PR #$pr (branch $branch) against the review feedback, push, and move #$n → awaiting-direction"
     return 0
   fi
-  # Claim: several synthesis runners may race a sent-back draft. Same
+  # Claim: several synthesis runners may race an UNCLAIMED sent-back draft
+  # (targets exclude other runners' live assignments). Same
   # assign-settle-tie-break as start_work.sh's claims.
   gh issue edit "$n" --repo "$REPO" --add-assignee "@me" >/dev/null 2>&1 || true
   resolve_claim_race "$n" || return 0


### PR DESCRIPTION
## What broke (seen live: PR #140 / stream #61)

When the adversarial reviewer sent synthesis draft PR #140 back:

1. The hand-off flipped root #61 to `changes-requested` but only stripped `in-review` — a synthesis root parks at `awaiting-direction`, which stayed on (label soup).
2. `synthesize_work.sh` has **no rework path** (its only queue is `needs-synthesis`), so the synthesis agent never saw it.
3. Instead a generic `start_work.sh` loop grabbed it, ran the **research** rework prompt (no steward-preservation / neutral-outcomes rules), and flipped the root to `in-review` — a status nothing ever clears for a root, since synthesis PRs have no closing ref (ADR-0001).

## The fix (ADR-0011, included)

- **`pr_is_synthesis`** (fg-common.sh): synthesis PRs are identified by their `synthesis/*` head branch.
- **`start_work.sh`** refuses synthesis rework in all three entry points (own queue → unassigns itself; TTL-freed queue; reconciler).
- **`review_work.sh`** hand-off strips `awaiting-direction` too, and its comment names the runner that will actually pick the rework up.
- **`synthesize_work.sh`** gains the rework path: reconciler for missed hand-offs, rework-first queue, a synthesis-specific rework prompt (steward text preserved verbatim, neutral candidate outcomes, edit only the overview, push same branch), and the status cycle `awaiting-direction → changes-requested → awaiting-direction`.

## Verified

- `bash -n` on all four scripts.
- `pr_is_synthesis`: PR #140 → true, PR #92 → false (live).
- `DRY_RUN` runs of both loops: synthesis loop finds no phantom rework; generic loop still picks up discover rework #110/PR #147.

## Follow-up for a maintainer

Issue #61 still carries a stray `status: in-review` next to `status: awaiting-direction` (left by the wrong-runner rework). Please remove `status: in-review` — the agent session wasn't permitted to edit live labels.

Automation-contract change → labelled `review: human-only` per docs/AUTOMATION.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)