### PR TITLE
fix(runners): stop the rework ping-pong that wedged #234/#307

### DIFF
--- a/review_work.sh
+++ b/review_work.sh
@@ -447,6 +447,22 @@ review_one() {  # $1 = PR number
     gh pr review "$pr" --repo "$REPO" --approve "${body_flag[@]}" >/dev/null \
       || gh pr comment "$pr" --repo "$REPO" "${body_flag[@]}" >/dev/null || true
     set_check "$sha" success "Adversarial review passed" "$url"
+    # A CHANGES_REQUESTED review from an EARLIER revision keeps the PR's
+    # reviewDecision at CHANGES_REQUESTED until its author re-reviews or it is
+    # dismissed — reviewers here never re-review their own round, so a passed,
+    # multiply-approved PR can stay unmergeable forever (#307 wedged this way
+    # with three approvals). This review just PASSED the current head, so any
+    # changes-request tied to a superseded commit is settled: dismiss it,
+    # best-effort (needs write access; the review text itself stays visible).
+    local stale_rid
+    for stale_rid in $(gh api "repos/$OWNER/$NAME/pulls/$pr/reviews" \
+        --jq ".[]|select(.state==\"CHANGES_REQUESTED\" and .commit_id!=\"$sha\")|.id" 2>/dev/null || true); do
+      gh api -X PUT "repos/$OWNER/$NAME/pulls/$pr/reviews/$stale_rid/dismissals" \
+        -f message="Superseded: rework was pushed after this review and a fresh adversarial review passed at $sha." \
+        -f event="DISMISS" >/dev/null 2>&1 \
+        && log "  dismissed stale changes-request $stale_rid (superseded revision)" \
+        || warn "  couldn't dismiss stale changes-request $stale_rid (needs write access) — merge may stay blocked."
+    done
     if [ "$AUTO_MERGE" = 1 ]; then
       info "AUTO_MERGE=1 — merging #$pr..."
       if gh pr merge "$pr" --repo "$REPO" --squash --delete-branch >/dev/null 2>&1; then

--- a/start_work.sh
+++ b/start_work.sh
@@ -209,6 +209,16 @@ claim_issue() {  # $1 = issue number; returns 0 if we hold the claim
   # Re-check it's still available (best-effort lock via the label + assignee).
   local labels; labels="$(issue_labels "$n")"
   case ",$labels," in *",status: available,"*) : ;; *) warn "#$n no longer available — skipping."; return 1 ;; esac
+  # Never start FRESH work on an issue that already has an open PR: a claim
+  # race that slips past the tie-break can otherwise produce two PRs for one
+  # issue (#305 + #307 both closed #234), and the loser's stale PR wedges the
+  # rework automation. The label is wrong in that state (should be in-review,
+  # not available) — leave that to a human/reconciler; just don't pile on.
+  local existing; existing="$(pr_for_issue "$n" || true)"
+  if [ -n "$existing" ]; then
+    warn "#$n already has open PR #$existing — skipping instead of opening a duplicate."
+    return 1
+  fi
   if [ "$DRY_RUN" = 1 ]; then info "[dry-run] would claim #$n (assign @$ME, status: available → claimed)"; return 0; fi
   gh issue edit "$n" --repo "$REPO" --add-assignee "@me" \
      --add-label "status: claimed" --remove-label "status: available" >/dev/null
@@ -319,14 +329,40 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
     fi
     return 0
   fi
+  # Only rework a CURRENT changes-request. A review is tied to the commit it
+  # judged: commits pushed AFTER the last CHANGES_REQUESTED review mean the
+  # rework already happened and the PR is waiting on a fresh review — feeding
+  # the same superseded feedback to another agent run just burns budget and
+  # spams the PR (this fed #307's agents the same addressed review 30+ times).
+  # ISO-8601 timestamps compare lexically, same as reconcile_rework.
+  local lastcr headdate
+  lastcr="$(gh pr view "$pr" --repo "$REPO" --json reviews --jq '[.reviews[]|select(.state=="CHANGES_REQUESTED")]|last|.submittedAt // ""' 2>/dev/null || true)"
+  headdate="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate // ""' 2>/dev/null || true)"
+  if [ -n "$lastcr" ] && [ -n "$headdate" ] && [[ "$headdate" > "$lastcr" ]]; then
+    log "#$n's last changes-request predates PR #$pr's head commit — already reworked; parking at in-review to await a fresh review (no agent run)."
+    [ "$DRY_RUN" = 0 ] && set_status_label "$n" "in-review" "changes-requested"
+    return 0
+  fi
   branch="$(gh pr view "$pr" --repo "$REPO" --json headRefName --jq .headRefName)"
   if [ "$DRY_RUN" = 1 ]; then
     info "[dry-run] would rework PR #$pr (branch $branch) against the review feedback, push, and move #$n → in-review"
     return 0
   fi
+  # Claim the rework (changes-requested → claimed) so ANOTHER loop of the same
+  # account doesn't pick it up mid-run — rework_issues() filters on the label,
+  # so this shrinks the duplicate-pick window from a full agent run (~40 min,
+  # which produced back-to-back duplicate reworks of #307) to seconds. Re-check
+  # the label first: a second loop working from an older queue snapshot bails
+  # here instead of double-claiming. A crash after the flip leaves the issue
+  # 'claimed' + assigned; reap.sh TTL-frees it as usual.
+  case ",$(issue_labels "$n")," in
+    *",status: changes-requested,"*) : ;;
+    *) log "#$n is no longer changes-requested — another loop got there first. Skipping."; return 0 ;;
+  esac
+  set_status_label "$n" "claimed" "changes-requested" || true
   local before after
   before="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"
