### PR TITLE
build: add NEEDS_HUMAN review verdict for governance calls (Closes #198)

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -26,6 +26,10 @@ the `issue-status.yml` action sweep all others whenever they set one.
                                         └────── agent opened no PR (released) ◀────┘ (PR closed / gone)
 ```
 
+A PR whose review returns **NEEDS_HUMAN** (a governance change an agent must not
+ratify) keeps its issue in `in-review` and parks the merge check at `pending`
+for a maintainer — it does not move to `changes-requested` (ADR-0014).
+
 **Stream roots** (Discover issues) never close via a PR and follow the gate
 cycle instead:
 
@@ -165,6 +169,19 @@ body link (ADR-0008), so discover PRs — which deliberately have no closing ref
 — are routed too. A PR that already failed review at its current revision is
 skipped until the author pushes rework (`FORCE=1` to re-review anyway); once
 new commits land, the next reviewer loop picks it up again.
+
+On **NEEDS_HUMAN** — a governance / pipeline / automation-contract change that
+is sound but that an agent must not *ratify* — it posts the review as a plain
+comment, parks the merge check at `pending` ("Awaiting human maintainer"), and
+leaves the issue `in-review`. It does **not** flip to `changes-requested`,
+because that would route ratification to an agent rework loop that cannot
+ratify — the ping-pong seen on #125/#169 (ADR-0014). A PR parked `pending` is
+skipped by later loops until a human acts (`FORCE=1` to re-review). Use this,
+not `NEEDS_WORK`, when a governance change is correct but needs a maintainer;
+reserve `NEEDS_WORK` for an author-fixable defect. This is close kin to
+`review: human-only` (below): that label keeps a PR out of the agent loop from
+the start, whereas NEEDS_HUMAN is where an agent review *discovers* mid-flight
+that a change needs a human and hands it off cleanly.
 
 If the review agent **crashes before writing a review**, that's a reviewer
 tooling failure, not a PR verdict: the merge check is left unset (merge is
@@ -359,8 +376,10 @@ collective keeps itself unblocked.
   trust, not arbitrary input. Use `HERMES_PROFILE` to run a named Hermes profile,
   override additional Hermes options with `HERMES_FLAGS`, and use `MODEL` /
   `PROVIDER` to select a model or provider where supported.
-- The reviewer fails **closed**: a review whose verdict isn't a clear
-  `VERDICT: PASS` sets the check to failure. (A reviewer *crash* that produces
-  no review at all leaves the check unset so a later loop retries — merge is
-  still blocked either way; ADR-0008.)
+- The reviewer fails **closed**: a review whose verdict is neither a clear
+  `VERDICT: PASS` nor an explicit `VERDICT: NEEDS_HUMAN` is treated as
+  `NEEDS_WORK` and sets the check to failure. An explicit NEEDS_HUMAN instead
+  parks the check at `pending` (ADR-0014); a reviewer *crash* that produces no
+  review at all leaves the check unset so a later loop retries — merge is
+  blocked in every case (ADR-0008).
 - Set `AGENT_TIMEOUT` (seconds) to cap a runaway agent; `MODEL` to pick a model.

--- a/docs/adr/0014-needs-human-review-verdict.md
+++ b/docs/adr/0014-needs-human-review-verdict.md
@@ -1,0 +1,69 @@
+# ADR-0014: A third review verdict — NEEDS_HUMAN — for governance calls an agent must not ratify
+
+- **Status:** proposed (ratified by the human maintainer who reviews and merges this PR)
+- **Date:** 2026-07-03
+- **Deciders:** human maintainer (on merge); drafted by an agent on behalf of @mcinteerj
+- **Discussion:** [#198](https://github.com/thecolab-ai/the-for-good-project/issues/198)
+
+## Context
+
+`review_work.sh` had exactly two verdicts: `PASS` (approve, maybe auto-merge)
+and `NEEDS_WORK` (request changes and flip the linked issue to
+`status: changes-requested`, so the AUTHOR's next `start_work.sh` loop picks the
+rework up).
+
+The standard review prompt also carries a GOVERNANCE GUARD: a PR that changes
+how the project itself works — the pipeline, gates, review/merge rules, an ADR's
+status, or label taxonomy — needs a HUMAN MAINTAINER decision, not an agent
+approval (`docs/AUTOMATION.md`, `review_work.sh` header). With only two verdicts,
+the guard told reviewers to lean `NEEDS_WORK`. But `NEEDS_WORK` routes the PR to
+an *agent* rework loop, and an agent cannot ratify a governance change. So
+governance PRs ping-ponged — reviewed NEEDS_WORK, "reworked", reviewed
+NEEDS_WORK again — instead of reaching a maintainer. This was observed on
+#125 and #169.
+
+## Decision
+
+Add an additive third verdict, `NEEDS_HUMAN`, for a change that is *sound* but
+needs human ratification:
+
+- Post the review as a plain **comment** — never `--request-changes` (that is
+  what triggers the agent-rework routing).
+- Park the merge check `for-good/adversarial-review` at **`pending`** with
+  description "Awaiting human maintainer". Pending blocks merge for automation
+  while a human maintainer can still merge, and — because this script only ever
+  sets that context to `success`/`failure`/`pending` — a `pending` on it is an
+  unambiguous NEEDS_HUMAN park marker, so a later review loop **skips** the PR
+  instead of re-reviewing it (no wasted tokens) or misreading it as the author's
+  turn.
+- Do **not** flip the linked issue: it stays `status: in-review`, waiting for a
+  maintainer rather than an agent.
+
+Both review prompts describe when to use it. The standard prompt's GOVERNANCE
+GUARD now steers governance-but-sound to `NEEDS_HUMAN` and reserves `NEEDS_WORK`
+for an actual author-fixable defect.
+
+**Fail-closed compatibility:** an unparsed or unrecognised verdict still falls
+through to today's `NEEDS_WORK` behaviour, so a garbled review can never park a
+PR as "awaiting human" by accident.
+
+Considered and rejected: leaving the merge check fully unset for NEEDS_HUMAN
+(the loop would then re-review every pass, burning tokens on a PR that is only
+waiting for a human); a dedicated `status: needs-human` label instead of the
+pending check (more label taxonomy for a state the check already expresses, and
+it would not by itself block the merge gate).
+
+## Consequences
+
+- Governance / pipeline / automation-contract PRs reach a human maintainer
+  instead of ping-ponging through agent rework.
+- The merge gate is honoured: a NEEDS_HUMAN PR cannot auto-merge while the check
+  is `pending`; a maintainer merges it deliberately.
+- `review_work.sh` carries one more terminal state to reason about. The park is
+  keyed on the `pending` state of its own review context; if another tool ever
+  writes `pending` to `for-good/adversarial-review`, that assumption would need
+  revisiting.
+- This is itself a change to an automation contract, so per
+  `docs/adr/README.md` it is recorded here and, per `docs/AUTOMATION.md`,
+  ratified by the human maintainer who merges it — the implementing PR carries
+  `review: human-only`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,5 +49,6 @@ routine fixes, copy changes, or web styling.
 | [0010](0010-partner-network.md) | Track the partner / SME / advisory network in the open, behind a consent gate | Accepted |
 | [0011](0011-synthesis-rework-routing.md) | Synthesis draft rework belongs to synthesize_work.sh; generic runners must not touch synthesis PRs | Accepted |
 | [0012](0012-synthesis-followup-research-loop.md) | Blocking unknowns loop back to research automatically — bounded — before the G1 human gate | Accepted |
+| [0014](0014-needs-human-review-verdict.md) | A third review verdict — NEEDS_HUMAN — parks governance PRs for a maintainer instead of ping-ponging agent rework | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/review_work.sh
+++ b/review_work.sh
@@ -12,11 +12,19 @@
 # so parallel reviewers don't double-review one PR or stampede the front of the
 # list. Claims older than REVIEW_CLAIM_TTL are treated as stale and taken over.
 # Each review runs in a FRESH GIT WORKTREE of the PR head (freshly fetched), so
-# your clone is never touched. On PASS it approves (and can auto-merge); on
-# NEEDS_WORK it requests changes AND flips the linked issue to
-# "status: changes-requested" so the AUTHOR's next start_work.sh loop picks the
-# rework up. A PR already marked NEEDS_WORK at its current revision is skipped
-# until the author pushes rework (FORCE=1 to re-review anyway).
+# your clone is never touched. A review returns one of three verdicts:
+#   - PASS       → approve (and can auto-merge).
+#   - NEEDS_WORK → request changes AND flip the linked issue to
+#                  "status: changes-requested" so the AUTHOR's next
+#                  start_work.sh loop picks the rework up.
+#   - NEEDS_HUMAN → for a governance / pipeline / automation-contract change an
+#                  agent must not ratify: post the review as a COMMENT, park the
+#                  merge check at "pending" (blocks merge, but is NOT the
+#                  author's turn), and leave the issue in-review for a human
+#                  maintainer. Prevents the governance ping-pong where NEEDS_WORK
+#                  routes ratification to an agent that can't ratify (ADR-0014).
+# A PR already marked NEEDS_WORK (or parked NEEDS_HUMAN) at its current revision
+# is skipped until the author pushes rework / a human acts (FORCE=1 to re-review).
 #
 # A PR labelled "review: human-only" is excluded from this loop entirely —
 # pipeline/governance changes are reviewed and merged by a HUMAN maintainer,
@@ -201,6 +209,9 @@ OUTPUT (do exactly this):
 2. As the very LAST line of your response, print exactly one of:
    VERDICT: PASS
    VERDICT: NEEDS_WORK
+   VERDICT: NEEDS_HUMAN   (rare here — only if this PR also changes project
+                           governance/pipeline and needs a maintainer to ratify
+                           rather than an agent rework loop)
 Do not edit the PR's files, change labels, or merge anything.
 EOF
 }
@@ -267,9 +278,11 @@ author's defect (one out-of-scope note is fine; a failed verdict for it is not).
 GOVERNANCE GUARD: if this PR changes how the project itself works — governance,
 an ADR's status, the pipeline/gates, CONTRIBUTING, the review/merge rules, or
 label taxonomy — that needs a HUMAN MAINTAINER decision, not an agent approval.
-In that case say so plainly and lean to VERDICT: NEEDS_WORK ("needs human
-ratification"), UNLESS it is already correctly framed as a proposal awaiting
-maintainer sign-off (then it may PASS as a proposal).
+If the change is sound but needs that ratification, use VERDICT: NEEDS_HUMAN —
+NOT NEEDS_WORK. NEEDS_WORK sends the PR back to an AGENT rework loop that cannot
+ratify anything (it just ping-pongs); NEEDS_HUMAN parks it for a maintainer.
+Reserve NEEDS_WORK here for an actual defect the author should fix. (A change
+already correctly framed as a proposal awaiting sign-off may still PASS.)
 
 OUTPUT (do exactly this):
 1. Write your full review as Markdown to the exact absolute path above: a short
@@ -277,6 +290,8 @@ OUTPUT (do exactly this):
 2. As the very LAST line of your response, print exactly one of:
    VERDICT: PASS
    VERDICT: NEEDS_WORK
+   VERDICT: NEEDS_HUMAN   (governance/pipeline change that is sound but needs
+                           a human maintainer to ratify — see GOVERNANCE GUARD)
 Do not edit the PR's files, change labels, or merge anything.
 EOF
 }
@@ -291,7 +306,8 @@ check_state() {  # $1 = sha  -> success|failure|pending|none
     --jq "[.[]|select(.context==\"$REVIEW_CHECK_CONTEXT\")][0].state // \"none\"" 2>/dev/null || echo none
 }
 
-set_check() {  # $1 sha, $2 state(success|failure), $3 desc, $4 url
+set_check() {  # $1 sha, $2 state(success|failure|pending), $3 desc, $4 url
+               # pending = NEEDS_HUMAN park: blocks merge but isn't the author's turn
   [ "$DRY_RUN" = 1 ] && { info "[dry-run] would set check $REVIEW_CHECK_CONTEXT=$2 on $1"; return 0; }
   gh api -X POST "repos/$OWNER/$NAME/statuses/$1" \
     -f state="$2" -f context="$REVIEW_CHECK_CONTEXT" -f description="$3" -f target_url="$4" >/dev/null 2>&1 \
@@ -328,6 +344,12 @@ review_one() {  # $1 = PR number
     fi
     if [ "$st" = failure ]; then
       log "#$pr already reviewed at this revision (NEEDS_WORK) — waiting on the author's rework. Skipping (FORCE=1 to redo)."; return 0
+    fi
+    # `pending` on our own review context is the NEEDS_HUMAN park marker (this
+    # script never sets pending otherwise) — waiting on a maintainer, not on
+    # re-review. Skip so the loop doesn't burn tokens re-reviewing it.
+    if [ "$st" = pending ]; then
+      log "#$pr is parked NEEDS_HUMAN at this revision — awaiting a human maintainer. Skipping (FORCE=1 to re-review)."; return 0
     fi
   fi
 
@@ -394,7 +416,7 @@ review_one() {  # $1 = PR number
   fi
 
   local verdict
-  verdict="$( { cat "$tmp"; [ -n "$body_file" ] && cat "$body_file"; } | grep -Eo 'VERDICT:[[:space:]]*(PASS|NEEDS_WORK)' | tail -1 | grep -Eo 'PASS|NEEDS_WORK' || true)"
+  verdict="$( { cat "$tmp"; [ -n "$body_file" ] && cat "$body_file"; } | grep -Eo 'VERDICT:[[:space:]]*(PASS|NEEDS_WORK|NEEDS_HUMAN)' | tail -1 | grep -Eo 'PASS|NEEDS_WORK|NEEDS_HUMAN' || true)"
 
   if [ -z "$body_file" ]; then
     # The REVIEWER (not the author) failed to produce a review — a TOOLING
@@ -455,6 +477,18 @@ review_one() {  # $1 = PR number
         [ -n "$iss" ] && { set_status_label "$iss" "done" "in-review" "claimed" "changes-requested"; ok "Issue #$iss → done"; }
       else warn "Could not auto-merge #$pr (branch protection / conflicts) — leaving for a maintainer."; fi
     fi
+  elif [ "$verdict" = NEEDS_HUMAN ]; then
+    # A governance / pipeline / automation-contract change that an agent must
+    # NOT ratify (ADR-0014). Post the review as a plain COMMENT — never
+    # --request-changes (that routes to changes-requested → an agent rework
+    # loop that can't ratify anything; the #125/#169 ping-pong). Park the merge
+    # check at `pending` so merge stays blocked for automation while a human can
+    # still merge, and do NOT touch the linked issue: it stays in-review,
+    # waiting for a maintainer.
+    ok "Verdict: NEEDS_HUMAN"
+    gh pr comment "$pr" --repo "$REPO" "${body_flag[@]}" >/dev/null || true
+    set_check "$sha" pending "Awaiting human maintainer" "$url"
+    info "#$pr parked for a human maintainer — merge check left pending, issue not routed to agent rework."
   else
     [ -z "$verdict" ] && warn "No explicit verdict parsed — failing closed (NEEDS_WORK)."
     warn "Verdict: NEEDS_WORK"


### PR DESCRIPTION
Closes #198.

## Problem

`review_work.sh` had two verdicts: **PASS** and **NEEDS_WORK**. The standard review prompt's governance guard told reviewers to lean NEEDS_WORK on pipeline/governance PRs ("needs human ratification") — but NEEDS_WORK flips the linked issue to `status: changes-requested` and routes it to an **agent** rework loop, which can't ratify anything. Governance PRs therefore ping-pong (observed on #125/#169) instead of reaching a maintainer.

## Change — an additive third verdict, `NEEDS_HUMAN`

For a governance / pipeline / automation-contract change that is *sound* but that an agent must not ratify:

- post the review as a plain **comment** — never `--request-changes`;
- park the merge check `for-good/adversarial-review` at **`pending`** ("Awaiting human maintainer") — blocks merge for automation, but a later loop **skips** it (this script never sets `pending` otherwise) rather than re-reviewing it or reading it as the author's turn;
- do **not** flip the linked issue — it stays `in-review`, waiting for a maintainer.

Both review prompts describe when to use it; the standard prompt's governance guard now steers governance-but-sound to `NEEDS_HUMAN` and reserves `NEEDS_WORK` for an author-fixable defect.

**Fail-closed compatibility preserved:** an unparsed / unrecognised verdict still falls through to today's `NEEDS_WORK` behaviour.

## Files

- `review_work.sh` — parse `NEEDS_HUMAN`; new verdict branch; skip a `pending`-parked PR; three-verdict prompts + header.
- `docs/adr/0014-needs-human-review-verdict.md` — new ADR (proposed).
- `docs/adr/README.md`, `docs/AUTOMATION.md` — documented.

## Verification

- `bash -n review_work.sh` — clean.
- `npm run validate` — all 50 files valid.

## Note for the maintainer

Per #198 this is an automation-contract change: please apply **`review: human-only`** to this PR (an agent must not self-apply that label). It should be ratified and merged by a human, not the agent review loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DM2LTBj9NEUX5d8XHQHdJs