### PR TITLE
fix: stream overviews say awaiting-direction once the synthesis draft exists

### DIFF
--- a/streams/2-small-nz-charities-miss-grants-they-re-eligible-fo.md
+++ b/streams/2-small-nz-charities-miss-grants-they-re-eligible-fo.md
@@ -1,7 +1,7 @@
 ---
 stream: 2
 title: "Small charities miss grants they're eligible for"
-state: needs-synthesis
+state: awaiting-direction
 steward: ""
 domain: grant-access
 updated: 2026-07-02

--- a/streams/3-council-spending-is-public-but-not-legible-to-citi.md
+++ b/streams/3-council-spending-is-public-but-not-legible-to-citi.md
@@ -1,7 +1,7 @@
 ---
 stream: 3
 title: "Council spending is public but not legible to citizens"
-state: needs-synthesis
+state: awaiting-direction
 steward: ""
 domain: civic-transparency
 updated: 2026-07-03

--- a/streams/60-consumer-credit-cost-fee-transparency-for-new-zeal.md
+++ b/streams/60-consumer-credit-cost-fee-transparency-for-new-zeal.md
@@ -1,7 +1,7 @@
 ---
 stream: 60
 title: "The true cost of small loans is hard for New Zealanders to see or compare"
-state: needs-synthesis
+state: awaiting-direction
 steward: ""
 domain: other
 updated: 2026-07-02

--- a/streams/61-supermarket-price-promotion-transparency-for-nz-ho.md
+++ b/streams/61-supermarket-price-promotion-transparency-for-nz-ho.md
@@ -1,7 +1,7 @@
 ---
 stream: 61
 title: "Shoppers can't tell a real supermarket deal from a manufactured one"
-state: needs-synthesis
+state: awaiting-direction
 steward: ""
 domain: other
 updated: 2026-07-03

--- a/streams/TEMPLATE.md
+++ b/streams/TEMPLATE.md
@@ -1,7 +1,7 @@
 ---
 stream: 0                      # the root Discover issue number
 title: ""                      # plain-language name, e.g. "Small charities miss grants they qualify for"
-state: researching             # framing | researching | needs-synthesis | ideating | building | shipped
+state: researching             # framing | researching | needs-synthesis | awaiting-direction | ideating | building | shipped
 steward: ""                    # GitHub handle of the human who owns direction
 domain: ""                     # child-welfare | grant-access | civic-transparency | ai-policy | biosecurity | other
 updated: YYYY-MM-DD

--- a/synthesize_work.sh
+++ b/synthesize_work.sh
@@ -142,8 +142,10 @@ exactly. Rules:
   wish, up to three one-line, clearly non-binding signals the steward may
   weigh, prefixed "Signal:"):
 > **TODO(steward): direction decision** — go deeper / pivot / proceed / park.
-- Frontmatter: stream: $n, title (plain-language), state: needs-synthesis,
-  domain: ${domain:-other}, updated: $today. ${resynth:+Preserve the existing steward value.}
+- Frontmatter: stream: $n, title (plain-language), state: awaiting-direction
+  (this draft IS the synthesis — once it merges the stream is waiting on the
+  human steward, and the overview must say so), domain: ${domain:-other},
+  updated: $today. ${resynth:+Preserve the existing steward value, and if the steward already advanced state past awaiting-direction (ideating/building/shipped), keep THEIR value.}
 - Do NOT touch ANY file other than $path. Do NOT open issues, close anything,
   change labels, or merge. Direction is not yours to set.
 


### PR DESCRIPTION
## Problem

Merged stream overviews (and the website, which treats the doc's `state:` frontmatter as the source of truth) kept saying **needs-synthesis** after synthesis was done. Cause: `synthesize_work.sh`'s prompt hardcoded `state: needs-synthesis` into the frontmatter of the very draft that *is* the synthesis.

The moment that draft merges is gate **G1** — the human steward grades the evidence, picks/edits/rejects the candidate outcomes, and writes the direction decision — so the state should read `awaiting-direction`.

## Changes

- **synthesize_work.sh**: the prompt now writes `state: awaiting-direction`; on re-synthesis, a state the steward already advanced (ideating/building/shipped) is preserved.
- **streams/TEMPLATE.md**: `awaiting-direction` added to the state vocabulary.
- **streams/{2,3,60,61}**: frontmatter-only repair of the four merged overviews (maintainer-directed — no prose or steward content touched). The web UI already has an `awaiting-direction` chip and maps it to the Synthesis stage, so no web changes needed.

## Related live repairs (already done, not in this diff)

Roots #2 and #60 were wedged at `status: in-review` and #3 carried `in-review` + `awaiting-direction` — leftovers of the pre-ADR-0011 hand-off bug whose PRs have since merged (out of reach of the new reconciler). All four roots now sit at `status: awaiting-direction`, which is the human steward queue.

Labelled `review: human-only`: touches a pipeline prompt and streams/ overview files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)