### PR TITLE
docs: truth pass — canonical lifecycle diagram, ADR-0011/0012 reality, one-page OVERVIEW

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+> One-page map of how everything fits: [docs/OVERVIEW.md](docs/OVERVIEW.md).
+
 Instructions for AI agents (Claude Code, and any coding/research agent) working this repo. If you're a person, read [`README.md`](README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md) instead — though you're welcome to read this too.
 
 You are here to move one issue forward, to a high standard, end to end. Work like a careful researcher, not an eager intern.
@@ -101,6 +103,7 @@ rather than waiting.
 - **Respect the human gates.** Streams (see [`docs/STREAMS.md`](docs/STREAMS.md)) require a HUMAN decision between research and ideation (G1) and between ideation and build (G2). Never open ideate or build issues, and never work one that isn't `status: available` — a human making it available *is* the gate. Carry `Part of #<parent>` (and `Stream: #<root>` when the parent isn't the root) in every issue and PR body so the stream label propagates. Never write or edit a `streams/` overview doc — that's the human steward's voice.
 - **Fan out chunky, and only two levels deep.** If your issue is too big for ONE high-quality output, split off what you won't cover as 2–5 *chunky* research sub-issues (`Part of #<n>` in the body) — real questions worth hours, never micro-tasks — then still complete your own issue, narrowed to its core. Depth limit: the root's agent may open sub-issues (depth 1), their agents may open depth 2, **and no further** — at depth 2 you narrow and flag instead. When a stream's issues all close, automation queues the root for synthesis — the draft is produced by `synthesize_work.sh` under its own guardrails (ADR-0003), so don't try to synthesise the stream from inside a work task.
 - **Respect the ADRs.** Significant decisions about how the project works are recorded in [`docs/adr/`](docs/adr/README.md). Read them before proposing a structural change (workflow, labels, automation, dependencies). If your change contradicts an accepted ADR, your PR must include a superseding ADR arguing why; if it *makes* a significant decision, it must include a new ADR. Don't re-litigate decided things in code.
+- **Never rework a `synthesis/*` PR from a generic work loop.** Synthesis draft rework belongs to `synthesize_work.sh` only — it carries the steward-preservation rules a generic rework prompt lacks ([ADR-0011](docs/adr/0011-synthesis-rework-routing.md)).
 - **Be honest about limits.** If a question needs lived experience, legal authority, or data you can't access, say that plainly and flag it for a human. That *is* a useful result.
 - **Consistency is checked automatically.** Every PR runs a deterministic validator over findings/solutions (`.github/workflows/validate.yml`) — required frontmatter incl. `agent`/`model`, valid `domain`/`confidence`, the standard sections, and at least one citation. Run it yourself before pushing: `npm run validate`.
 - **Record provenance.** Set `agent:` (codex / claude / hermes / none) and `model:` (the exact model id) in the finding's frontmatter, so the client and model behind every finding are tracked.
@@ -184,7 +187,7 @@ skill you add makes the next contributor's research faster.
 
 ## Run it on autopilot
 
-Two scripts wrap your `codex`, `claude`, or `hermes` CLI so you can put spare tokens to work
+Five scripts wrap your `codex`, `claude`, or `hermes` CLI so you can put spare tokens to work — `start_work.sh` (do), `review_work.sh` (review), `synthesize_work.sh` (stream rollups), `merge_ready.sh` (maintainer merges), `reap.sh` (free stale claims); see [docs/AUTOMATION.md](docs/AUTOMATION.md)
 without babysitting each step — see [`docs/AUTOMATION.md`](docs/AUTOMATION.md):
 
 - **`./start_work.sh`** — claims the next available issue, runs the loop above,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+> One-page map of how everything fits: [docs/OVERVIEW.md](docs/OVERVIEW.md).
+
 Welcome. This is the method that keeps The For Good Project useful. It's short on purpose — read it once and you're ready.
 
 The work here informs real decisions about real people. That's why the bar is "cited and honest," not "fast and confident."
