### PR TITLE
research: NZ flood-risk disclosure to buyers vs lender practice (Closes #264)

### DIFF
--- a/research/findings/other/nz-flood-lending-buyer-disclosure.md
+++ b/research/findings/other/nz-flood-lending-buyer-disclosure.md
@@ -1,0 +1,111 @@
+---
+title: "NZ flood-risk disclosure to buyers has strengthened on paper, but lender practice and real-world visibility still lag the risk"
+domain: "other"
+issue: "#264"
+confidence: "Medium"
+author: "claude-opus-4-8 (agent)"
+agent: "claude"
+model: "claude-opus-4-8"
+date: "2026-07-03"
+status: "draft"
+---
+
+# What flood/natural-hazard information an NZ buyer, lender, and conveyancer actually sees before purchase — and whether bank lending accounts for insurance-retreat risk
+
+## Executive answer
+
+- **Legal disclosure has genuinely improved.** From **1 July 2025** LGOIMA amendments require regional councils to hand all hazard information to territorial authorities, and from **17 October 2025** the *Local Government (Natural Hazard Information in Land Information Memoranda) Regulations 2025* require every LIM to carry a standardised **natural-hazard section** with a **plain-language summary** ([Regulations 2025, ss 2, 7–11](https://www.legislation.govt.nz/regulation/public/2025/0068/latest/whole.html); [Simpson Grierson](https://www.simpsongrierson.com/insights-news/legal-updates/streamlining-natural-hazard-information-in-lims-what-new-requirements-mean-in-practice-for-both-councils-and-customers)).
+- **But a LIM is a disclosure of information the council *already holds* — not a risk assessment of the specific property.** The regulations expressly **do not require** a council to prepare a risk assessment, do further analysis, or search for hazard information beyond what it must already include ([Regulations 2025, reg 6](https://www.legislation.govt.nz/regulation/public/2025/0068/latest/whole.html)). So what a buyer "sees" still depends on how much hazard data their council has mapped.
+- **What a buyer actually looks at is fragmented and opt-in:** a LIM (paid, usually ordered by the buyer's lawyer), the free **Natural Hazards Portal**, council flood maps, and — increasingly — the **insurance quote itself**, which now often prices flood risk. The Natural Hazards Commission's own home-buyer guidance points buyers to all of these plus a pre-purchase inspection ([NHC, Buying a home](https://www.naturalhazards.govt.nz/be-prepared/home-buyers/understand-the-risks/)).
+- **Banks do *not* systematically account for insurance-retreat risk.** RBNZ's 2023 Climate Stress Test found banks lack cost-effective ways to even **track whether mortgaged homes stay insured**, and recommended they fix this ([RBNZ, Apr 2024](https://web.archive.org/web/20260703112646/https://www.rbnz.govt.nz/news-and-events/news/2024/04/climate-stress-test-assesses-resilience-of-major-nz-banks)). By mid-2026 only *"some banks"* assess flood risk at loan origination, and LVR/top-up restrictions for high-risk homes are still only *"being considered"* ([RBNZ FSR May 2026](https://web.archive.org/web/20260510114013/https://www.rbnz.govt.nz/financial-stability/financial-stability-report/financial-stability-reports/2026/may/financial-stability-report-may-2026/web-version)). New Zealand's LVR limits are **macroprudential, not hazard-based** — and were *loosened* in December 2025.
+- **Net:** disclosure is catching up, but the sharpest live signal of flood risk reaching buyers is **insurance pricing/retreat**, not the LIM or the mortgage. ~6% of properties (~120,000) are assessed by RBNZ as high flood risk, and flood-risk premiums are already appearing in quotes ([RBNZ FSR May 2024](https://web.archive.org/web/20260226122011/https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2024/may-2024/fsr-may-24-special-topic-2)).
+
+**Overall confidence:** Medium — the legal/regulatory facts are High confidence (primary legislation), but "what a buyer *actually* sees" and individual bank lending policy are only partially observable (mostly through RBNZ's aggregate reporting; individual bank criteria are not public).
+
+## Evidence
+
+### 1. The legal disclosure regime — two-stage, 2025
+
+Natural-hazard disclosure to buyers runs primarily through the **Land Information Memorandum (LIM)**, a report a buyer (usually via their lawyer/conveyancer) requests from the territorial authority. Two 2025 changes reshaped it:
+
+- **1 July 2025 — LGOIMA amendments.** The *Local Government Official Information and Meetings Amendment Act 2023* provisions took effect, requiring **regional councils to supply all the hazard information they hold to territorial authorities** (who issue LIMs), including modelled/potential hazards, so the body writing the LIM has the region's hazard data ([Simpson Grierson](https://www.simpsongrierson.com/insights-news/legal-updates/streamlining-natural-hazard-information-in-lims-what-new-requirements-mean-in-practice-for-both-councils-and-customers); [Rice Speir](https://ricespeir.co.nz/natural-hazard-information-whats-changing-for-lims-in-2025/)).
+- **17 October 2025 — LIM natural-hazard regulations.** The *Local Government (Natural Hazard Information in Land Information Memoranda) Regulations 2025* came into force ([Regulations 2025, reg 2](https://www.legislation.govt.nz/regulation/public/2025/0068/latest/whole.html)). They require each LIM to include a dedicated **natural-hazard section** (reg 7), certain **maps** (reg 10), a **plain-language summary** where a technical report exists (reg 11), and information from the district plan and various notices (regs 12–13). The intent is clearer, more consistent, more accessible hazard information for lay buyers ([Anderson Lloyd](https://www.al.nz/lims-are-changing-to-give-more-information-about-natural-hazards-what-property-owners-need-to-know/)).
+
+### 2. The load-bearing limit: a LIM discloses held information, it does not assess the property
+
+This is the crux for "what a buyer really sees." Regulation 6 states the regulations **do not require** a territorial authority:
+
+> "(a) to prepare a risk assessment that relates to the land concerned; or (b) to undertake any further analysis that relates to the land concerned; or (c) to search for, or make inquiries as to the existence of, information about natural hazards … other than information that the territorial authority is required to include under section 44B of the Act." ([Regulations 2025, reg 6](https://www.legislation.govt.nz/regulation/public/2025/0068/latest/whole.html))
+
+Legal commentary reaches the same conclusion: "LIMs remain disclosure documents, not risk assessments … councils are not required to prepare new risk assessments or otherwise undertake specific analysis" — they report what they already hold, and "determining what constitutes a hazard affecting particular land … remains a judgment call" ([Simpson Grierson](https://www.simpsongrierson.com/insights-news/legal-updates/streamlining-natural-hazard-information-in-lims-what-new-requirements-mean-in-practice-for-both-councils-and-customers)). So **visibility is bounded by how much hazard mapping the council has done** — a well-mapped urban catchment yields a rich LIM; a data-poor area yields a thin one, and the absence of a listed hazard is not evidence of safety.
+
+### 3. What a buyer/conveyancer actually consults
+
+The Natural Hazards Commission Toka Tū Ake (NHC, formerly EQC) home-buyer guidance points buyers to a **layered, opt-in** set of sources, not a single authoritative disclosure:
+
+- **The LIM** — "You can get information about flood risk from your local or regional council, and it should be present on a Land Information Memorandum (LIM) report" ([NHC](https://www.naturalhazards.govt.nz/be-prepared/home-buyers/understand-the-risks/)). A LIM is paid-for and typically ordered by the buyer's lawyer during due diligence; it is not automatic.
+- **The free [Natural Hazards Portal](https://www.naturalhazardsportal.govt.nz/)** and **council hazard maps** — NHC tells buyers to "check the geological hazard maps on the Natural Hazard Portal to check what hazards the property is likely to be affected by."
+- **Professional inspection** — NHC recommends a pre-purchase inspection and, for high-hazard properties, a structural/geotechnical engineer ([NHC checklist](https://www.naturalhazards.govt.nz/assets/Be-Prepared/NHC-buying-a-home-checklist.pdf)).
+- **The insurance quote.** Because insurers now price flood risk (see §5), a buyer who obtains a quote before settling gets a market signal that a LIM may not spell out.
+
+Conveyancing practice therefore layers LIM + title + client's own portal/insurer checks; the LIM is the formal instrument, but it is one input, and the buyer must actively commission and read it.
+
+### 4. Lenders: insurance-retreat risk is a known gap, not yet embedded in lending
+
+RBNZ has repeatedly flagged that **banks cannot reliably see the insurance status of the homes they lend against**:
+
+- **2023 Climate Stress Test (published Apr 2024).** RBNZ's recommendations to banks included "considering cost-effective ways of **tracking the insurance status of mortgages**" — i.e. banks currently can't do this well ([RBNZ, Apr 2024](https://web.archive.org/web/20260703112646/https://www.rbnz.govt.nz/news-and-events/news/2024/04/climate-stress-test-assesses-resilience-of-major-nz-banks)).
+- **FSR May 2024.** "Banks need to work with insurers to obtain better and more regular information on mortgaged properties' insurance status. This was a finding from our Climate Stress Test." It also warned "Banks need to be conscious of the ongoing insurability of the properties against which they lend[,] … more scrutiny in their lending decisions than currently" ([RBNZ FSR May 2024](https://web.archive.org/web/20260226122011/https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2024/may-2024/fsr-may-24-special-topic-2)).
+- **FSR May 2026 — where practice has (and hasn't) got to.** "Mortgage contracts typically require borrowers to maintain insurance, but banks often lack mechanisms to systematically monitor compliance." On response: "**Some** banks get information from individual insurers to identify under-insurance … **Some** are assessing physical risks, such as flood risk, at loan origination rather than relying solely on whether a property is insured. For properties identified as under-insured or in high-risk areas, **policy responses are being considered** such as restricting top-ups or limiting loan-to-value ratios for new lending. We encourage banks to continue this work." ([RBNZ FSR May 2026](https://web.archive.org/web/20260510114013/https://www.rbnz.govt.nz/financial-stability/financial-stability-report/financial-stability-reports/2026/may/financial-stability-report-may-2026/web-version))
+
+The language ("some", "being considered", "we encourage") shows hazard-aware lending is **emerging and uneven**, not standard. Crucially, NZ's formal LVR limits are a **macroprudential** tool applied across the market, not a hazard screen — and in December 2025 RBNZ *increased* the share of high-LVR lending banks may write, loosening (not tightening) settings ([RBNZ FSR May 2026](https://web.archive.org/web/20260510114013/https://www.rbnz.govt.nz/financial-stability/financial-stability-report/financial-stability-reports/2026/may/financial-stability-report-may-2026/web-version)). So there is currently **no market-wide LVR mechanism that prices in flood/insurance-retreat risk**; where it happens, it is individual banks' internal, largely undisclosed origination criteria.
+
+### 5. The signal that *is* reaching the market: insurance pricing
+
+RBNZ's flood-risk analysis quantifies the exposure and shows insurers already differentiating price:
+
+- "Around 6% of properties (around 120,000) are assessed [as] being at high flood risk" (riverine/surface-water flood expected more often than once in 100 years) ([RBNZ FSR May 2024](https://web.archive.org/web/20260226122011/https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2024/may-2024/fsr-may-24-special-topic-2)).
+- For those, "an average of around 20% of the insurers' quotes were assessed as including additional flood risk premiums averaging $250 or more annually ('flood pricing')," varying sharply by suburb ([RBNZ FSR May 2024](https://web.archive.org/web/20260226122011/https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2024/may-2024/fsr-may-24-special-topic-2)).
+- Residential insurance uptake is ~96%, but RBNZ warns of "insurance affordability, underinsurance and insurance retreat from areas exposed to elevated flooding risk" as growing financial-stability pressures ([RBNZ FSR May 2024](https://web.archive.org/web/20260226122011/https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2024/may-2024/fsr-may-24-special-topic-2)), and by Nov 2025 notes insurers "continued to adopt more risk-based pricing of dwelling insurance" with premiums "gradually becoming less affordable for some" ([RBNZ FSR Nov 2025](https://web.archive.org/web/20260506213731/https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2025/november/financial-stability-report-november-2025/web-version)).
+
+So the risk price is arriving through insurers first — reaching buyers who obtain a quote — ahead of both the LIM's descriptive disclosure and the mortgage decision. This directly matters to the stream's premise (flood-zone values rising, [#254](https://github.com/thecolab-ai/the-for-good-project/issues/254)): the disclosure channel most likely to change a buyer's price is the one they may only encounter *after* going unconditional.
+
+## Surprising or load-bearing claims
+
+| Claim | Source 1 | Source 2 | Confidence |
+|---|---|---|---|
+| A 2025-reformed LIM discloses hazard info the council already holds; it does **not** require a property-specific risk assessment or new analysis | [Regulations 2025, reg 6 (primary)](https://www.legislation.govt.nz/regulation/public/2025/0068/latest/whole.html) | [Simpson Grierson legal update](https://www.simpsongrierson.com/insights-news/legal-updates/streamlining-natural-hazard-information-in-lims-what-new-requirements-mean-in-practice-for-both-councils-and-customers) | High |
+| Banks lack systematic means to track whether mortgaged homes stay insured; RBNZ recommended they build this | [RBNZ Climate Stress Test, Apr 2024](https://web.archive.org/web/20260703112646/https://www.rbnz.govt.nz/news-and-events/news/2024/04/climate-stress-test-assesses-resilience-of-major-nz-banks) | [RBNZ FSR May 2026 ("often lack mechanisms to systematically monitor compliance")](https://web.archive.org/web/20260510114013/https://www.rbnz.govt.nz/financial-stability/financial-stability-report/financial-stability-reports/2026/may/financial-stability-report-may-2026/web-version) | High |
+| Hazard-aware lending (origination flood checks, LVR/top-up limits) is only *emerging* — "some" banks, still "being considered" | [RBNZ FSR May 2026 (primary)](https://web.archive.org/web/20260510114013/https://www.rbnz.govt.nz/financial-stability/financial-stability-report/financial-stability-reports/2026/may/financial-stability-report-may-2026/web-version) | [RBNZ FSR May 2024 ("more scrutiny … than currently")](https://web.archive.org/web/20260226122011/https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2024/may-2024/fsr-may-24-special-topic-2) | Medium |
+| ~6% of properties (~120,000) high flood risk; ~20% of quotes carry flood pricing (avg $250+) | [RBNZ FSR May 2024 (primary; single-source RBNZ analysis)](https://web.archive.org/web/20260226122011/https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2024/may-2024/fsr-may-24-special-topic-2) | *Single authoritative source (RBNZ's own dataset) — no independent replication found* | Medium |
+
+## What would change this conclusion
+
+- **Public, hazard-based bank lending policy.** If a major bank published (or RBNZ mandated) an explicit flood/insurance-retreat LVR or serviceability overlay applied market-wide, the "lending doesn't systematically account for retreat" conclusion would weaken. The **Council of Financial Regulators** review of insurance pricing/affordability, directed by Cabinet and reporting mid-2026, could shift this — I could not verify its outcome as at 3 Jul 2026 and flag it as the key watch-item ([search-surfaced; unverified primary]).
+- **Evidence LIMs are, in practice, comprehensive.** If council hazard mapping is near-complete nationally, the "held-information-only" limit matters less. I could not verify coverage completeness across councils — this needs a council-by-council data audit and likely a practitioner (conveyancer/council LIM officer) with lived experience of what actually lands on a LIM.
+- **Independent replication of the 6%/120,000 and flood-pricing figures.** These rest on RBNZ's own dataset (Finity Consulting/Treasury inputs). An independent hazard-layer × insurance-quote study (e.g. via `linz-data-service` hazard layers) could confirm or revise them.
+- **Individual bank origination criteria are not public.** I relied on RBNZ's aggregate characterisation ("some banks…"). Direct confirmation would need bank lending policies or supervisory data I can't access.
+
+Two things I could **not** verify and that need a human: (1) actual buyer behaviour — how many buyers order and read a LIM *before going unconditional* vs after; (2) the mid-2026 CoFR review conclusions.
+
+## Open follow-up questions
+
+- How complete and consistent is council natural-hazard mapping nationally, and how does that variation shape what different LIMs actually disclose? (Potential sub-issue; would use council data + `nz-council`/LGOIMA requests.)
+- What is the outcome of the 2026 Council of Financial Regulators review of insurance pricing/affordability, and does it recommend any mandatory bank tracking of insurance status or hazard-based lending?
+- Do sale-and-purchase / conveyancing timelines mean the flood signal (insurance quote) typically arrives before or after a buyer is contractually committed?
+
+## Sources
+
+1. *Local Government (Natural Hazard Information in Land Information Memoranda) Regulations 2025* (SL 2025/68) — https://www.legislation.govt.nz/regulation/public/2025/0068/latest/whole.html (fetched 3 Jul 2026 via curl with browser UA; legislation.govt.nz 403s to plain fetchers).
+2. RBNZ, *Financial Stability Report May 2024 — Special Topic 2: Insurance availability and risk-based pricing* — https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2024/may-2024/fsr-may-24-special-topic-2 (via Wayback snapshot https://web.archive.org/web/20260226122011/... — RBNZ 403s to fetchers; accessed 3 Jul 2026).
+3. RBNZ, *Financial Stability Report May 2026* (web version) — https://www.rbnz.govt.nz/financial-stability/financial-stability-report/financial-stability-reports/2026/may/financial-stability-report-may-2026/web-version (via Wayback https://web.archive.org/web/20260510114013/...; accessed 3 Jul 2026).
+4. RBNZ, *Financial Stability Report November 2025* (web version) — https://www.rbnz.govt.nz/hub/publications/financial-stability-report/2025/november/financial-stability-report-november-2025/web-version (via Wayback https://web.archive.org/web/20260506213731/...; accessed 3 Jul 2026).
+5. RBNZ news, *Climate Stress Test assesses resilience of major NZ banks* (Apr 2024) — https://www.rbnz.govt.nz/hub/news/2024/04/climate-stress-test-assesses-resilience-of-major-nz-banks (via Wayback https://web.archive.org/web/20260703112646/...; accessed 3 Jul 2026).
+6. Simpson Grierson, *Streamlining natural hazard information in LIMs — what new requirements mean in practice* — https://www.simpsongrierson.com/insights-news/legal-updates/streamlining-natural-hazard-information-in-lims-what-new-requirements-mean-in-practice-for-both-councils-and-customers (accessed 3 Jul 2026).
+7. Rice Speir, *Natural Hazard Information: what's changing for LIMs in 2025* — https://ricespeir.co.nz/natural-hazard-information-whats-changing-for-lims-in-2025/ (accessed 3 Jul 2026).
+8. Anderson Lloyd, *LIMs are changing to give more information about Natural Hazards* — https://www.al.nz/lims-are-changing-to-give-more-information-about-natural-hazards-what-property-owners-need-to-know/ (accessed 3 Jul 2026).
+9. Natural Hazards Commission Toka Tū Ake, *Check natural hazard risks when house hunting* — https://www.naturalhazards.govt.nz/be-prepared/home-buyers/understand-the-risks/ (accessed 3 Jul 2026).
+10. Natural Hazards Commission Toka Tū Ake, *Buying a home checklist* (PDF) — https://www.naturalhazards.govt.nz/assets/Be-Prepared/NHC-buying-a-home-checklist.pdf (accessed 3 Jul 2026).
+11. Natural Hazards Portal — https://www.naturalhazardsportal.govt.nz/ (accessed 3 Jul 2026).
+</content>
+</invoke>


### PR DESCRIPTION
Closes #264. Stream: #254

Finding on what flood/natural-hazard information an NZ buyer, lender, and conveyancer actually sees before purchase, and whether bank lending accounts for insurance-retreat risk. Key result: 2025 LGOIMA + LIM natural-hazard regulations strengthened disclosure, but a LIM discloses info councils already hold (not a property risk assessment, reg 6); banks still lack systematic insurance-status tracking and there is no market-wide hazard-based LVR — insurance pricing is the sharpest live flood signal reaching buyers. Sourced primarily to legislation.govt.nz and RBNZ FSRs / Climate Stress Test (fetched via Wayback where RBNZ 403s plain fetchers).