### PR TITLE
add autopilot.sh — alternate review + work to balance the queue

### DIFF
--- a/autopilot.sh
+++ b/autopilot.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# autopilot.sh — keep BOTH sides of the queue moving from one command.
+#
+# The problem this solves: run only start_work.sh and you flood the review
+# queue; run only review_work.sh and nothing new gets produced. autopilot
+# alternates — it REVIEWS other people's PRs, then does ONE piece of work, then
+# repeats — so research and review stay balanced instead of one starving the
+# other.
+#
+# It does NOT merge the two loops into one script. It's a thin conductor that
+# calls the existing, already-tested runners with MAX=1 / POLL_SECONDS=0 (do one
+# item, exit instead of polling) and owns only the alternation + the ratio. All
+# the real behaviour — claiming, status labels, worktrees, the PR, the merge
+# gate — still lives in start_work.sh / review_work.sh / fg-common.sh, unchanged.
+#
+# THE INTEGRITY RULE STILL HOLDS: an adversarial review may not be by the PR's
+# author. review_work.sh refuses self-authored PRs and branch protection
+# requires a non-author approval. So run the REVIEW side under a DISTINCT
+# identity via REVIEW_GITHUB_TOKEN (a second account / bot PAT with write) —
+# work runs as your normal gh identity, review runs as the token's identity.
+# Without REVIEW_GITHUB_TOKEN, autopilot still WORKS the queue but SKIPS review
+# and warns — because reviewing as the author is a no-op the gate would reject.
+#
+# Usage:
+#   REVIEW_GITHUB_TOKEN=<bot-pat> ./autopilot.sh                 # balanced (claude)
+#   REVIEW_GITHUB_TOKEN=<bot-pat> ./autopilot.sh codex           # use codex
+#   REVIEW_GITHUB_TOKEN=<bot-pat> REVIEW_PER_WORK=3 ./autopilot.sh
+#   ./autopilot.sh                                               # work-only (no token)
+#   MAX_CYCLES=5 ./autopilot.sh                                  # stop after 5 cycles
+#
+# Args: [claude|codex|hermes] [--model <name>]   (forwarded to both runners)
+# Env:  REVIEW_GITHUB_TOKEN  REVIEW_PER_WORK(=2)  POLL_SECONDS(=120)
+#       MAX_CYCLES(=0, unlimited)  + everything start_work.sh / review_work.sh read
+set -euo pipefail
+cd "$(dirname "$0")"
+source "scripts/fg-common.sh"
+
+REVIEW_PER_WORK="${REVIEW_PER_WORK:-2}"   # review passes per work pass — bias to review; it's the bottleneck
+POLL_SECONDS="${POLL_SECONDS:-120}"       # idle wait between cycles when the whole queue is empty
+MAX_CYCLES="${MAX_CYCLES:-0}"             # 0 = run forever
+
+trap 'rule; warn "autopilot stopping."; exit 130' INT TERM
+
+if [ -z "${REVIEW_GITHUB_TOKEN:-}" ]; then
+  warn "REVIEW_GITHUB_TOKEN is not set — running WORK-ONLY (no review passes)."
+  warn "To balance the queue, set REVIEW_GITHUB_TOKEN to a DISTINCT GitHub identity with write access."
+fi
+
+cycle=0
+while :; do
+  cycle=$((cycle + 1))
+  rule; info "${c_bold}autopilot cycle $cycle${c_reset}  (review×${REVIEW_PER_WORK} → work×1)"
+
+  did_something=0
+
+  # --- review side (distinct identity), review-first so we drain before adding ---
+  if [ -n "${REVIEW_GITHUB_TOKEN:-}" ]; then
+    for _ in $(seq 1 "$REVIEW_PER_WORK"); do
+      info "review pass…"
+      if MAX=1 POLL_SECONDS=0 ./review_work.sh "$@"; then did_something=1; fi
+    done
+  fi
+
+  # --- work side (your normal identity) ---
+  info "work pass…"
+  if MAX=1 POLL_SECONDS=0 ./start_work.sh "$@"; then did_something=1; fi
+
+  if [ "$MAX_CYCLES" != 0 ] && [ "$cycle" -ge "$MAX_CYCLES" ]; then
+    ok "Reached MAX_CYCLES=$MAX_CYCLES — stopping."; break
+  fi
+
+  # Both queues were empty this cycle — nap before looking again.
+  if [ "$did_something" = 0 ]; then
+    log "Nothing to review or work right now. Sleeping ${POLL_SECONDS}s… (Ctrl-C to stop)"
+    sleep "$POLL_SECONDS"
+  fi
+done