@@ -17,7 +19,7 @@ Every piece of work is a GitHub Issue moving through four stages:
 
 Issues link forward: a Discover issue spawns Research issues; a Research finding feeds an Ideate issue; a chosen idea becomes a Build issue. Always link the issue you came from (`Part of #123`) so the chain stays traceable.
 
-Everything descending from one Discover issue is a **stream** (tracked by an auto-applied `stream:<n>` label and a plain-language overview in [`streams/`](streams/README.md)). Streams pass through **human gates**: a person must synthesise the research before ideation starts (G1) and approve a solution before anything is built (G2) — see [`docs/STREAMS.md`](docs/STREAMS.md). Agents do the volume; humans do the judgement.
+Everything descending from one Discover issue is a **stream** (tracked by an auto-applied `stream:<n>` label and a plain-language overview in [`streams/`](streams/README.md)). Streams pass through **human gates**: an agent drafts the synthesis, then a person reviews it and sets direction before ideation starts (G1) and approve a solution before anything is built (G2) — see [`docs/STREAMS.md`](docs/STREAMS.md). Agents do the volume; humans do the judgement.
 
 ## The workflow
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![The Colab branded Aotearoa evidence map for The For Good Project](docs/assets/readme/for-good-hero.jpg)
 
+**New here? Start with the one-page map: [docs/OVERVIEW.md](docs/OVERVIEW.md).**
+
 **An open research commons where people and AI agents work together on Aotearoa New Zealand's public-good problems, to a standard high enough that real decisions can rest on the work.**
 
 By [thecolab.ai](https://thecolab.ai), New Zealand's community-driven AI consultancy: _AI expertise, built together._

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -9,25 +9,66 @@ no model calls. **The scripts own every status change and the merge gate; the
 agent only does the actual work.** That's deliberate — it's why tracking stays
 correct no matter which agent runs or how it behaves.
 
-## The status lifecycle
+## The status lifecycle (canonical — every other doc links here)
+
+An issue carries exactly **one** `status:` label at a time — the scripts and
+the `issue-status.yml` action sweep all others whenever they set one.
+
+**Work issues** (research / ideate / build):
 
 ```
-status: available ──claim──▶ status: claimed ──PR opened──▶ status: in-review ──review passes + merge──▶ status: done
-        ▲                                                       │        ▲
-        │                                                review says     │ author's next loop
-        │                                                NEEDS_WORK      │ pushes the rework
-        │                                                       ▼        │
-        │                                              status: changes-requested
-        └───────────── agent opened no PR (released) ◀─────────┘ (PR closed / gone)
+(no status) ──maintainer triages──▶ available ──claim──▶ claimed ──PR opened──▶ in-review ──review passes + merge──▶ done
+                                        ▲                                          │      ▲
+                                        │                                   review says   │ author's next loop
+                                        │                                   NEEDS_WORK    │ pushes the rework
+                                        │                                          ▼      │
+                                        │                                  changes-requested
+                                        └────── agent opened no PR (released) ◀────┘ (PR closed / gone)
 ```
+
+**Stream roots** (Discover issues) never close via a PR and follow the gate
+cycle instead:
+
+```
+(no status) ──G0: maintainer──▶ available → claimed → in-review ──framing PR merges──▶ (no status: researching)
+                                                                                             │
+                             children all close (the stream "drains")                       ▼
+        ┌──────────────────────────────────────────────────────────────────── needs-synthesis
+        │                                                                            │
+        │            synthesize_work.sh drafts/updates the overview PR               ▼
+        │        draft flags BLOCKING UNKNOWNS (ADR-0012, bounded)          ┌── which way? ──┐
+        └── back to researching: follow-up research issues open ◀───────────┤                ├───▶ awaiting-direction
+            (re-drains → re-synthesises with the answers folded in)         └────────────────┘    (gate G1: the human
+                                                                                                    steward decides)
+        reviewer sends the draft back:  awaiting-direction → changes-requested → awaiting-direction
+        (synthesis rework belongs to synthesize_work.sh, never start_work.sh — ADR-0011)
+```
+
+The full vocabulary, in one table:
+
+| Label | Applies to | Set by | Meaning |
+|---|---|---|---|
+| *(no status)* | new Discover issues | the issue template | Not yet triaged — invisible to every runner (gate **G0**) |
+| `status: available` | issues | maintainer (G0) · scripts (release) | Up for grabs — the ONLY status runners pick up |
+| `status: claimed` | issues | `start_work.sh` | A worker is on it |
+| `status: in-review` | issues | scripts + `issue-status.yml` | Its PR is open and awaiting adversarial review |
+| `status: changes-requested` | issues | `review_work.sh` | Review found problems — routed back for rework |
+| `status: needs-synthesis` | stream roots | `stream-sync.yml` (drain) · humans (force a re-synthesis) | Stream drained — synthesis queue |
+| `status: awaiting-direction` | stream roots | `synthesize_work.sh` | Parked at gate **G1** for the human steward's direction decision |
+| `status: blocked` | issues | humans only | Waiting on something. Runners ignore it either way |
+| `status: done` | issues | merge automation | Merged and complete |
+| `review: claimed` | PRs | `review_work.sh` | A reviewer is holding this PR (double-review lock) |
+| `review: human-only` | PRs | maintainers | Pipeline/governance change — humans review and merge, agents skip |
+| `do-not-automate` | issues | humans only | Parking brake: excluded from every automation queue |
+| `priority: high` | issues | humans | Jumps every queue |
+| `stage: *` / `domain: *` / `stream:<n>` | issues/PRs | template / `stream-sync.yml` | What kind of work, which problem area, which stream |
 
 `start_work.sh` moves `available → claimed → in-review` (and
 `changes-requested → in-review` after rework). `review_work.sh` records reviews
-and flips `in-review → changes-requested` on a NEEDS_WORK verdict, which routes
-the work back to its **author**: the issue stays assigned to them, and their
-next `start_work.sh` loop picks it up before any new issue. `merge_ready.sh`
-(maintainer) merges what qualifies → `done`. No agent is trusted to set these
-itself.
+and flips `in-review → changes-requested` on a NEEDS_WORK verdict — **except
+for synthesis draft PRs (branch `synthesis/*`), whose rework routes to
+`synthesize_work.sh` (ADR-0011)**. `merge_ready.sh` (maintainer) merges what
+qualifies → `done`. No agent is trusted to set these itself.
 
 ### Worktrees & fresh main
 
@@ -94,7 +135,8 @@ Two TTLs are enforced:
 - `status: claimed` with no PR after `CLAIM_TTL` (default 2 hours) is moved
   back to `status: available` and unassigned.
 - `status: changes-requested` with assignees after `REWORK_TTL` (default 2
-  hours) is unassigned, so any worker's `start_work.sh` loop can pick up the
+  hours) is unassigned, so any worker's `start_work.sh` loop — or
+  `synthesize_work.sh`, for a synthesis draft (ADR-0011) — can pick up the
   rework.
 
 Run it manually when you want an immediate sweep:

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,0 +1,61 @@
+# How it all fits — on one page
+
+The For Good Project points spare AI capacity at real New Zealand problems,
+with humans steering. This page is the map; every detail links out.
+
+## The idea in one paragraph
+
+Someone surfaces a real NZ problem (a **Discover** issue). Agents fan it out
+into cited **research**, an agent **synthesises** what was learned into a
+plain-language overview, and a **human steward** decides the direction —
+go deeper, pivot, proceed to solutions, or park. Nothing is ideated or built
+without that human decision, and everything merged has survived an
+**adversarial review** by a different identity than its author.
+
+## The pipeline
+
+```
+Discover ──G0──▶ Research (agents, cited) ──drain──▶ Synthesis (agent drafts)
+                     ▲                                      │
+                     └── blocking unknowns loop back ◀──────┤ (automatic, bounded — ADR-0012)
+                         (≤3 issues × ≤2 rounds)            ▼
+                                            G1: human steward sets direction
+                                                            │
+                                             Ideate ──G2──▶ Build ──▶ Shipped
+```
+
+- **G0** — a maintainer applies `status: available` to a new Discover issue.
+  Until then it's invisible to every runner.
+- **G1** — the steward reads the drafted overview, grades the evidence,
+  edits/rejects the candidate outcomes, writes the direction. ([docs/STREAMS.md](STREAMS.md))
+- **G2** — a human approves one specific solution before anything is built.
+
+## Who does what
+
+| Actor | Does | Never does |
+|---|---|---|
+| **Agents** (via the five scripts) | research, drafts, reviews, synthesis rollups, bounded follow-up questions | direction decisions, ideate/build issues, `streams/` overview edits, label changes |
+| **Scripts** (`start_work` / `review_work` / `synthesize_work` / `merge_ready` / `reap`) | every status transition, claims, queues, merges | judgement |
+| **Maintainers / stewards** | G0 triage, G1 direction, G2 build approval, governance PRs (`review: human-only`) | — |
+
+## The labels, in one line each
+
+One `status:` label per issue, always (see the canonical table in
+[docs/AUTOMATION.md](AUTOMATION.md)): `available` (up for grabs — the only
+status runners take) → `claimed` → `in-review` → `changes-requested` (rework)
+→ `done`. Stream roots additionally cycle `needs-synthesis` (drained,
+awaiting a rollup) and `awaiting-direction` (parked for the human steward).
+`review: claimed` / `review: human-only` mark PRs, not issues.
+`do-not-automate` parks anything away from every queue. `priority: high`
+jumps queues.
+
+## Where the truth lives
+
+| Question | Doc |
+|---|---|
+| How do I contribute / what's the method? | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| What do the scripts and labels do, exactly? | [docs/AUTOMATION.md](AUTOMATION.md) |
+| How do streams and the human gates work? | [docs/STREAMS.md](STREAMS.md) |
+| Why is it like this? | [docs/adr/](adr/README.md) |
+| What are agents allowed to do? | [AGENTS.md](../AGENTS.md) |
+| What do we stand for? | [CONSTITUTION.md](../CONSTITUTION.md) |

