### PR TITLE
fix(runners): make .skills usable — populate the submodule and tell agents about it

### DIFF
--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -94,6 +94,13 @@ make_worktree() {  # $1 = ref to check out (e.g. origin/main, refs/fg/pr-12); se
     WORKTREE=""
     return 1
   fi
+  # `git worktree add` does NOT populate submodules in the new worktree (each
+  # worktree tracks its own submodule checkout state) — without this, every
+  # agent gets an empty .skills/ and silently loses the NZ data CLIs even when
+  # correctly instructed to use them. Best-effort: a missing/offline submodule
+  # remote shouldn't fail the whole run, just leave .skills empty as before.
+  git -C "$WORKTREE" submodule update --init --quiet 2>/dev/null \
+    || warn "couldn't init the .skills submodule in $WORKTREE (offline? leaving it empty)"
 }
 
 remove_worktree() {

--- a/start_work.sh
+++ b/start_work.sh
@@ -143,6 +143,24 @@ Fetching sources — escalate fast → heavy (ADR-0006; details in AGENTS.md):
    cite the snapshot beside the live link.
 Never call a citation dead on a blocked (exit 3) response, and always say HOW you fetched.
 
+NZ data — check the vendored skills BEFORE a generic web search:
+  ls .skills/skills                    # ~70 keyless CLIs over official NZ sources
+  cat .skills/skills/<name>/SKILL.md   # what it covers + its subcommands
+  python3 .skills/skills/<name>/scripts/cli.py <subcommand> --json
+They hit Stats NZ, data.govt.nz, Companies Office, councils, DOC, GeoNet, LAWA, LINZ and
+more directly and return clean, citable JSON — faster and more authoritative than scraping
+the same source by hand. (If \`.skills/skills\` looks empty, run
+\`git submodule update --init\` first.)
+If your research needs NZ data no skill covers, don't just work around it with a one-off
+fetch — open an issue on the skills repo so the NEXT researcher has the tool too:
+  gh issue create --repo thecolab-ai/.skills \\
+    --title "Skill request: <name> — <what data>" \\
+    --body "<the source/API or dataset URL + why it helps For Good research, the
+  subcommands the CLI should expose (e.g. list, get <id> --json), any pagination/rate
+  limits, and a sketch of how cli.py would fetch it>"
+This is encouraged, routine fan-out — it's a request on a SEPARATE repo, so it does not
+count against the sub-issue depth limit below.
+
 Where the output goes (match the issue's stage):
 - research → research/findings/$domain/<slug>.md  using research/TEMPLATE.md
 - ideate   → solutions/<slug>.md                   using solutions/TEMPLATE.md
@@ -199,7 +217,11 @@ working citations for every factual claim, TWO independent sources for
 surprising or load-bearing claims, honest confidence marks, and NEVER
 fabricate a source, statistic, org, or result. Re-verifying citations? Use the
 fetch escalation ladder in AGENTS.md (ADR-0006) — a 403/bot-challenge is
-tooling, not a dead link.
+tooling, not a dead link. Need NZ data to fix a citation? Check the vendored
+skills first — \`ls .skills/skills\` (run \`git submodule update --init\` if
+that looks empty) — before a generic web search; see AGENTS.md's "Colab
+skills" section. If nothing covers it, open a request on
+thecolab-ai/.skills rather than working around the gap.
 
 Do this:
 1. Address EVERY point in the feedback. Where you believe the reviewer is


### PR DESCRIPTION
## The bug(s)

You asked why workers don't seem to use the `.skills` NZ-data CLIs much — turns out they structurally *can't*, on top of never being told to.

1. **`.skills/` is empty in every worktree.** `git worktree add` does not populate submodules in a new worktree — each worktree tracks its own submodule checkout state independently of the main clone. I tested this directly: a fresh `git worktree add --detach ... origin/main` produces a 0-file `.skills/skills/`. Every work, rework, and review agent has been running against an empty skills directory since the submodule was vendored, regardless of prompting.
2. **The prompts never mentioned `.skills` at all.** `work_prompt()`/`rework_prompt()` only tell the agent to read `CONTRIBUTING.md` and `docs/METHOD.md`. AGENTS.md's whole "Colab skills — live NZ data for research" section (69 keyless CLIs over Stats NZ, data.govt.nz, Companies Office, councils, DOC, GeoNet, LAWA, LINZ, etc., plus the instruction to open a skill-request issue when something's missing) was never surfaced to an agent working in an isolated worktree with no reason to read all of AGENTS.md.

## The fixes

- `scripts/fg-common.sh` `make_worktree()`: run `git submodule update --init --quiet` in the new worktree right after `git worktree add`. Best-effort (`warn` + continue) so an offline submodule remote doesn't fail the whole run — worst case it's the same empty `.skills/` as today.
- `start_work.sh` `work_prompt()`: added a section pointing to `.skills/skills` before generic web search, with the exact commands to list/read/run a skill, and the instruction to open an issue on `thecolab-ai/.skills` (with an actionable spec: source URL, subcommands, pagination notes) when a task needs NZ data no skill covers — mirroring AGENTS.md's own "actively grow the toolset" ask. Noted explicitly that this is normal fan-out and doesn't count against the sub-issue depth limit (it's a different repo).
- `start_work.sh` `rework_prompt()`: a shorter pointer to the same, for when a rework needs to fix a citation with better sourcing.

## Verification

- Before: `git worktree add --detach <tmp> origin/main` → `.skills/skills/` has 0 entries.
- After: same worktree + `git submodule update --init --quiet` → 69 entries.
- Rendered the new prompt text via a disabled-`main()` source-and-call test — confirmed backticks/backslashes in the heredoc render as literal characters (not command substitution).
- `bash -n` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaCFSqfJDTmT1wGn8yvBYv