### PR TITLE
ci: hourly workflow to update .skills submodule

### DIFF
--- a/.github/workflows/update-skills-submodule.yml
+++ b/.github/workflows/update-skills-submodule.yml
@@ -1,0 +1,43 @@
+# Keep the vendored `.skills` submodule (thecolab-ai/.skills) pointed at its
+# latest upstream commit. Runs hourly, commits the moved pointer straight to the
+# default branch when it changes, and can be kicked manually.
+name: Update .skills submodule
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-skills-submodule
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Update .skills to latest upstream commit
+        run: git submodule update --remote --recursive .skills
+
+      - name: Commit and push if the pointer moved
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .skills; then
+            echo "No .skills update available — pointer unchanged."
+            exit 0
+          fi
+          new_sha="$(git -C .skills rev-parse --short HEAD)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .skills
+          git commit -m "chore: update .skills submodule to ${new_sha}"
+          git push


### PR DESCRIPTION
## What this is

Adds a scheduled GitHub Actions workflow that keeps the vendored `.skills` submodule (thecolab-ai/.skills) pointed at its latest upstream commit.

**Stage:** 🔨 Build (repo tooling)
**Domain:** other (CI / automation)

## Summary

New workflow `.github/workflows/update-skills-submodule.yml` runs every hour (`cron: "0 * * * *"`, plus `workflow_dispatch` for manual runs). It checks out with submodules, runs `git submodule update --remote --recursive .skills`, and — only when the pointer actually moves — commits the bump (`chore: update .skills submodule to <sha>`) to the default branch and pushes. If upstream hasn't changed, it exits cleanly with no commit. Uses `contents: write` and a `concurrency` group so overlapping runs can't race.

## Method checklist

- [x] No personal or identifying data; no overstated or fabricated claims
- [x] Files are in the right place and follow the relevant convention (mirrors existing `reap.yml` scheduled-workflow shape)
- [ ] N/A — no factual claims / research content in this change

## For the reviewer

Two things worth a hard look:
- **Push permissions.** The commit goes straight to the default branch via the default `GITHUB_TOKEN` (`contents: write`). If branch protection blocks direct pushes to `main`, this should instead open a PR (e.g. via `peter-evans/create-pull-request`). Flag if that's the preferred pattern here.
- **Cadence.** Hourly per the request; happy to dial back to daily if that's excessive for how often `.skills` moves.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M9BXzH6gtfj245wxGFrS5n)_