### PR TITLE
research: assess NZ startup funding access attribution (Closes #141)

### DIFF
--- a/research/findings/grant-access/nz-startup-funding-access-attribution.md
+++ b/research/findings/grant-access/nz-startup-funding-access-attribution.md
@@ -1,0 +1,123 @@
+---
+title: "NZ does not publicly measure how many startups seek angel/seed funding or why failed raises fail"
+domain: "grant-access"
+issue: "#141"
+confidence: "Low"
+author: "adam91holt"
+agent: "codex"
+model: "gpt-5-codex"
+date: "2026-07-03"
+status: "draft"
+---
+
+# NZ does not publicly measure how many startups seek angel/seed funding or why failed raises fail
+
+## Executive answer
+
+- **No public NZ source I found answers the issue's numerator.** NZGCP explicitly said in its 2024/25 Statement of Performance Expectations that "significant gaps" in data on startup companies and their fundraising needs made it hard to assess how to develop the investment ecosystem, and I found no later public source that counts annual active angel/seed fundraisers, failed raises, or failed-raise reasons. [NZGCP SPE 2024/25](https://www.nzgcp.co.nz/assets/Media/NZGCP-SPE-2024-25-FINAL-30-June24.pdf); [NZGCP Dealroom](https://www.nzgcp.co.nz/about-us/news-and-media/resources/dealroom)
+- **The best public lower bound is funded companies, not seekers:** in 2025 NZGCP's Young Company Finance recorded **166 funded deals**, **$754m invested**, and **47 new companies invested in**; that proves at least 47 companies newly crossed the funding line, but it does not count the companies that tried and failed. [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf)
+- **The broad startup denominator is about 2,400, but it is not a fundraising denominator.** Startup Genome's MBIE-commissioned 2022 assessment estimated about **2,400+ startups** in New Zealand and used 176 founder survey responses, but the public report does not say how many were actively raising in a given year or how many failed to raise. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem); [Upstart Nation](https://www.mbie.govt.nz/assets/upstart-nation.pdf)
+- **The evidence supports three bottlenecks at once, not a single binding constraint:** discovery/access problems are real in qualitative evidence, capital scarcity is real in official briefings and stage data, and investment-readiness/capability problems are also real in founder guidance and ecosystem reports. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem); [MBIE Access to growth capital](https://www.mbie.govt.nz/dmsdocument/31135-access-growth-capital); [NZGCP capital raising guide](https://www.nzgcp.co.nz/about-us/news-and-media/resources/a-guide-to-capital-raising-for-founders)
+- **Bottom line:** the stream's "discovery/access is the binding constraint" assumption is **not proven**. A founder survey, or matched funnel data from angel groups, accelerators, incubators and NZGCP/Dealroom, is needed before any share can be assigned to discovery/access versus capital scarcity versus investment-readiness. [NZGCP SPE 2024/25](https://www.nzgcp.co.nz/assets/Media/NZGCP-SPE-2024-25-FINAL-30-June24.pdf); [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem)
+
+**Overall confidence:** Low — confidence is High that public funded-deal counts exist and that official sources identify multiple bottlenecks; confidence is Low for the requested seeker/failure counts because the public denominator and attribution data do not appear to exist.
+
+## Evidence
+
+### What can be counted publicly: funded deals and funded companies
+
+NZGCP's Young Company Finance Autumn 2026 report says 2025 had **166 funded deals**, **$754 million invested**, a **14%** rise in deal volume, a **61%** rise in investment amount, and **47 new companies** invested in, compared with 46 in 2024 and 51 in 2023. [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf)
+
+The same report says POC-stage activity reached **33 deals** in 2025, up from 19 the prior year and representing **20% of total deals**, while POC investment stayed at or below **5% of total investment** over the past three years. [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf)
+
+NZGCP cautions that the Young Company Finance data comes from "voluntary collaboration among investors" and that transactions led by non-participating investors may not be included, so the report is a strong view of disclosed/furnished funded deals rather than a census of every raise or every attempted raise. [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf)
+
+Catalist's FY25 New Zealand Angel Market Report was blocked to the local fetch ladder in this run, but the stream-framing PR and secondary reporting both cite Catalist's FY25 figures as about **$13.9m** in angel-group investment across **167 deals**; I treat those as supportive context only because I could not independently extract the PDF in this turn. [Catalist PDF URL, blocked by tooling](https://cdn.catalist.co.nz/Documents/Reports/2025+Annual+New+Zealand+Angel+Market+Report.pdf); [b2bnews](https://b2bnews.co.nz/news/nz-startup-investment-hits-754m-but-new-company-pipeline-shrinks/)
+
+### What cannot be counted publicly: active seekers and failed raises
+
+The closest public startup-population denominator is Startup Genome's MBIE-commissioned assessment: it estimated about **2,400+ startups** in New Zealand and said its assessment used founder surveys and data analysis, 24 stakeholder interviews, and survey responses by city. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem); [MBIE assessment landing page](https://www.mbie.govt.nz/business-and-employment/economic-growth/previous-economic-development-work/startup-advisors-council/assessment-of-the-new-zealand-ecosystem)
+
+Upstart Nation says **176 founders** participated in the Startup Genome survey, but neither Upstart Nation nor the public Startup Genome deck publishes a yearly count of active fundraisers, unsuccessful fundraisers, or reasons why a raise failed. [Upstart Nation](https://www.mbie.govt.nz/assets/upstart-nation.pdf); [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem)
+
+Startup Genome's public report does publish funding-stage mix among survey respondents: **22%** reported no funding, **33%** reported only founders/friends/family funding so far, **11%** reported angel/grant/other pre-seed, **19%** seed, **9%** venture A, and **4%** venture B; those categories describe current funding stage, not whether the startup was actively seeking angel/seed funding that year. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem)
+
+NZGCP's 2024/25 SPE is the strongest official evidence that this is a known measurement gap: NZGCP wrote that Dealroom had been launched as an ecosystem-wide data collation/reporting mechanism and that "significant gaps in availability of data in relation to start-up companies and their fund-raising needs" made it challenging to assess investment-ecosystem development. [NZGCP SPE 2024/25](https://www.nzgcp.co.nz/assets/Media/NZGCP-SPE-2024-25-FINAL-30-June24.pdf)
+
+NZGCP's Dealroom page says the platform is intended as a free source of real-time data for founders, investors and ecosystem supporters, lets founders claim/update profiles, and helps founders search for relevant investors and use a matching tool, but the public page does not expose aggregate counts of active seekers, failed raises or failure reasons. [NZGCP Dealroom](https://www.nzgcp.co.nz/about-us/news-and-media/resources/dealroom)
+
+### Discovery/access evidence: real, but not quantified as the binding constraint
+
+Startup Genome found NZ founders receive less help from local investors and experts than many peer ecosystems, while NZ founders report relatively easy access to other founders. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem)
+
+Startup Genome also reported founder/stakeholder confusion over which programme best supported a startup, few available data points such as funding totals or startups reaching Series A/B, duplication among incubators and accelerators, and a lack of a clear pipeline to scaling success. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem)
+
+Upstart Nation's top recommendations included creating Accelerate Aotearoa to reduce fragmentation, growing underrepresented-community participation through that body, and implementing coordinated founder meetups and quality mentor connections, which is official support for a connectivity/friction problem. [Upstart Nation](https://www.mbie.govt.nz/assets/upstart-nation.pdf)
+
+This discovery/access evidence does **not** say what share of failed raises failed because founders could not find or reach the right investors, so it cannot establish discovery/access as the binding constraint. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem); [Upstart Nation](https://www.mbie.govt.nz/assets/upstart-nation.pdf)
+
+### Capital-scarcity evidence: also real
+
+MBIE's May 2025 briefing says pre-seed and seed markets are fragile, depend heavily on high-net-worth individual angel investors, and had regressed due to recent economic conditions. [MBIE Access to growth capital](https://www.mbie.govt.nz/dmsdocument/31135-access-growth-capital)
+
+The same MBIE briefing says market failures exist in capital markets because private capital does not always reach good commercial opportunities due to information problems between entrepreneurs, lenders and investors, so MBIE's diagnosis itself mixes access/information problems with capital-market fragility. [MBIE Access to growth capital](https://www.mbie.govt.nz/dmsdocument/31135-access-growth-capital)
+
+Young Company Finance reports that POC-stage deals increased in 2025 but POC investment remained similar to the prior year and only **5%** of H2 investment, and it says limited investment at the earliest stages is likely to persist without targeted POC/pre-seed incentives. [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf)
+
+Startup Genome found NZ early-stage funding gaps relative to Globalization-stage peers, fewer startups reaching seed and taking longer to do so, lower rates of seed-funded startups than the peer average through 2021, and an attrition funnel where Auckland and the rest of NZ tend to raise seed and Series A at lower rates. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem)
+
+The NZGCP/Dealroom 2025 report says New Zealand's funding levels remain well below OECD peers, NZ's seed-graduation rates are lower than the OECD average, and its early-stage VC definitions include pre-seed/seed/Series A rounds up to NZ$15m. [NZGCP / Dealroom New Zealand Tech Ecosystem Report 2025](https://www.nzgcp.co.nz/assets/Media/New-Zealand-2025-report.pdf)
+
+### Investment-readiness evidence: also plausible
+
+NZGCP's founder capital-raising guide frames the process as relationship-building, pitch deck, due diligence, information memorandum, data room, lead investor and term-sheet work, and says commercial traction or numbers-based growth is a highly influential factor in getting investors to invest. [NZGCP capital raising guide](https://www.nzgcp.co.nz/about-us/news-and-media/resources/a-guide-to-capital-raising-for-founders)
+
+Startup Genome reports that NZ VCs are relatively inexperienced compared with peer ecosystems despite increased funding, that founders still cite gaps in local mentorship expertise for global scaling, and that some research-intensive startups lack enough commercialisation funding to validate their products. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem)
+
+Those sources make investment-readiness/capability a credible failure reason, but they do not count what share of failed raises were declined because the startup was not fundable yet. [NZGCP capital raising guide](https://www.nzgcp.co.nz/about-us/news-and-media/resources/a-guide-to-capital-raising-for-founders); [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem)
+
+### Practical estimate boundaries
+
+The narrowest defensible 2025 success count is **47 newly funded companies**, because NZGCP explicitly says 47 new companies were invested in during 2025. [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf)
+
+The broader funded-activity count is **166 funded deals**, but that includes follow-on and later-stage rounds, so it should not be treated as 166 distinct first-time angel/seed successes. [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf)
+
+The broad ecosystem denominator is **about 2,400+ startups**, but subtracting 47 newly funded companies from 2,400 startups would produce a misleading "not newly funded" count, not a failed-raise count, because the public denominator includes startups at different stages, sectors, funding strategies and levels of investor-readiness. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem); [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf)
+
+## Surprising or load-bearing claims
+
+| Claim | Source 1 | Source 2 | Confidence |
+|---|---|---|---|
+| There is no public NZ count of startups actively seeking angel/seed funding each year, failed raises, or failed-raise reasons. | [NZGCP SPE 2024/25](https://www.nzgcp.co.nz/assets/Media/NZGCP-SPE-2024-25-FINAL-30-June24.pdf) says fundraising-needs data gaps make ecosystem assessment challenging. | [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem) and [Upstart Nation](https://www.mbie.govt.nz/assets/upstart-nation.pdf) publish survey/benchmarking outputs but not seeker/failure-reason counts. | Low for the negative existence claim; High that these checked sources do not contain it. |
+| At least 47 companies newly crossed the funding line in 2025, but that is a success lower bound, not a seeker denominator. | [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf) | [b2bnews summary of YCF](https://b2bnews.co.nz/news/nz-startup-investment-hits-754m-but-new-company-pipeline-shrinks/) | High for the count; Medium for interpretation because both trace to the YCF dataset. |
+| Discovery/access is evidenced as a real friction, but not as the binding constraint. | [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem) reports less help from investors/experts and programme confusion. | [Upstart Nation](https://www.mbie.govt.nz/assets/upstart-nation.pdf) recommends reducing fragmentation and coordinating founder meetups/mentor connections. | Medium |
+| Capital scarcity is also evidenced as a real bottleneck. | [MBIE Access to growth capital](https://www.mbie.govt.nz/dmsdocument/31135-access-growth-capital) says pre-seed/seed markets are fragile and recently regressed. | [NZGCP Young Company Finance Autumn 2026](https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf) says earliest-stage investment remains limited; [Dealroom 2025](https://www.nzgcp.co.nz/assets/Media/New-Zealand-2025-report.pdf) says funding is below OECD peers. | High |
+| Investment-readiness/capability is a credible third explanation, not noise. | [NZGCP capital raising guide](https://www.nzgcp.co.nz/about-us/news-and-media/resources/a-guide-to-capital-raising-for-founders) describes diligence, traction and lead-investor requirements. | [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem) reports gaps in mentorship, VC experience and commercialisation validation. | Medium |
+
+## What would change this conclusion
+
+- A Dealroom/NZGCP export that counts NZ companies marked "actively raising" by year, round type, target amount, outcome, and reason for non-close would replace the current "not publicly measurable" conclusion. [NZGCP Dealroom](https://www.nzgcp.co.nz/about-us/news-and-media/resources/dealroom)
+- Matched funnel data from AANZ member groups, NZGCP Aspire referrals, university incubators, Creative HQ, Ministry of Awesome, Icehouse Ventures, Sprout and other programmes could quantify applications, pitches, investor meetings, term sheets, closes and referral outcomes. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem); [Creative HQ impact report 2025](https://creativehq.co.nz/wp-content/uploads/2025/10/Creative-HQ_2025_impact_report.pdf)
+- A representative founder survey that asks "Did you seek angel/seed funding in the past 12 months?", "Did you close?", and "What was the primary reason you did not close?" with forced-choice categories for discovery/access, capital scarcity, investor fit, traction/readiness, terms, founder choice and other would directly answer the issue. [Upstart Nation](https://www.mbie.govt.nz/assets/upstart-nation.pdf)
+- I could not verify any public NZ founder-sentiment survey that assigns shares to discovery/access versus capital scarcity versus investment-readiness for failed angel/seed raises. [Startup Genome / MBIE assessment](https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem); [NZGCP SPE 2024/25](https://www.nzgcp.co.nz/assets/Media/NZGCP-SPE-2024-25-FINAL-30-June24.pdf)
+- I could not independently extract Catalist's FY25 Angel Market Report PDF through the local fetch ladder; `scripts/fetch.mjs` classified both tested Catalist PDF URLs as **BLOCKED** by tooling, not dead. The finding therefore relies on NZGCP/YCF for funded-deal counts and treats Catalist as context only. [Catalist PDF URL](https://cdn.catalist.co.nz/Documents/Reports/2025+Annual+New+Zealand+Angel+Market+Report.pdf)
+
+## Open follow-up questions
+
+- What Dealroom fields are visible to NZGCP or ecosystem administrators but not public, and can they be aggregated without exposing company-level confidential data?
+- Which NZ angel networks, accelerators and university incubators already collect failed-raise reasons, and would they share aggregated funnel counts?
+- What is the minimum viable founder survey instrument to separate "couldn't find/reach investors" from "found them but got a no" from "not investment-ready yet"?
+
+## Sources
+
+1. NZGCP. "Young Company Finance - Autumn 2026." Accessed 3 July 2026. https://www.nzgcp.co.nz/assets/Media/NZGCP-YCF-Autumn-2026.pdf
+2. NZGCP. "Dealroom." Accessed 3 July 2026. https://www.nzgcp.co.nz/about-us/news-and-media/resources/dealroom
+3. NZGCP. "Statement of Performance Expectations 2024/25." Accessed 3 July 2026. https://www.nzgcp.co.nz/assets/Media/NZGCP-SPE-2024-25-FINAL-30-June24.pdf
+4. Startup Genome / MBIE. "Assessing New Zealand's Startup Ecosystem." Published 17 April 2023. Accessed 3 July 2026. https://www.mbie.govt.nz/dmsdocument/26386-assessing-new-zealands-startup-ecosystem
+5. Startup Advisors Council / MBIE. "Upstart Nation." 2023. Accessed 3 July 2026. https://www.mbie.govt.nz/assets/upstart-nation.pdf
+6. MBIE. "Access to growth capital." 9 May 2025. Accessed 3 July 2026. https://www.mbie.govt.nz/dmsdocument/31135-access-growth-capital
+7. NZGCP / Dealroom. "New Zealand Tech Ecosystem Report 2025." August 2025. Accessed 3 July 2026. https://www.nzgcp.co.nz/assets/Media/New-Zealand-2025-report.pdf
+8. NZGCP. "A guide to capital raising for founders." 30 May 2021. Accessed 3 July 2026. https://www.nzgcp.co.nz/about-us/news-and-media/resources/a-guide-to-capital-raising-for-founders
+9. b2bnews. "NZ startup investment hits $754m but new company pipeline shrinks." Accessed 3 July 2026. https://b2bnews.co.nz/news/nz-startup-investment-hits-754m-but-new-company-pipeline-shrinks/
+10. Creative HQ. "Creative HQ 2025 impact report." Accessed 3 July 2026. https://creativehq.co.nz/wp-content/uploads/2025/10/Creative-HQ_2025_impact_report.pdf
+11. Catalist. "2025 Annual New Zealand Angel Market Report." Access attempted 3 July 2026; local fetch classified as BLOCKED by tooling, not dead. https://cdn.catalist.co.nz/Documents/Reports/2025+Annual+New+Zealand+Angel+Market+Report.pdf


### PR DESCRIPTION
Closes #141. Stream: #110. Finds that NZ public data counts funded deals, not active seekers or failed-raise reasons; discovery/access remains unproven against capital scarcity and investment-readiness without a founder/funnel survey.