### PR TITLE
runners: detect API usage limits and back off 60m (no false failures)

### DIFF
--- a/review_work.sh
+++ b/review_work.sh
@@ -323,6 +323,21 @@ review_one() {  # $1 = PR number
     return "$agent_status"
   fi
 
+  # The REVIEWER ran out of API budget (usage cap / provider rate limit). That's
+  # a temporary tooling condition, not a defect in this PR — so do NOT post a
+  # diagnostic or touch the merge check (that's the false "failure" we were
+  # spamming onto PRs like #174). Release the claim, back off, and let a later
+  # loop re-review once the limit resets.
+  if was_usage_limited "$tmp"; then
+    warn "Review of PR #$pr hit an API usage/rate limit — NOT posting a failure. Backing off ${USAGE_LIMIT_SLEEP}s before continuing."
+    rm -f "$tmp" "$fallback_review_file"
+    release_pr "$pr"; CLAIMED_PR=""
+    remove_worktree
+    git -C "$REPO_DIR" update-ref -d "refs/fg/pr-$pr" 2>/dev/null || true
+    sleep "$USAGE_LIMIT_SLEEP"
+    return 75   # temporary failure — loop just retries; PR state untouched
+  fi
+
   local body_file=""
   if [ -s "$REVIEW_FILE" ]; then
     body_file="$REVIEW_FILE"

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -13,6 +13,7 @@ AGENT_TIMEOUT="${AGENT_TIMEOUT:-2400}"   # seconds per agent run (0 = none)
 CLAIM_TTL="${CLAIM_TTL:-7200}"           # secs a claimed-but-undelivered issue is held before reap.sh frees it
 CLAIM_SETTLE="${CLAIM_SETTLE:-8}"        # base secs to let racing claimants' assignments settle before the tie-break
 REWORK_TTL="${REWORK_TTL:-7200}"         # secs a sent-back rework is held for its author before reap.sh frees it
+USAGE_LIMIT_SLEEP="${USAGE_LIMIT_SLEEP:-3600}"  # secs to back off when an agent hits an API usage/rate limit (60 min)
 REVIEW_CHECK_CONTEXT="for-good/adversarial-review"
 RUNS_AGENT="${RUNS_AGENT:-0}"             # scripts that call run_agent set this to 1
 
@@ -310,6 +311,18 @@ set_status_label() {  # $1 issue, $2 new-status (bare, e.g. in-review), $3.. old
 # run_agent to stop reliably.
 was_interrupted() {  # $1 = exit status
   case "$1" in 130|143) return 0 ;; *) return 1 ;; esac
+}
+
+# An agent that ran out of API budget (usage cap / provider rate limit) is a
+# TEMPORARY tooling condition, NOT a defect in the work — so callers must back
+# off and retry later instead of posting a failure or mangling issue/PR state.
+# Only the TAIL of the captured output is inspected: a real limit surfaces as a
+# fatal message at the very end of the run, so a finding that merely *discusses*
+# rate limits in its body won't trip this.
+was_usage_limited() {  # $1 = path to captured agent stdout+stderr
+  [ -s "${1:-}" ] || return 1
+  tail -n 40 "$1" | grep -qiE \
+    'usage limit|rate[ _-]?limit|too many requests|\b429\b|quota|overloaded|resource[_ ]exhausted|insufficient_quota|limit reached|try again later|retry after|resets? (at|in)'
 }
 
 # ---- agent runner ----