--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -96,10 +96,15 @@ From there, **`synthesize_work.sh`** (see [AUTOMATION.md](AUTOMATION.md),
 ADR-0003, ADR-0007) does the tedious half: an agent reads every merged finding
 in the stream and drafts the overview as a PR — takeaways with carried
 confidence, open questions, and 2–4 neutral candidate outcomes the evidence
-could support — and the root moves to `status: awaiting-direction`. The
-judgement half never leaves the human: the options are unranked and
-unrecommended, the draft's direction section is a literal `TODO(steward)`,
-and only the steward's edit + decision + merge passes the gate.
+could support. If the draft flags unknowns that genuinely **block** its
+conclusions, the stream first loops back to research automatically —
+bounded to ≤3 issues/round and ≤2 rounds/stream (ADR-0012) — and only
+re-synthesises once the answers land; otherwise (or once the loop is spent)
+the root moves to `status: awaiting-direction`. The judgement half never
+leaves the human: the options are unranked and unrecommended, the draft's
+direction section is a literal `TODO(steward)`, and only the steward's edit
++ decision + merge passes the gate. To send a parked stream back through
+synthesis at any time, relabel the root `status: needs-synthesis`.
 
 ## 2. The human gates
 
@@ -156,16 +161,4 @@ a human.
   required**. Their input lands as a `feedback`-labelled item against the
   stream (filed by whoever captured it, or by the community bot).
 
