### PR TITLE
ci: open a PR instead of pushing .skills bumps straight to main

### DIFF
--- a/.github/workflows/update-skills-submodule.yml
+++ b/.github/workflows/update-skills-submodule.yml
@@ -1,6 +1,13 @@
 # Keep the vendored `.skills` submodule (thecolab-ai/.skills) pointed at its
-# latest upstream commit. Runs hourly, commits the moved pointer straight to the
-# default branch when it changes, and can be kicked manually.
+# latest upstream commit. Runs hourly and can be kicked manually. Opens a PR
+# when the pointer moves instead of pushing straight to main — `main` requires
+# the `validate` and `for-good/adversarial-review` status checks, which a bare
+# push can never satisfy (confirmed: the direct-push version of this workflow
+# failed with GH006 on its first run). Going through a PR needs no branch-
+# protection bypass and keeps this workflow's commits under the same review
+# gate as everything else in the repo; the pointer-only diff gets the
+# lightweight "standard maintainer review" path (see review_work.sh
+# pr_review_kind), not the citation-gated research method.
 name: Update .skills submodule
 
 on:
@@ -10,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: update-skills-submodule
@@ -19,6 +27,8 @@ jobs:
   update:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,7 +38,7 @@ jobs:
       - name: Update .skills to latest upstream commit
         run: git submodule update --remote --recursive .skills
 
-      - name: Commit and push if the pointer moved
+      - name: Open a PR if the pointer moved
         run: |
           set -euo pipefail
           if git diff --quiet -- .skills; then
@@ -36,8 +46,23 @@ jobs:
             exit 0
           fi
           new_sha="$(git -C .skills rev-parse --short HEAD)"
+          branch="chore/update-skills-submodule-${new_sha}"
+
+          # Idempotent: an earlier run for this exact pointer may already have
+          # an open PR awaiting review — don't spam a duplicate.
+          existing="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already open for $branch — nothing to do."
+            exit 0
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
           git add .skills
           git commit -m "chore: update .skills submodule to ${new_sha}"
-          git push
+          git push -u origin "$branch"
+          gh pr create --title "chore: update .skills submodule to ${new_sha}" \
+            --body "Automated bump of the vendored \`.skills\` submodule to its latest upstream commit (thecolab-ai/.skills@${new_sha}). Pointer-only change, no other content in this repo touched."
+          gh pr merge "$branch" --auto --squash --delete-branch \
+            || echo "Could not enable auto-merge (needs write/branch-protection settings) — a reviewer/maintainer can merge once it passes review."


### PR DESCRIPTION
## Why

You asked me to add a rule letting the `.skills`-update bot bypass main's branch protection. Before doing that I checked what actually happened: the workflow already ran once and failed —

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 2 of 2 required status checks are expected.
```

`main` uses **classic branch protection** (`validate` + `for-good/adversarial-review` required, `enforce_admins: false`, no rulesets exist). Classic protection has no per-actor bypass list — the only way to make a bypass *actually work* (since a coexisting ruleset's bypass is overridden by classic protection's required checks, most-restrictive-wins) is either:

- loosen classic protection and rely on a Ruleset bypass for the **GitHub Actions App** — but that bypass is App-wide: any current or future workflow in this repo with `contents: write` could then push to main skipping `validate` *and* the adversarial-review gate, or
- give a bot account real repo **Admin** and push with its PAT — narrower (only that credential), but Admin also bypasses force-push/deletion protection and can edit branch protection itself.

Both weaken the guarantee AGENTS.md states as a hard rule ("every PR is adversarially reviewed before it can merge"), for the sake of an hourly submodule-pointer bump. I flagged this trade-off and you picked the third option: no bypass, just route it through a PR like everything else.

## What changed

`update-skills-submodule.yml` now, when the `.skills` pointer moves: commits to a branch named after the target commit (`chore/update-skills-submodule-<sha>`, so re-runs before merge are idempotent — checks for an already-open PR first), opens a PR, and calls `gh pr merge --auto --squash --delete-branch`. The diff is submodule-pointer-only, so it lands on the lightweight "standard maintainer review" path in `review_work.sh` (doesn't touch `research/findings/**` or `solutions/**` → no citation gate) and auto-merges once that passes.

Labelled `review: human-only` since it's a `.github/workflows/*` change (CI/CD pipeline), same treatment as #331/#341.

Validated: `python3 -c "import yaml; yaml.safe_load(open(...))"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaCFSqfJDTmT1wGn8yvBYv