### PR TITLE
fix: commit the shared CLAUDE.md bridge — /CLAUDE.md was wrongly gitignored in #223

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ Thumbs.db
 .idea/
 .vscode/
 
-# Claude Code — local per-contributor config (not the shared AGENTS.md)
-/CLAUDE.md
+# Claude Code — personal, per-contributor config (never commit these).
+# The shared bridge /CLAUDE.md (a one-line @AGENTS.md import) IS committed — leave it
+# tracked. Only these two are personal:
+CLAUDE.local.md
 .claude/settings.local.json
 
 # Local env / secrets — never commit these

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+@AGENTS.md
+
+<!--
+Committed SHARED bridge — not a personal file. Claude Code auto-loads CLAUDE.md, not
+AGENTS.md (https://code.claude.com/docs/en/memory), so this one-line @import pulls the
+canonical AGENTS.md into every contributor's session with zero setup. Leave it tracked —
+don't gitignore or delete it. Personal, per-machine overrides go in CLAUDE.local.md
+(gitignored), which Claude Code loads alongside this file for you only.
+This comment is stripped before load, so it costs no context tokens.
+-->

--- a/docs/GIT-WORKFLOW.md
+++ b/docs/GIT-WORKFLOW.md
@@ -38,8 +38,10 @@ are the same everywhere; only the buttons differ.
    You can't approve or merge your own work.
 6. **Want several things open at once?** Use **worktrees**, not several clones —
    one repo, many folders, each on a different branch.
-7. **Keep local config out of commits** — your `CLAUDE.md` and
-   `.claude/settings.local.json` are personal and already gitignored.
+7. **The shared `CLAUDE.md` is committed; keep your *personal* config out.** `CLAUDE.md`
+   is a tiny tracked bridge (`@AGENTS.md`) so Claude Code — which loads `CLAUDE.md`, not
+   `AGENTS.md` — picks up this repo's guidance. Your personal `CLAUDE.local.md` and
+   `.claude/settings.local.json` are gitignored; never stage them.
 8. **Merges are squash-merges**, so don't agonise over tidy branch history — it
    collapses to one commit on merge.
 9. **After your PR merges, delete the branch and clean up any worktree.**
@@ -228,20 +230,24 @@ own branch, force-pushing your own rework (`git push --force-with-lease`) is fin
 
 ---
 
-## Local, uncommitted config — keep it out of git
+## Agent config: shared `CLAUDE.md` vs. personal files
 
-Working on this repo with an AI agent creates **personal** files that must never
-be committed:
+Claude Code auto-loads **`CLAUDE.md`**, not `AGENTS.md`
+([claude-code#34235](https://github.com/anthropics/claude-code/issues/34235);
+[memory docs](https://code.claude.com/docs/en/memory)). So this repo commits a tiny
+**shared bridge** and keeps everything personal out of git:
 
-- **`/CLAUDE.md`** (root) — a local pointer so Claude Code loads this repo's
-  `AGENTS.md`. Yours, not shared.
-- **`.claude/settings.local.json`** — your local tool/permission settings.
+- **`/CLAUDE.md`** (root, **committed — leave it tracked**) — one `@AGENTS.md` import, so
+  every contributor's Claude Code loads the canonical [`AGENTS.md`](../AGENTS.md) with zero
+  setup. It's shared, not personal — don't gitignore or delete it.
+- **`CLAUDE.local.md`** (root, **gitignored**) — your private per-project notes. Claude
+  Code loads it alongside `CLAUDE.md`, for you only. Personal overrides go here.
+- **`.claude/settings.local.json`** (**gitignored**) — your local tool/permission settings.
 
-Both are gitignored at the repo level, so a normal `git add -A` won't pick them
-up. If you ever see them in `git status` staged, unstage them — don't commit your
-personal agent config into the shared repo. (Shared, checked-in agent config
-lives in `AGENTS.md` and the tracked `.claude/skills/` — those *are* meant to be
-in git; your per-machine config is not.)
+The two personal files won't be caught by `git add -A`. If you ever see them staged,
+unstage them — don't commit personal agent config into the shared repo. (Shared,
+checked-in agent config lives in `CLAUDE.md` → `AGENTS.md` and the tracked
+`.claude/skills/` — those *are* meant to be in git; your per-machine config is not.)
 
 ---
 
@@ -289,8 +295,9 @@ imperative form.
    the author's own PR branch during rework.
 8. **Never create, apply, or remove the `review: human-only` label**, and never
    act on a PR that carries it — those are human-maintainer only. ([AGENTS.md](../AGENTS.md))
-9. **Keep personal config uncommitted** — never stage `CLAUDE.md` or
-   `.claude/settings.local.json`.
+9. **Never gitignore or delete the committed `CLAUDE.md` bridge** — it's how Claude Code
+   loads the repo's guidance. Keep *personal* config uncommitted instead:
+   `CLAUDE.local.md` and `.claude/settings.local.json`.
 10. **When a step needs write access you lack, escalate — don't retry the 403 or
     work around the permission.** Post the exact commands for a maintainer per
     [ADR-0009](adr/0009-maintainer-escalation-handoff.md).


### PR DESCRIPTION
Closes #265. Refs #222, #223.

## The regression (live on `main`)

#223 squash-merged as `f76c750`, which **gitignores `/CLAUDE.md`** and commits no bridge file. **Claude Code auto-loads `CLAUDE.md`, not `AGENTS.md`** ([claude-code#34235](https://github.com/anthropics/claude-code/issues/34235); [memory docs](https://code.claude.com/docs/en/memory) — *"Claude Code reads `CLAUDE.md`, not `AGENTS.md`"*). So every fresh clone gets the one file Claude Code reads ignored, with no committed `CLAUDE.md` at all → **zero repo context**. The `.gitignore` rule even blocks committing the bridge that would fix it.

## Why it merged, and why a fresh PR

@thecolab-clawd flagged this exact problem in a **non-blocking heads-up** at 10:01Z, but the PR merged at 10:05Z — a non-blocking comment doesn't hold the gate, so the merge automation landed the flawed branch. It shouldn't have merged in that state. #222 is legitimately "done" for the doc it shipped, so this is a follow-forward fix on its own issue (#265) rather than a reopen.

## How it happened (post-mortem, owning it)

- A parked `.gitignore` patch used the **wrong filename** — `/CLAUDE.md` (the shared bridge) instead of `CLAUDE.local.md` (the personal file) — and never committed a bridge.
- #223's first review correctly caught the doc claiming these were ignored when they weren't, and offered "add the rules **(A)** or reword **(B)**".
- **Option A** was folded in on a wrong reassurance that ignoring `CLAUDE.md` was "consistent with the repo's design" — which missed that `CLAUDE.md` is the file Claude Code loads.

## The fix

- ✅ Commit `/CLAUDE.md` = `@AGENTS.md` — the documented bridge; loads `AGENTS.md` for every contributor with zero setup. (The "leave this tracked, don't delete" note for humans lives in an HTML comment, stripped before load, so it costs no context tokens.)
- ✅ `.gitignore`: ignore **`CLAUDE.local.md`** (genuinely personal; Claude Code loads it *alongside* `CLAUDE.md`) instead of `/CLAUDE.md`; keep the correct `.claude/settings.local.json` line.
- ✅ Reword `docs/GIT-WORKFLOW.md` (the same lines the first review flagged) to state shared-bridge-vs-personal correctly, with citations.
- ✅ Drop the local `.git/info/exclude` `/CLAUDE.md` shim that was shadowing the committed file.

`npm run validate` passes (59 files).

## Review

Leaving this open for **non-author** review by @thecolab-clawd — whose merge automation landed the original flawed branch, so it has the context. No self-review, no self-merge.

Opened via Claude Code on behalf of @joesutheran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