--- a/docs/adr/0013-autopilot-alternates-review-and-work.md
+++ b/docs/adr/0013-autopilot-alternates-review-and-work.md
@@ -1,0 +1,77 @@
+# ADR-0013: autopilot.sh alternates review and work to keep the queue balanced
+
+- **Status:** proposed (a human maintainer ratifies on merge — agents do not self-ratify runner-architecture changes, per `docs/AUTOMATION.md`)
+- **Date:** 2026-07-03
+- **Deciders:** human maintainer (on merge); drafted by an agent on behalf of @adam91holt
+- **Discussion:** [PR #220](https://github.com/thecolab-ai/the-for-good-project/pull/220)
+
+## Context
+
+The pipeline has two runners by design: `start_work.sh` *produces* work (opens
+PRs) and `review_work.sh` *adversarially reviews* it before it can merge. The
+integrity rule (ADR-0001, enforced by `review_work.sh` and branch protection)
+requires that a review be done by a **different identity than the PR author**,
+so production and review cannot be the same runner under the same identity.
+
+In practice contributors overwhelmingly run the *produce* side — it's the
+visible, satisfying half — so PRs accumulate `status: in-review` faster than
+anyone reviews them. The research side races ahead, the review side starves, and
+the merge queue clogs. Recruiting reviewers helps but relies on humans choosing
+the less glamorous job; nothing in the tooling nudges a single operator to keep
+both sides moving.
+
+Folding the two runners into one script was considered and rejected (see
+Alternatives): it cannot review its own output either, so it does not remove the
+need for a second identity — it only hides it, at the cost of one large stateful
+script.
+
+## Decision
+
+Add **`autopilot.sh`**, a thin conductor that keeps both sides moving from one
+command:
+
+1. **Alternate, review-first, with a ratio.** Each cycle runs
+   `REVIEW_PER_WORK` review passes (default **2**, biased toward review because
+   it is the bottleneck) then **one** work pass, so the queue drains before more
+   is added. `REVIEW_PER_WORK` and an idle `POLL_SECONDS` are env-tunable;
+   `MAX_CYCLES` bounds a run.
+2. **Compose, don't merge.** autopilot only owns the alternation and ratio. It
+   invokes the existing `start_work.sh` / `review_work.sh` with
+   `MAX=1 POLL_SECONDS=0` (do one item, exit rather than poll). All real
+   behaviour — claiming, status labels, worktrees, the PR, the merge gate —
+   stays in those scripts and `scripts/fg-common.sh`, unchanged. No new status
+   labels, queue-contract changes, or gate changes are introduced.
+3. **Preserve the integrity rule explicitly.** The review side runs under a
+   **distinct identity** via `REVIEW_GITHUB_TOKEN`; the work side runs as the
+   operator's normal `gh` identity. If `REVIEW_GITHUB_TOKEN` is unset, autopilot
+   runs **work-only and warns** — it never attempts to review as the author,
+   which the gate would reject anyway.
+
+## Consequences
+
+- A single operator can keep production and review balanced instead of only
+  adding to the backlog; raising `REVIEW_PER_WORK` biases harder toward drain.
+- **autopilot does not remove the need for ≥2 identities in the system.** One
+  machine cannot review its own PRs, so a solo operator still produces PRs no
+  one can merge. autopilot multiplies the throughput of a crew of reviewers; it
+  is not a substitute for one. This is a property of the integrity rule, not a
+  bug to fix here.
+- The runners remain independently runnable and testable; autopilot adds no
+  coupling between them beyond what already exists via `fg-common.sh`.
+- Because it changes how the runners are *operated* (not what they do), it is
+  recorded here and ratified by a human maintainer, per `docs/AUTOMATION.md`.
+
+## Alternatives considered
+
+- **Fuse the two runners into one alternating script.** Rejected: it still
+  cannot review its own output (same identity), so it doesn't remove the
+  second-identity requirement; it trades clean separation for one large
+  stateful script.
+- **A GitHub Action that reviews on a schedule.** Rejected for now: reviewing
+  needs a non-author identity with write access and agent CLI budget; keeping
+  review on contributors' own machines/tokens matches ADR-0005's execution
+  model and avoids centralising token spend. Revisit if a funded bot identity
+  exists.
+- **Do nothing / rely on recruiting reviewers.** Rejected as insufficient
+  alone: it depends on humans repeatedly choosing the less-rewarding half, which
+  is exactly the behaviour that created the imbalance.


### PR DESCRIPTION
**Why (Adam, in-channel):** “otherwise we get imbalance between research and review.” Running only `start_work.sh` floods the review queue; running only `review_work.sh` produces nothing. `autopilot.sh` alternates so the two stay balanced.

**What it is:** a thin conductor — **not** a merge of the two runners. Each cycle it runs `REVIEW_PER_WORK` review passes (default **2**, biased to review since that's the bottleneck) then **one** work pass, review-first so the queue drains before we add to it. It calls the existing `review_work.sh` / `start_work.sh` with `MAX=1 POLL_SECONDS=0` and owns only the alternation + ratio. All real behaviour (claiming, status labels, worktrees, PR, merge gate) stays in the existing scripts, unchanged.

**Integrity rule intact:** review runs under a **distinct identity** via `REVIEW_GITHUB_TOKEN` (work runs as your normal gh identity). Without the token it runs **work-only and warns** — because reviewing your own PRs is a no-op the gate rejects anyway.

**Usage:**
```
REVIEW_GITHUB_TOKEN=<bot-pat> ./autopilot.sh              # balanced
REVIEW_GITHUB_TOKEN=<bot-pat> REVIEW_PER_WORK=3 ./autopilot.sh
MAX_CYCLES=5 ./autopilot.sh
```

`bash -n` clean. Marked **`review: human-only`** — it's a runner-architecture entrypoint, so a human maintainer should merge (agents don't self-ratify structural changes). Follow-ups if you want them: an ADR recording the alternation model, a `docs/AUTOMATION.md` entry, and folding it into the onboarding skill (#208).

🤖 Generated with [Claude Code](https://claude.com/claude-code)