--- a/start_work.sh
+++ b/start_work.sh
@@ -257,8 +257,21 @@ work_one() {  # $1 = issue number
   fi
   make_worktree origin/main || { err "Couldn't create worktree for #$n — skipping."; return 1; }
   info "Handing #$n to $AGENT (worktree: $WORKTREE)..."
-  set +e; run_agent "$(work_prompt "$n")" "$WORKTREE"; local rc=$?; set -e
-  was_interrupted "$rc" && release_on_interrupt   # Ctrl-C the agent → stop the whole run, don't roll to the next issue
+  local tmp; tmp="$(mktemp)"
+  set +e; run_agent "$(work_prompt "$n")" "$WORKTREE" 2>&1 | tee "$tmp"; local rc=${PIPESTATUS[0]}; set -e
+  was_interrupted "$rc" && { rm -f "$tmp"; release_on_interrupt; }   # Ctrl-C the agent → stop the whole run, don't roll to the next issue
+  # Usage/rate limit: back off and release the issue quietly (no "finished
+  # without a PR" comment — that's a false failure), so a later loop retries it.
+  if was_usage_limited "$tmp"; then
+    warn "#$n hit an API usage/rate limit — releasing quietly and backing off ${USAGE_LIMIT_SLEEP}s (no failure posted)."
+    rm -f "$tmp"; remove_worktree
+    set_status_label "$n" "available" "claimed"
+    gh issue edit "$n" --repo "$REPO" --remove-assignee "@me" >/dev/null 2>&1 || true
+    CLAIMED_ISSUE=""
+    sleep "$USAGE_LIMIT_SLEEP"
+    return 0
+  fi
+  rm -f "$tmp"
   if [ "$rc" -eq 0 ]; then ok "Agent run complete for #$n"; else err "Agent run failed/aborted for #$n (exit $rc)"; fi
   remove_worktree
   finish_issue "$n"
@@ -315,8 +328,18 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
   before="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"
   make_worktree "origin/$branch" || { err "Couldn't create worktree for PR #$pr (branch $branch) — leaving #$n for a future loop."; return 1; }
   info "Handing PR #$pr rework to $AGENT (worktree: $WORKTREE)..."
-  set +e; run_agent "$(rework_prompt "$n" "$pr" "$branch")" "$WORKTREE"; local rc=$?; set -e
-  was_interrupted "$rc" && release_on_interrupt   # Ctrl-C the agent → stop the whole run
+  local tmp; tmp="$(mktemp)"
+  set +e; run_agent "$(rework_prompt "$n" "$pr" "$branch")" "$WORKTREE" 2>&1 | tee "$tmp"; local rc=${PIPESTATUS[0]}; set -e
+  was_interrupted "$rc" && { rm -f "$tmp"; release_on_interrupt; }   # Ctrl-C the agent → stop the whole run
+  # Usage/rate limit: back off and leave #$n as 'changes-requested' for a future
+  # loop (no commits pushed, no status churn, no failure posted).
+  if was_usage_limited "$tmp"; then
+    warn "Rework of #$n hit an API usage/rate limit — leaving it 'changes-requested' and backing off ${USAGE_LIMIT_SLEEP}s (no failure posted)."
+    rm -f "$tmp"; remove_worktree
+    sleep "$USAGE_LIMIT_SLEEP"
+    return 0
+  fi
+  rm -f "$tmp"
   if [ "$rc" -eq 0 ]; then ok "Rework agent run complete for #$n"; else err "Rework agent run failed/aborted for #$n (exit $rc)"; fi
   remove_worktree
   after="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"


### PR DESCRIPTION
**What Adam flagged on #174:** a reviewer that ran out of API budget posted a `review failed` diagnostic — a false failure, not a defect in the PR.

**Fix.** Treat a usage cap / provider rate limit as a temporary tooling condition and back off instead of posting a failure.

- `scripts/fg-common.sh`: new `was_usage_limited()` (inspects only the **tail** of captured agent output, so a finding that merely *discusses* rate limits doesn't trip it) + `USAGE_LIMIT_SLEEP` (default **3600s / 60 min**).
- `review_work.sh`: on a detected limit, **skip the diagnostic comment and leave the merge check untouched**, release the claim, `sleep 60m`, and let a later loop re-review.
- `start_work.sh` (work + rework): capture agent output via `tee`, and on a limit back off 60m — releasing the issue **quietly** (work) or leaving it `changes-requested` (rework), with **no failure comment**.

Matches signatures across claude/codex/hermes: `usage limit`, `rate limit`, `429`, `quota`, `overloaded`, `resource_exhausted`, `insufficient_quota`, `limit reached`, `retry after`, `resets at/in`.

All three scripts `bash -n` clean; detector self-tested (clean output → not limited; usage-limit line and `429` → detected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)