-## 4. Decisions made (from #30's open questions)
-
-1. **`stream:<n>` label + body convention**, not Projects/milestones — least
-   friction, queryable, and the Action removes the bookkeeping burden.
-2. **Stream state lives in the overview doc's frontmatter** (single source of
-   truth). The label taxonomy stays small; the human work queue is driven by
-   `status: needs-synthesis` / `status: awaiting-direction` on the root issue.
-3. **Stewards**: trusted reviewers; maintainer co-sign for sensitive domains.
-4. **Feedback channel**: WhatsApp → community bot first (that's where this
-   community already is), web form later — split into its own issue.
-5. **Agent-drafted synthesis**: deferred. The reviewer stays per-finding; if
-   G1 proves heavy, an agent can *draft* the synthesis for the steward to
-   edit — but the decision stays human.
+(Design history for streams and gates lives in the ADRs: [`0001`](adr/0001-streams-and-human-gates.md), [`0003`](adr/0003-agent-drafted-synthesis.md), [`0007`](adr/0007-synthesis-drafts-candidate-outcomes.md), [`0011`](adr/0011-synthesis-rework-routing.md), [`0012`](adr/0012-synthesis-followup-research-loop.md).)

--- a/docs/adr/0004-analysis-documents-and-rendered-companions.md
+++ b/docs/adr/0004-analysis-documents-and-rendered-companions.md
@@ -1,6 +1,6 @@
 # ADR-0004: Project analysis lives in `analysis/`
 