-  make_worktree "origin/$branch" || { err "Couldn't create worktree for PR #$pr (branch $branch) — leaving #$n for a future loop."; return 1; }
+  make_worktree "origin/$branch" || { err "Couldn't create worktree for PR #$pr (branch $branch) — leaving #$n for a future loop."; set_status_label "$n" "changes-requested" "claimed" || true; return 1; }
   info "Handing PR #$pr rework to $AGENT (worktree: $WORKTREE)..."
   local tmp; tmp="$(mktemp)"
   set +e; run_agent "$(rework_prompt "$n" "$pr" "$branch")" "$WORKTREE" 2>&1 | tee "$tmp"; local rc=${PIPESTATUS[0]}; set -e
@@ -336,6 +372,7 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
   if was_usage_limited "$tmp"; then
     warn "Rework of #$n hit an API usage/rate limit — leaving it 'changes-requested' and backing off ${USAGE_LIMIT_SLEEP}s (no failure posted)."
     rm -f "$tmp"; remove_worktree
+    set_status_label "$n" "changes-requested" "claimed" || true
     sleep "$USAGE_LIMIT_SLEEP"
     return 0
   fi
@@ -344,10 +381,11 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
   remove_worktree
   after="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"
   if [ "$after" != "$before" ]; then
-    set_status_label "$n" "in-review" "changes-requested"
+    set_status_label "$n" "in-review" "claimed" "changes-requested"
     gh issue comment "$n" --repo "$REPO" --body "🔁 Rework pushed to PR #$pr — moving back to **in review** for a fresh adversarial review." >/dev/null || true
     ok "#$n → in-review (rework pushed to PR #$pr)"
   else
+    set_status_label "$n" "changes-requested" "claimed" || true
     warn "Agent pushed no new commits to PR #$pr — leaving #$n as 'changes-requested' for a future loop."
   fi
 }
@@ -377,6 +415,13 @@ reconcile_rework() {
     [ -n "$headcommit" ] && [[ "$headcommit" > "$lastcr" ]] && continue
     iss="$(issue_addressed_by_pr "$pr" || true)"
     [ -z "$iss" ] && continue
+    # A duplicate-claim race can leave TWO open PRs addressing one issue
+    # (#305/#307 both closed #234). Every rework loop pushes to the CANONICAL
+    # PR — the one pr_for_issue resolves to — so a stale sibling PR must never
+    # route the issue: its changes-request stays current forever (nobody pushes
+    # to it) and it would flip the issue back to changes-requested every cycle.
+    # FAIL CLOSED: an empty lookup (rate limit) also skips.
+    [ "$(pr_for_issue "$iss" || true)" = "$pr" ] || continue
     labels="$(issue_labels "$iss" 2>/dev/null || true)"
     case ",$labels," in
       *",status: changes-requested,"*) continue ;;   # already routed


### PR DESCRIPTION
## The bug

Issue #234 ended up with **two open PRs closing it** (#305 by @richardofortune, #307 by @adam91holt) after a claim race. Every worker resolves the issue to the *newest* PR (#307) via `pr_for_issue`, so #305 was never reworked — which made its `CHANGES_REQUESTED` review permanently "current". Richard's `reconcile_rework` then flipped #234 back to `changes-requested` on **every poll cycle**, each flip triggering a fresh full agent rework of #307 fed the *same already-addressed review feedback*. Result: 33 "Rework pushed" cycles on #234, 108 comments on #307, and #307 unmergeable despite **three approvals** because one stale changes-request was never dismissed. Two `start_work.sh` loops running as the same account doubled the churn.

## The fixes

1. **`reconcile_rework` canonical-PR guard** — only the PR that `pr_for_issue` resolves to may route its issue back to `changes-requested`; stale sibling PRs are ignored (fail-closed on lookup failure).
2. **`rework_one` stale-review skip** — if the last changes-request predates the PR head commit, the rework already happened: park the issue back at `in-review` to await a fresh review instead of burning an agent run on superseded feedback.
3. **`rework_one` claim** — flip `changes-requested → claimed` for the duration of the run (with a pre-flip label re-check) so a second loop of the same account can't double-rework; every exit path (worktree failure, usage limit, no-push, success) restores the right label.
4. **`claim_issue` duplicate-PR guard** — never start fresh work on an issue that already has an open PR.
5. **`review_work.sh` stale-review dismissal on PASS** — after approving the current head, dismiss `CHANGES_REQUESTED` reviews tied to superseded commits (best-effort, needs write access) so `reviewDecision` clears and auto-merge can actually fire.

## Manual cleanup still needed (maintainer)

- Close #305 as superseded by #307.
- Dismiss the stale changes-request on #307 (review id `4625426075`, against `a065b70`; three approvals exist at later commits).
- Un-assign one of the two assignees on #234.
- Run at most **one** `start_work.sh` per identity per repo (thebeast had three).

Verified with `bash -n` and a `DRY_RUN=1` pass of the queue logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaCFSqfJDTmT1wGn8yvBYv