### PR TITLE
web: two-door hero, plain-language states, forwardable stream briefs

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -12,10 +12,10 @@ type NavGroup = { label: string; items: NavItem[] };
 
 const LINKS: NavItem[] = [
   { to: "/", label: "Dashboard", end: true },
+  { to: "/partners", label: "For partners" },
   { to: "/live", label: "Live" },
   { to: "/board", label: "Board" },
   { to: "/streams", label: "Streams" },
-  { to: "/partners", label: "For partners" },
 ];
 
 const GROUPS: NavGroup[] = [
@@ -31,7 +31,7 @@ const GROUPS: NavGroup[] = [
     label: "Community",
     items: [
       { to: "/leaderboard", label: "Leaderboard" },
-      { to: "/contribute", label: "Get started" },
+      { to: "/contribute", label: "Contribute" },
       { to: "/methodology", label: "Method" },
       { to: "/decisions", label: "Decisions" },
     ],

--- a/web/src/components/shared/Markdown.tsx
+++ b/web/src/components/shared/Markdown.tsx
@@ -1,8 +1,9 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { resolveDocHref } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
-export function Markdown({ children, className }: { children: string; className?: string }) {
+export function Markdown({ children, className, linkBase }: { children: string; className?: string; linkBase?: string }) {
   return (
     <div className={cn(
       "text-sm leading-relaxed text-foreground/90 [&_a]:text-brand-cyan-dark [&_a]:underline [&_a]:underline-offset-2",
@@ -13,7 +14,16 @@ export function Markdown({ children, className }: { children: string; className?
       "[&_blockquote]:border-l-2 [&_blockquote]:border-brand-cyan [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground",
       className
     )}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={linkBase ? {
+          a: ({ href, children: linkChildren, ...props }) => (
+            <a {...props} href={resolveDocHref(href, linkBase)} target="_blank" rel="noreferrer">{linkChildren}</a>
+          ),
+        } : undefined}
+      >
+        {children}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -27,3 +27,24 @@ export function cleanTitle(title: string): string {
 export function pct(n: number, total: number): number {
   return total > 0 ? Math.round((n / total) * 100) : 0;
 }
+
+// Resolve a repo-relative markdown href (e.g. "../research/findings/x.md")
+// against the source doc's GitHub blob URL so it doesn't 404 on-site.
+// Absolute URLs, anchors and root-relative paths pass through untouched.
+export function resolveDocHref(href: string | undefined, base: string): string | undefined {
+  if (!href || !base) return href;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith("#") || href.startsWith("/")) return href;
+  try {
+    return new URL(href, base).toString();
+  } catch {
+    return href;
+  }
+}
+
+// "3 Jul 2026" — the plain-words date used in forwardable briefs.
+export function shortDate(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-NZ", { day: "numeric", month: "short", year: "numeric" });
+}

--- a/web/src/lib/meta.ts
+++ b/web/src/lib/meta.ts
@@ -9,17 +9,29 @@ export const STAGE_META: Record<Stage, { label: string; color: string; ring: str
   none: { label: "Unsorted", color: "#78716C", ring: "ring-stone-300", icon: CircleDot, blurb: "Not yet triaged" },
 };
 
+// Labels are plain language on purpose — partners and visitors see these, so
+// no repo jargon ("needs-synthesis", "claimed") leaks through.
 export const STATUS_META: Record<StatusKey, { label: string; color: string; text: string }> = {
-  available: { label: "Available", color: "#0E8A16", text: "text-emerald-700" },
-  claimed: { label: "Claimed", color: "#B8860B", text: "text-amber-700" },
-  "in-review": { label: "In review", color: "#1D76DB", text: "text-blue-700" },
-  "changes-requested": { label: "Changes requested", color: "#D93F0B", text: "text-orange-700" },
-  "needs-synthesis": { label: "Needs synthesis", color: "#14B8A6", text: "text-teal-700" },
-  "awaiting-direction": { label: "Awaiting direction", color: "#8250DF", text: "text-purple-700" },
+  available: { label: "Open for pickup", color: "#0E8A16", text: "text-emerald-700" },
+  claimed: { label: "In progress", color: "#B8860B", text: "text-amber-700" },
+  "in-review": { label: "Being checked", color: "#1D76DB", text: "text-blue-700" },
+  "changes-requested": { label: "Fixes requested", color: "#D93F0B", text: "text-orange-700" },
+  "needs-synthesis": { label: "Being summarised", color: "#14B8A6", text: "text-teal-700" },
+  "awaiting-direction": { label: "Waiting on a human decision", color: "#8250DF", text: "text-purple-700" },
   blocked: { label: "Blocked", color: "#B60205", text: "text-red-700" },
   done: { label: "Done", color: "#5319E7", text: "text-violet-700" },
   none: { label: "New", color: "#78716C", text: "text-stone-600" },
 };
+
+// Translate any raw state string (issue status label or stream doc lifecycle
+// state) into a partner-friendly label; unknown states fall back to the raw
+// string, capitalised.
+export function statusLabel(state: string): string {
+  if (!state) return "";
+  const m = STATUS_META[state as StatusKey];
+  if (m) return m.label;
+  return state.charAt(0).toUpperCase() + state.slice(1);
+}
 
 export const DOMAIN_LABELS: Record<string, string> = {
   "child-welfare": "Child welfare",

--- a/web/src/lib/streams.ts
+++ b/web/src/lib/streams.ts
@@ -1,5 +1,6 @@
-import type { IssueLite, Finding, Stage } from "./types";
-import { STAGE_ORDER } from "./meta";
+import type { IssueLite, Finding, Stage, StreamDoc } from "./types";
+import { STAGE_ORDER, statusLabel } from "./meta";
+import { resolveDocHref, shortDate } from "./format";
 
 // issue number -> stream number, from the stream:<n> label.
 export function issueStreamMap(issues: IssueLite[]): Map<number, number> {
@@ -87,6 +88,63 @@ export function isStreamShipped(state: string): boolean {
 // treatment on the Streams and StreamDetail pages.
 export function isAwaitingDirection(state: string): boolean {
   return (state || "").toLowerCase().includes("direction");
+}
+
+// Strip editorial scaffolding from a stream overview before showing it to a
+// partner: steward TODO callouts, and a "Feedback log" section whose table
+// has no filled-in rows yet.
+export function stripEditorialDebris(body: string): string {
+  const lines = (body || "").split("\n").filter((l) => !(/^\s*>/.test(l) && l.includes("TODO(steward)")));
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (/^##\s+Feedback log\s*$/i.test(lines[i])) {
+      let end = lines.length;
+      for (let j = i + 1; j < lines.length; j++) if (/^##\s/.test(lines[j])) { end = j; break; }
+      // Table rows past the header + separator; keep the section only if any
+      // cell actually has content.
+      const dataRows = lines.slice(i + 1, end).filter((l) => /^\s*\|/.test(l)).slice(2);
+      const hasContent = dataRows.some((r) => r.split("|").some((c) => c.trim().length > 0));
+      if (hasContent) out.push(...lines.slice(i, end));
+      i = end;
+      continue;
+    }
+    out.push(lines[i]);
+    i++;
+  }
+  return out.join("\n").trim();
+}
+
+// A single "## Heading" section's body (up to the next h2), or "".
+function mdSection(body: string, heading: RegExp): string {
+  const lines = body.split("\n");
+  const start = lines.findIndex((l) => /^##\s/.test(l) && heading.test(l));
+  if (start === -1) return "";
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) if (/^##\s/.test(lines[i])) { end = i; break; }
+  return lines.slice(start + 1, end).join("\n").trim();
+}
+
+// A plain-text/markdown brief a partner can forward as-is: opens with "What we
+// know now" (the problem paragraph + the learned-so-far bullets), a plain-words
+// date + state line, and absolute source links — no badges, harness or repo
+// mechanics.
+export function buildStreamBrief(doc: StreamDoc): string {
+  const body = stripEditorialDebris(doc.body || "");
+  // Rewrite repo-relative markdown links against the doc's GitHub blob URL so
+  // every link in the brief works outside the site.
+  const absolute = (md: string) => md.replace(/\]\(([^()\s]+)\)/g, (_m, href: string) => `](${resolveDocHref(href, doc.url) ?? href})`);
+  const problem = mdSection(body, /problem/i);
+  const learned = mdSection(body, /learned/i);
+  const date = shortDate(doc.updated);
+  const state = statusLabel(doc.state).toLowerCase();
+  const statusLine = `${date ? `Evidence gathered as of ${date}` : "Evidence gathered to date"}${state ? ` — ${state}` : ""}.`;
+  const parts: string[] = [doc.title, "", "What we know now", ""];
+  if (problem) parts.push(absolute(problem), "");
+  if (learned) parts.push(absolute(learned), "");
+  parts.push(statusLine);
+  if (doc.url) parts.push("", `Full overview: ${doc.url}`);
+  return parts.join("\n");
 }
 
 // The agent frontmatter value → a human harness label.

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { Activity, BookOpen, FolderGit2, Link2, Users, ArrowRight, ScanEye } from "lucide-react";
+import { Activity, BookOpen, FolderGit2, HeartHandshake, Link2, Users, ArrowRight, ScanEye, Wrench } from "lucide-react";
 import {
   ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip as RTooltip, Cell,
 } from "recharts";
@@ -30,7 +30,7 @@ export default function Dashboard() {
       <section className="relative overflow-hidden rounded-3xl border border-border bg-card px-6 py-12 md:px-12 md:py-16">
         <div className="pointer-events-none absolute -left-24 -top-24 h-72 w-72 rounded-full bg-brand-indigo/10 blur-3xl" />
         <div className="pointer-events-none absolute -right-24 -top-10 h-72 w-72 rounded-full bg-brand-cyan/10 blur-3xl" />
-        <div className="relative max-w-3xl animate-fade-in">
+        <div className="relative max-w-4xl animate-fade-in">
           <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-border bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground">
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" /> Open research commons · by thecolab.ai
           </div>
@@ -40,12 +40,52 @@ export default function Dashboard() {
           </h1>
           <p className="mt-5 max-w-2xl text-lg text-muted-foreground">
             People and AI agents, working the same queue — discovering problems, researching them with citations,
-            ideating solutions, and building real things. Bring your spare tokens and pick up a piece.
+            ideating solutions, and building real things.
           </p>
-          <div className="mt-7 flex flex-wrap gap-3">
-            <Link to="/live"><Button variant="brand" size="lg">Watch the work live <ArrowRight className="h-4 w-4" /></Button></Link>
-            <Link to="/board"><Button variant="outline" size="lg">Explore the board</Button></Link>
-            {repo.url ? <a href={`${repo.url}/blob/main/CONTRIBUTING.md`} target="_blank" rel="noreferrer"><Button variant="ghost" size="lg">Read the method</Button></a> : null}
+
+          {/* Two doors: a visitor should know which one is theirs within seconds. */}
+          <div className="mt-8 grid gap-4 md:grid-cols-2">
+            <Link to="/partners" className="group">
+              <Card className="flex h-full flex-col border-l-2 border-l-brand-navy p-6 transition-all hover:-translate-y-0.5 hover:shadow-md dark:border-l-brand-cyan">
+                <div className="flex items-center gap-2.5">
+                  <div className="rounded-lg bg-brand-navy/10 p-2 dark:bg-brand-cyan/10"><HeartHandshake className="h-5 w-5 text-brand-navy dark:text-brand-cyan" /></div>
+                  <div className="font-serif text-xl font-bold group-hover:text-brand-cyan-dark">Bring a problem</div>
+                </div>
+                <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+                  For charities, councils and policy teams. You carry a real NZ problem.
+                  We build rigorous, cited evidence around it — free.
+                </p>
+                <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-brand-cyan-dark">
+                  How partnering works <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                </span>
+              </Card>
+            </Link>
+            <Link to="/contribute" className="group">
+              <Card className="flex h-full flex-col border-l-2 border-l-brand-cyan p-6 transition-all hover:-translate-y-0.5 hover:shadow-md">
+                <div className="flex items-center gap-2.5">
+                  <div className="rounded-lg bg-brand-cyan/10 p-2"><Wrench className="h-5 w-5 text-brand-cyan-dark" /></div>
+                  <div className="font-serif text-xl font-bold group-hover:text-brand-cyan-dark">Bring capacity</div>
+                </div>
+                <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+                  For contributors. Bring your skills, your agents, or your spare AI tokens
+                  and pick up a piece of the queue.
+                </p>
+                <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-brand-cyan-dark">
+                  Start contributing <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                </span>
+              </Card>
+            </Link>
+          </div>
+
+          <div className="mt-5 flex flex-wrap items-center gap-4 text-sm">
+            <Link to="/live" className="inline-flex items-center gap-1.5 font-medium text-muted-foreground hover:text-foreground">
+              <span className="relative flex h-2 w-2">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+              </span>
+              Or just watch the work live <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+            {repo.url ? <a href={`${repo.url}/blob/main/CONTRIBUTING.md`} target="_blank" rel="noreferrer" className="text-muted-foreground hover:text-foreground">Read the method</a> : null}
           </div>
         </div>
       </section>
@@ -151,7 +191,7 @@ export default function Dashboard() {
               <div className="shrink-0 rounded-lg bg-blue-100 p-2 dark:bg-blue-900/50"><ScanEye className="h-5 w-5 text-blue-700 dark:text-blue-300" /></div>
               <div className="min-w-0">
                 <div className="font-serif font-semibold">{reviewQueue.length} item{reviewQueue.length > 1 ? "s" : ""} need human review</div>
-                <div className="text-sm text-muted-foreground">Findings and PRs waiting for someone to check the work.</div>
+                <div className="text-sm text-muted-foreground">Findings and submitted work waiting for someone to check.</div>
               </div>
             </div>
             <ArrowRight className="h-5 w-5 shrink-0 text-muted-foreground" />

--- a/web/src/pages/IssueDetail.tsx
+++ b/web/src/pages/IssueDetail.tsx
@@ -9,6 +9,7 @@ import { StageBadge, StatusBadge, DomainBadge } from "@/components/shared/Badges
 import { PersonAvatar } from "@/components/shared/PersonAvatar";
 import { Markdown } from "@/components/shared/Markdown";
 import { relativeTime } from "@/lib/format";
+import type { Stage } from "@/lib/types";
 
 export default function IssueDetail() {
   const { number } = useParams();
@@ -110,7 +111,23 @@ export default function IssueDetail() {
           <Card>
             <CardHeader><CardTitle className="text-sm uppercase tracking-wide text-muted-foreground">Labels</CardTitle></CardHeader>
             <CardContent className="flex flex-wrap gap-1.5">
-              {issue.labels.map((l) => <span key={l} className="rounded-md border border-border bg-secondary/50 px-2 py-0.5 text-xs">{l}</span>)}
+              {/* Raw repo labels get translated for visitors: status:* is hidden
+                  (the StatusBadge above already says it in plain words), stage:*
+                  renders as the stage badge, stream:<n> links to the stream. */}
+              {issue.labels.map((l) => {
+                if (/^status:/i.test(l)) return null;
+                const stage = l.match(/^stage:\s*(\S+)$/i);
+                if (stage) return <StageBadge key={l} stage={stage[1].toLowerCase() as Stage} />;
+                const stream = l.match(/^stream:\s*(\d+)$/i);
+                if (stream) {
+                  return (
+                    <Link key={l} to={`/streams/${stream[1]}`} className="rounded-md border border-border bg-secondary/50 px-2 py-0.5 text-xs transition-colors hover:bg-secondary hover:text-brand-cyan-dark">
+                      Stream #{stream[1]}
+                    </Link>
+                  );
+                }
+                return <span key={l} className="rounded-md border border-border bg-secondary/50 px-2 py-0.5 text-xs">{l}</span>;
+              })}
             </CardContent>
           </Card>
 

--- a/web/src/pages/Review.tsx
+++ b/web/src/pages/Review.tsx
@@ -32,7 +32,7 @@ export default function Review() {
 
       <h2 className="mb-3 flex items-center gap-2 font-serif text-xl font-semibold"><ScanEye className="h-5 w-5" /> In the review queue</h2>
       {queue.length === 0 ? (
-        <EmptyState icon={ShieldCheck} title="Nothing waiting">No open PRs or in-review work right now. New submissions show up here for a human to check.</EmptyState>
+        <EmptyState icon={ShieldCheck} title="Nothing waiting">No submitted work waiting to be checked right now. New submissions show up here for a human to check.</EmptyState>
       ) : (
         <div className="space-y-3">
           {queue.map((i) => (
@@ -40,7 +40,7 @@ export default function Review() {
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span className="font-mono">#{i.number}</span>
-                  {i.isPR ? <span className="inline-flex items-center gap-1 text-violet-600"><GitPullRequest className="h-3.5 w-3.5" /> pull request</span> : <StageBadge stage={i.stage} />}
+                  {i.isPR ? <span className="inline-flex items-center gap-1 text-violet-600"><GitPullRequest className="h-3.5 w-3.5" /> submitted work</span> : <StageBadge stage={i.stage} />}
                   <DomainBadge domain={i.domain} />
                   <span className="ml-auto">{relativeTime(i.updatedAt)}</span>
                 </div>

--- a/web/src/pages/StreamDetail.tsx
+++ b/web/src/pages/StreamDetail.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, FileText, Network, Users, Cpu, Wrench, ScrollText, ExternalLink, Lightbulb, ArrowRight, UserCheck } from "lucide-react";
+import { ArrowLeft, Check, Copy, FileText, Network, Users, Cpu, Wrench, ScrollText, ExternalLink, Lightbulb, ArrowRight, UserCheck } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { EmptyState } from "@/components/shared/EmptyState";
@@ -11,8 +11,10 @@ import { PersonAvatar } from "@/components/shared/PersonAvatar";
 import { DomainBadge } from "@/components/shared/Badges";
 import { StreamProgress } from "@/components/shared/StreamProgress";
 import { buildStreamChains, type ChainNode } from "@/lib/lineage";
-import { findingsForStream, streamStateStyle, harnessLabel, isAwaitingDirection } from "@/lib/streams";
+import { findingsForStream, streamStateStyle, harnessLabel, isAwaitingDirection, stripEditorialDebris, buildStreamBrief } from "@/lib/streams";
+import { statusLabel } from "@/lib/meta";
 import { cleanTitle } from "@/lib/format";
+import type { StreamDoc } from "@/lib/types";
 
 const alwaysMatches = () => true;
 
@@ -28,6 +30,26 @@ function excerpt(body: string, max = 320): string {
     .replace(/\s+/g, " ")
     .trim();
   return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
+}
+
+// Builds the forwardable plain-text brief and puts it on the clipboard —
+// something a partner can paste straight into an email.
+function CopyBriefButton({ doc }: { doc: StreamDoc }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(buildStreamBrief(doc));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable (permissions / insecure context) — nothing to do */
+    }
+  };
+  return (
+    <button type="button" onClick={onCopy} className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-secondary">
+      {copied ? <><Check className="h-3.5 w-3.5 text-emerald-600" /> Copied</> : <><Copy className="h-3.5 w-3.5" /> Copy brief</>}
+    </button>
+  );
 }
 
 function StepHeader({ n, icon: Icon, label }: { n: number; icon: typeof FileText; label: string }) {
@@ -101,7 +123,7 @@ export default function StreamDetail() {
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <span className="font-mono text-xs text-muted-foreground">Stream #{streamNum}</span>
         <h1 className="font-serif text-2xl font-bold text-brand-navy dark:text-foreground md:text-3xl">{title}</h1>
-        {state ? <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize" style={{ backgroundColor: streamStateStyle(state).bg, color: streamStateStyle(state).color }}>{state}</span> : null}
+        {state ? <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium" style={{ backgroundColor: streamStateStyle(state).bg, color: streamStateStyle(state).color }}>{statusLabel(state)}</span> : null}
         <DomainBadge domain={domain} />
       </div>
 
@@ -204,10 +226,13 @@ export default function StreamDetail() {
 
           {/* 3 — the synthesis */}
           <section id="synthesis" className="scroll-mt-20">
-            <StepHeader n={3} icon={Lightbulb} label="The synthesised stream" />
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <StepHeader n={3} icon={Lightbulb} label="The synthesised stream" />
+              {hasOverview && doc ? <CopyBriefButton doc={doc} /> : null}
+            </div>
             {hasOverview ? (
               <Card className="border-l-2 border-l-brand-cyan p-6">
-                <Markdown>{doc?.body ?? ""}</Markdown>
+                <Markdown linkBase={doc?.url}>{stripEditorialDebris(doc?.body ?? "")}</Markdown>
                 {doc?.url ? <a href={doc.url} target="_blank" rel="noreferrer" className="mt-3 inline-flex items-center gap-1 text-xs text-brand-cyan-dark hover:underline">Overview source <ExternalLink className="h-3 w-3" /></a> : null}
               </Card>
             ) : (
@@ -223,7 +248,7 @@ export default function StreamDetail() {
 
             <div className="grid grid-cols-3 gap-2 border-b border-border pb-3 text-center">
               <div><div className="text-lg font-bold tabular-nums">{summary?.issues ?? 0}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">issues</div></div>
-              <div><div className="text-lg font-bold tabular-nums">{summary?.mergedPRs ?? 0}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">merged</div></div>
+              <div><div className="text-lg font-bold tabular-nums">{summary?.mergedPRs ?? 0}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">accepted</div></div>
               <div><div className="text-lg font-bold tabular-nums">{summary?.findings ?? findings.length}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">findings</div></div>
             </div>
 

--- a/web/src/pages/Streams.tsx
+++ b/web/src/pages/Streams.tsx
@@ -13,6 +13,7 @@ import { PersonAvatar } from "@/components/shared/PersonAvatar";
 import { DomainBadge, StageBadge, StatusBadge } from "@/components/shared/Badges";
 import { StreamProgress } from "@/components/shared/StreamProgress";
 import { streamStateStyle, harnessLabel, isStreamShipped, isAwaitingDirection, streamStageIndex, subtasksByStream } from "@/lib/streams";
+import { statusLabel } from "@/lib/meta";
 import { relativeTime, cleanTitle } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { StreamSummary, IssueLite } from "@/lib/types";
@@ -37,9 +38,11 @@ const RANK: Record<SortKey, (s: StreamSummary) => number | string> = {
 const readView = (): View => { try { return (localStorage.getItem(VIEW_KEY) as View) || "table"; } catch { return "table"; } };
 const writeView = (v: View) => { try { localStorage.setItem(VIEW_KEY, v); } catch { /* ignore */ } };
 
+// Raw frontmatter states ("needs-synthesis") never reach a partner's eyes —
+// translate via STATUS_META, falling back to the raw string capitalised.
 function StatePill({ state }: { state: string }) {
   if (!state) return null;
-  return <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium capitalize" style={{ backgroundColor: streamStateStyle(state).bg, color: streamStateStyle(state).color }}>{state}</span>;
+  return <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium" style={{ backgroundColor: streamStateStyle(state).bg, color: streamStateStyle(state).color }}>{statusLabel(state)}</span>;
 }
 
 // The human-gate marker: research is done and synthesised — a person now has
@@ -121,7 +124,7 @@ function StreamCard({ s, subtasks }: { s: StreamSummary; subtasks: IssueLite[] }
 
         <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
           <span className="inline-flex items-center gap-1" title="Issues (open / total)"><GitBranch className="h-3.5 w-3.5" /> {s.openIssues}/{s.issues}</span>
-          <span className="inline-flex items-center gap-1" title="Merged outputs"><GitMerge className="h-3.5 w-3.5" /> {s.mergedPRs}</span>
+          <span className="inline-flex items-center gap-1" title="Accepted work"><GitMerge className="h-3.5 w-3.5" /> {s.mergedPRs}</span>
           <span className="inline-flex items-center gap-1" title="Findings"><FileText className="h-3.5 w-3.5" /> {s.findings}</span>
         </div>
 
@@ -190,7 +193,7 @@ function StreamTable({ streams, subtasksMap, sort, onSort }: { streams: StreamSu
             <TableHead>Domain</TableHead>
             <SortHead label="Issues" sortKey="issues" active={active("issues")} dir={sort.dir} onSort={onSort} numeric className="text-right" />
             <SortHead label="Findings" sortKey="findings" active={active("findings")} dir={sort.dir} onSort={onSort} numeric className="text-right" />
-            <SortHead label="Merged" sortKey="merged" active={active("merged")} dir={sort.dir} onSort={onSort} numeric className="text-right" />
+            <SortHead label="Accepted" sortKey="merged" active={active("merged")} dir={sort.dir} onSort={onSort} numeric className="text-right" />
             <TableHead>Team</TableHead>
             <SortHead label="Updated" sortKey="updated" active={active("updated")} dir={sort.dir} onSort={onSort} className="text-right" />
           </TableRow>
@@ -348,7 +351,7 @@ export default function Streams() {
             <StatCard label="In progress" value={totals.inProgress} icon={Loader2} accent="#0EA5E9" />
             <StatCard label="Shipped" value={totals.shipped} icon={CheckCircle2} accent="#0E8A16" />
             <StatCard label="Findings" value={totals.findings} icon={FileText} accent="#8B5CF6" />
-            <StatCard label="Merged outputs" value={totals.merged} icon={GitMerge} accent="#C2410C" />
+            <StatCard label="Accepted work" value={totals.merged} icon={GitMerge} accent="#C2410C" />
             <StatCard label="Contributors" value={totals.people} icon={Users} accent="#1D76DB" />
           </section>
 


### PR DESCRIPTION
Closes #182. Closes #184.

## What changed

**Two-door hero (#182)** — the Dashboard hero now presents two side-by-side door cards so a visitor knows which door is theirs within seconds:
- **Bring a problem** — for charities, councils and policy teams: "You carry a real NZ problem. We build rigorous, cited evidence around it — free." → `/partners`
- **Bring capacity** — for contributors: skills, agents, or spare AI tokens → `/contribute`
- "Watch the work live" kept as a secondary link, alongside "Read the method".
- Header nav: "For partners" moved up to second position; "Get started" renamed "Contribute".

**Vocabulary translation layer** — partners never see raw repo jargon:
- `STATUS_META` labels rewritten: needs-synthesis → "Being summarised", awaiting-direction → "Waiting on a human decision", in-review → "Being checked", changes-requested → "Fixes requested", claimed → "In progress", available → "Open for pickup".
- New `statusLabel()` helper; Streams `StatePill` and the StreamDetail header pill now route raw frontmatter states through it (falling back to the raw string capitalised). The amber `DecisionPill` behaviour for awaiting-direction is unchanged.
- IssueDetail labels: `status:*` hidden (the translated StatusBadge already shows it), `stage:*` renders via the existing StageBadge, `stream:<n>` renders as a "Stream #n" link chip.
- Counters reworded on partner-visible pages: "Merged outputs" → "Accepted work" (Streams stats, cards, table header, StreamDetail sidebar); "PRs"/"pull request" → "submitted work" (Dashboard review callout, Review page). Contribute and Board keep their technical vocabulary.

**Stream overview rendering + forwardable brief (#184)**:
- `Markdown` gains an optional `linkBase` prop; repo-relative hrefs (e.g. `../research/findings/...`) resolve against the stream doc's GitHub blob URL so they no longer 404 on-site.
- `stripEditorialDebris()` removes "TODO(steward)" blockquote lines and empty "Feedback log" tables from the partner-visible overview.
- New "Copy brief" button on the synthesis section: `buildStreamBrief()` produces a plain-text brief opening with "What we know now" (problem paragraph + learned-so-far bullets), a plain-words date+state line ("Evidence gathered as of 2 Jul 2026 — being summarised."), all relative links rewritten to absolute GitHub URLs, and no badges/harness/repo mechanics. Copies via `navigator.clipboard.writeText` with a "Copied" state for 2s.

## Verified

- `npm install && npm run build` passes (`tsc -b && vite build`, clean).
- `npm run lint` exits 0 — only pre-existing warnings, none in changed files.
- Brief builder + debris stripper exercised against the checked-in snapshot (`public/data/snapshot.json`, stream 2): TODO(steward) and empty feedback-log table stripped; no relative links remain in the brief; `../research/findings/...` resolves to `https://github.com/thecolab-ai/the-for-good-project/blob/main/research/findings/...`; date+state line renders as "Evidence gathered as of 2 Jul 2026 — being summarised."
- `scripts/build-data.mjs` needs a `GITHUB_TOKEN`, so the checked-in snapshot was used as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbWdhvpH3uwMgen7MyUay7