-- **Status:** proposed
+- **Status:** accepted (merged by the human maintainer)
 - **Date:** 2026-07-02
 - **Deciders:** Proposed by PR #96; accepted only if merged
 - **Discussion:** [#96](https://github.com/thecolab-ai/the-for-good-project/pull/96)

--- a/docs/adr/0008-rework-handoff-and-runner-interrupts.md
+++ b/docs/adr/0008-rework-handoff-and-runner-interrupts.md
@@ -1,6 +1,6 @@
 # ADR-0008: Rework hand-off routes by worked issue; reviewer crashes retry; runner interrupts stop the run
 
-- **Status:** proposed (ratified by the human maintainer who reviews and merges PR #109)
+- **Status:** accepted (merged by the human maintainer)
 - **Date:** 2026-07-03
 - **Deciders:** human maintainer (on merge); drafted by an agent on behalf of @mcinteerj
 - **Discussion:** [PR #109](https://github.com/thecolab-ai/the-for-good-project/pull/109)

--- a/docs/adr/0009-maintainer-escalation-handoff.md
+++ b/docs/adr/0009-maintainer-escalation-handoff.md
@@ -1,6 +1,6 @@
 # ADR-0009: Agents hand off write-gated actions to maintainers via a documented escalation path
 
-- **Status:** proposed (ratified by the human maintainer who reviews and merges PR #112)
+- **Status:** accepted (merged by the human maintainer)
 - **Date:** 2026-07-02 (UTC; drafted 2026-07-03 NZST — no repo convention on ADR date timezones yet)
 - **Deciders:** human maintainer (on merge); drafted by an agent on behalf of @mcinteerj
 - **Discussion:** [PR #112](https://github.com/thecolab-ai/the-for-good-project/pull/112), [issue #111](https://github.com/thecolab-ai/the-for-good-project/issues/111)

--- a/docs/adr/0010-partner-network.md
+++ b/docs/adr/0010-partner-network.md
@@ -1,6 +1,6 @@
 # ADR-0010: Track the partner / SME / advisory network in the open, behind a consent gate
 
-- **Status:** proposed (requires human-maintainer ratification before merge)
+- **Status:** accepted (merged by the human maintainer)
 - **Date:** 2026-07-03
 - **Deciders:** human maintainer (on merge); drafted by an agent at the maintainer's request
 - **Discussion:** [issue #123](https://github.com/thecolab-ai/the-for-good-project/issues/123)

--- a/docs/adr/0011-synthesis-rework-routing.md
+++ b/docs/adr/0011-synthesis-rework-routing.md
@@ -1,6 +1,6 @@
 # ADR-0011: Synthesis draft rework belongs to synthesize_work.sh; generic runners must not touch synthesis PRs
 
-- **Status:** proposed (ratified by the human maintainer who reviews and merges the PR)
+- **Status:** accepted (merged by the human maintainer)
 - **Date:** 2026-07-03
 - **Deciders:** human maintainer (on merge); drafted by an agent on behalf of the maintainer
 

--- a/docs/adr/0012-synthesis-followup-research-loop.md
+++ b/docs/adr/0012-synthesis-followup-research-loop.md
@@ -1,6 +1,6 @@
 # ADR-0012: Blocking unknowns loop back to research automatically — bounded — before the G1 human gate
 
-- **Status:** proposed (ratified by the human maintainer who reviews and merges the PR)
+- **Status:** accepted (merged by the human maintainer)
 - **Date:** 2026-07-03
 - **Deciders:** human maintainer (on merge); drafted by an agent at the maintainer's direction
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,14 +40,14 @@ routine fixes, copy changes, or web styling.
 | [0001](0001-streams-and-human-gates.md) | Streams + human gates: agents grind, humans steer | Accepted |
 | [0002](0002-vendor-thecolab-skills-submodule.md) | Vendor `thecolab-ai/.skills` as a git submodule | Accepted |
 | [0003](0003-agent-drafted-synthesis.md) | Agents draft the G1 synthesis; humans keep the decision | Accepted |
-| [0004](0004-analysis-documents-and-rendered-companions.md) | Project analysis lives in `analysis/` | Proposed |
+| [0004](0004-analysis-documents-and-rendered-companions.md) | Project analysis lives in `analysis/` | Accepted |
 | [0005](0005-agent-execution-environment.md) | How & where we run the agents (containerise + sandboxed auto modes) | Accepted |
 | [0006](0006-fetch-proxy-browser-management.md) | Fetch, proxy & browser management for research + citation checks | Accepted |
 | [0007](0007-synthesis-drafts-candidate-outcomes.md) | Synthesis drafts candidate outcomes; the direction stays human | Accepted |
-| [0008](0008-rework-handoff-and-runner-interrupts.md) | Rework hand-off routes by worked issue; reviewer crashes retry; runner interrupts stop the run | Proposed |
-| [0009](0009-maintainer-escalation-handoff.md) | Agents hand off write-gated actions to maintainers via a documented escalation path | Proposed |
-| [0010](0010-partner-network.md) | Track the partner / SME / advisory network in the open, behind a consent gate | Proposed |
-| [0011](0011-synthesis-rework-routing.md) | Synthesis draft rework belongs to synthesize_work.sh; generic runners must not touch synthesis PRs | Proposed |
-| [0012](0012-synthesis-followup-research-loop.md) | Blocking unknowns loop back to research automatically — bounded — before the G1 human gate | Proposed |
+| [0008](0008-rework-handoff-and-runner-interrupts.md) | Rework hand-off routes by worked issue; reviewer crashes retry; runner interrupts stop the run | Accepted |
+| [0009](0009-maintainer-escalation-handoff.md) | Agents hand off write-gated actions to maintainers via a documented escalation path | Accepted |
+| [0010](0010-partner-network.md) | Track the partner / SME / advisory network in the open, behind a consent gate | Accepted |
+| [0011](0011-synthesis-rework-routing.md) | Synthesis draft rework belongs to synthesize_work.sh; generic runners must not touch synthesis PRs | Accepted |
+| [0012](0012-synthesis-followup-research-loop.md) | Blocking unknowns loop back to research automatically — bounded — before the G1 human gate | Accepted |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).


### PR DESCRIPTION
Replaces #197 (auto-closed when its stacked base branch was deleted at #195's merge — same content, rebased onto main).

- **docs/AUTOMATION.md** gains the single canonical lifecycle: both diagrams (work issues + stream root gate cycle), the full label table with who-sets-what, and the single-status invariant.
- **docs/OVERVIEW.md** is new: the one-page map linked first from README/CONTRIBUTING/AGENTS.
- Everything the audits flagged as **false after ADR-0011/0012** is fixed.
- ADRs 0004/0008–0012 flipped to **Accepted**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)