### PR TITLE
ci: react to a repository_dispatch from thecolab-ai/.skills on push

### DIFF
--- a/.github/workflows/update-skills-submodule.yml
+++ b/.github/workflows/update-skills-submodule.yml
@@ -1,19 +1,25 @@
 # Keep the vendored `.skills` submodule (thecolab-ai/.skills) pointed at its
-# latest upstream commit. Runs hourly and can be kicked manually. Opens a PR
-# when the pointer moves instead of pushing straight to main — `main` requires
-# the `validate` and `for-good/adversarial-review` status checks, which a bare
-# push can never satisfy (confirmed: the direct-push version of this workflow
-# failed with GH006 on its first run). Going through a PR needs no branch-
-# protection bypass and keeps this workflow's commits under the same review
-# gate as everything else in the repo; the pointer-only diff gets the
-# lightweight "standard maintainer review" path (see review_work.sh
-# pr_review_kind), not the citation-gated research method.
+# latest upstream commit. Fires immediately on a push to that repo's main (via
+# repository_dispatch — see thecolab-ai/.skills .github/workflows/notify-forgood.yml),
+# with the hourly schedule kept as a fallback for any dispatch that's missed or
+# fires before that workflow's dispatch secret exists. Can also be kicked
+# manually. Opens a PR when the pointer moves instead of pushing straight to
+# main — `main` requires the `validate` and `for-good/adversarial-review`
+# status checks, which a bare push can never satisfy (confirmed: the
+# direct-push version of this workflow failed with GH006 on its first run).
+# Going through a PR needs no branch-protection bypass and keeps this
+# workflow's commits under the same review gate as everything else in the
+# repo; the pointer-only diff gets the lightweight "standard maintainer
+# review" path (see review_work.sh pr_review_kind), not the citation-gated
+# research method.
 name: Update .skills submodule
 
 on:
   schedule:
     - cron: "0 * * * *"
   workflow_dispatch:
+  repository_dispatch:
+    types: [skills-updated]
 
 permissions:
   contents: write


### PR DESCRIPTION
Companion to [thecolab-ai/.skills#124](https://github.com/thecolab-ai/.skills/pull/124), which adds a workflow there that fires a `repository_dispatch` (`skills-updated`) on every push to its `main`. This adds the matching trigger here so `update-skills-submodule.yml` reacts immediately instead of waiting up to an hour for its cron poll — the schedule stays in place as a fallback (covers a missed dispatch, or any push to `.skills` before its `FORGOOD_DISPATCH_TOKEN` secret exists).

No change to the workflow's actual logic — same PR-then-auto-merge flow as #343 either way this fires.

Labelled `review: human-only` like #331/#341/#343 (`.github/workflows/*` change).

`python3 -c \"import yaml; yaml.safe_load(open(...))\"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaCFSqfJDTmT1wGn8yvBYv