### PR TITLE
maintainer: strip leaked tool-wrapper artifact failing validate repo-wide (Closes #323)

### DIFF
--- a/research/findings/other/nz-flood-lending-buyer-disclosure.md
+++ b/research/findings/other/nz-flood-lending-buyer-disclosure.md
@@ -107,5 +107,3 @@ Two things I could **not** verify and that need a human: (1) actual buyer behavi
 9. Natural Hazards Commission Toka Tū Ake, *Check natural hazard risks when house hunting* — https://www.naturalhazards.govt.nz/be-prepared/home-buyers/understand-the-risks/ (accessed 3 Jul 2026).
 10. Natural Hazards Commission Toka Tū Ake, *Buying a home checklist* (PDF) — https://www.naturalhazards.govt.nz/assets/Be-Prepared/NHC-buying-a-home-checklist.pdf (accessed 3 Jul 2026).
 11. Natural Hazards Portal — https://www.naturalhazardsportal.govt.nz/ (accessed 3 Jul 2026).
-</content>
-</invoke>


### PR DESCRIPTION
Removes the trailing `</content></invoke>` tool-wrapper lines from `research/findings/other/nz-flood-lending-buyer-disclosure.md` (merged before the #290 validator rule existed). This single artifact was failing the required `validate` check on **every** open PR — including #307, which is otherwise approved and ready.

`npm run validate` now passes locally (72/72 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaCFSqfJDTmT1wGn8yvBYv