### PR TITLE
research: reconcile cold damp housing cost estimates (Closes #330)

### DIFF
--- a/research/findings/other/cold-damp-housing-costs.md
+++ b/research/findings/other/cold-damp-housing-costs.md
@@ -1,0 +1,95 @@
+---
+title: "Cold and damp housing costs New Zealand at least hundreds of millions annually, but excess winter mortality should not be treated as a housing-attributable death count"
+domain: "other"
+issue: "#330"
+confidence: "Medium"
+author: "codex"
+agent: "codex"
+model: "gpt-5-codex"
+date: "2026-07-03"
+status: "draft"
+---
+
+# Cold and damp housing costs New Zealand at least hundreds of millions annually, but excess winter mortality should not be treated as a housing-attributable death count
+
+## Executive answer
+
+- The best current causal answer is still anchored in Riggs et al.'s 2010-2017 population-attributable-burden study: cold, damp or mould, and crowding were estimated to cause about 7,427 hospitalisations, about NZ$39.7 million in hospitalisation costs, and about 162 deaths per year before including home fall hazards, in 2017-2018 dollars [Riggs et al., 2021](https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/).
+- Riggs et al.'s broader unsafe/substandard-housing estimate, which adds home fall hazards, was about NZ$141 million in direct public-sector costs, 229 deaths, and NZ$938.9 million in monetised mortality costs per year in 2017-2018 dollars [Riggs et al., 2021](https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/).
+- A CPI-only uplift from June 2017 to the March 2026 quarter is 33.9%, so the broader Riggs et al. direct-cost estimate is roughly NZ$189 million and the mortality-cost estimate roughly NZ$1.26 billion in March-2026 dollars; this is not a new burden-of-disease estimate, only an inflation adjustment using Stats NZ CPI index values of 1000.0 in June 2017 and 1339.0 in March 2026 [Stats NZ CPI CSV, 2026](https://www.stats.govt.nz/assets/Uploads/Consumers-price-index/Consumers-price-index-March-2026-quarter/Download-data/consumers-price-index-march-2026-quarter-index-numbers.csv).
+- The excess-winter-mortality estimate is a different, broader seasonal-mortality measure: Telfar-Barnard et al. found about 1,450 excess winter deaths per year in the 2010s, 4.5% of all deaths, but explicitly could not attribute the trend to any single factor such as housing [Telfar-Barnard et al., 2024](https://link.springer.com/article/10.1007/s00484-023-02573-6).
+- Post-2017 evidence strengthens the case that housing interventions reduce illness and absence, but does not replace Riggs et al. with a new national causal death/cost model: Health NZ's 2024 Healthy Homes Initiative evaluation estimated 10,354 averted hospitalisations per year, 5,309 fewer medical-absence school days per year, and a five-year health-sector return of NZ$5.07 per NZ$1 spent for referred households [Health NZ, 2024](https://static.info.content.health.nz/docs/publications/Healthy-Homes-Initiative-Five-year-outcomes-evaluation.pdf).
+
+**Overall confidence:** Medium - the distinction between EWM and housing-attributable disease is well supported, and programme evidence is current, but I found no public post-2017 national re-run of the Riggs et al. burden model.
+
+## Evidence
+
+### The two headline death counts answer different questions
+
+Telfar-Barnard et al. measure seasonal mortality by comparing deaths in June-September with deaths in adjacent non-winter months, using a 145-year New Zealand death series from 1876 to 2020 [Telfar-Barnard et al., 2024](https://link.springer.com/article/10.1007/s00484-023-02573-6). Their headline 2010s figure is about 1,450 excess winter deaths per year, or 4.5% of all deaths, and the authors state that no single measure among living standards, health services, immunisation, household size, housing and climate can be identified as the driver of the long-run decline [Telfar-Barnard et al., 2024](https://link.springer.com/article/10.1007/s00484-023-02573-6).
+
+Riggs et al. ask a narrower causal-attribution question using population attributable fractions for household crowding, cold, damp or mould, and fall hazards, with hospitalisation data from 2010-2017 and mortality data from 2010-2014 [Riggs et al., 2021](https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/). For cold, damp or mould, and crowding alone, they estimate 526 crowding-attributable hospitalisations costing almost NZ$1.4 million, 625 cold-home-attributable hospitalisations costing more than NZ$2.3 million, and 6,276 damp/mould-attributable hospitalisations costing almost NZ$36.0 million per year [Riggs et al., 2021](https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/).
+
+The same Riggs et al. mortality table attributes about 1 death per year to household crowding, 16 to cold, and 145 to dampness or mould, for about 162 deaths per year before adding fall hazards [Riggs et al., 2021](https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/). Their full 229-death figure includes about 68 deaths attributable to falls, and their full NZ$141 million direct public-sector cost includes home-injury claims as well as health costs from crowding, cold, damp and mould [Riggs et al., 2021](https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/).
+
+### What is newer than the 2010-2017 burden estimate
+
+Health NZ's Healthy Homes Initiative is a current intervention programme aimed at increasing the number of people living in warm, dry homes and reducing housing-related hospitalisations [Health NZ HHI page, 2026](https://www.healthnz.govt.nz/about-us/what-we-do/programmes-and-initiatives/healthy-homes-initiative). Its 2024 five-year outcomes evaluation linked programme households to administrative data and estimated an 18.6% lower all-cause hospitalisation rate in the five years after intervention, scaling to 10,354 averted hospitalisations per year across 44,667 referrals [Health NZ, 2024](https://static.info.content.health.nz/docs/publications/Healthy-Homes-Initiative-Five-year-outcomes-evaluation.pdf).
+
+The Health NZ evaluation is not a national population-attributable-fraction update because it studies referred HHI households, counts all-cause hospitalisations, and uses a health-sector cost perspective that excludes some partner-funded intervention costs such as beds and insulation products [Health NZ, 2024](https://static.info.content.health.nz/docs/publications/Healthy-Homes-Initiative-Five-year-outcomes-evaluation.pdf). Within those boundaries, it estimates NZ$95.4 million in year-one healthcare benefits and NZ$398.2 million in discounted healthcare benefits over years 1-5, against real programme costs of about NZ$91-93 million in 2023 dollars [Health NZ, 2024](https://static.info.content.health.nz/docs/publications/Healthy-Homes-Initiative-Five-year-outcomes-evaluation.pdf).
+
+Motu's Warmer Kiwi Homes evaluation provides an independent programme-economics cross-check rather than a national disease-burden update: EECA says the study worked with about 164 homeowners receiving efficient-heater grants and collected health/wellbeing, temperature, humidity and electricity-use data [EECA, 2023](https://www.eeca.govt.nz/insights/eeca-insights/warmer-kiwi-homes-research-and-evaluation/). Motu estimated the full Warmer Kiwi Homes programme had benefit-cost ratios of 4.36 on a wellbeing/energy basis and 1.89 on a health/energy basis, with a base-case wellbeing/energy net present value of NZ$189.1 million for 2020/21 installations [Motu, 2022](https://motu-www.motu.org.nz/wpapers/22_14.pdf).
+
+A 2026 peer-reviewed article from the same Warmer Kiwi Homes heat-pump study reports that installing heat pumps in already insulated lower-income homes increased living-area temperatures, reduced relative humidity, reduced winter electricity use by about 16%, reduced perceived cold, and improved some mental-wellbeing components [Taptiklis et al., 2026](https://pmc.ncbi.nlm.nih.gov/articles/PMC13052806/). That supports the mechanism that warmer/drier interventions improve conditions, but it does not estimate national deaths attributable to cold or damp homes [Taptiklis et al., 2026](https://pmc.ncbi.nlm.nih.gov/articles/PMC13052806/).
+
+### Current exposure context
+
+Current exposure is lower than the 2018 Census dampness baseline but still material: EHINZ reports that 20.6% of New Zealanders, or 859,137 people, lived in damp dwellings in the 2023 Census, down from 24.1% in 2018 [EHINZ, 2025](https://www.ehinz.ac.nz/assets/Surveillance-reports/Released_2025/Damp-dwellings-surveillance-report-2023.pdf). EHINZ also reports that 29.2% of rental households reported dampness and 22.9% reported mould larger than A4 size in 2023, compared with 13.1% dampness and 9.9% mould in owner-occupied households [EHINZ tenure report, 2025](https://www.ehinz.ac.nz/assets/Surveillance-reports/Released_2025/Dampness-and-mould-in-New-Zealand-households-a-tenure-based-analysis.pdf).
+
+This matters for any future update because Riggs et al. used self-reported exposure estimates of 21.2% for cold and 31.8% for damp or mould from the 2014 New Zealand General Social Survey, and they warn that self-reports may underestimate actual exposure because assessor and temperature-monitoring studies found more mould and low indoor temperatures than householders reported [Riggs et al., 2021](https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/).
+
+### School and work days
+
+The strongest current school-absence estimate I found is Health NZ's 2024 HHI evaluation: it estimates a 5% reduction in school absences for medical reasons, equal to 5,309 fewer absent days per year across 57,626 children, but says the effect was significant with standard errors and not significant with robust standard errors [Health NZ, 2024](https://static.info.content.health.nz/docs/publications/Healthy-Homes-Initiative-Five-year-outcomes-evaluation.pdf). The same evaluation found wage-income results were generally positive but statistically insignificant, so it does not support a firm current estimate of work days gained [Health NZ, 2024](https://static.info.content.health.nz/docs/publications/Healthy-Homes-Initiative-Five-year-outcomes-evaluation.pdf).
+
+Motu's Warmer Kiwi Homes CBA includes time-off-work and school benefits, but it is mostly an assumption imported from earlier insulation evidence: the report says an explicit value for time off work or school avoided could only be sourced for the insulation component, and heat-pump work/school-day benefits were assumed equal to insulation benefits because COVID-19 made attendance data unreliable during the evaluation period [Motu, 2022](https://motu-www.motu.org.nz/wpapers/22_14.pdf). The CBA assumptions list 0.167 work-sickness days avoided per household with a working adult per year, 0.180 caregiving work days avoided per household with a school-aged child where all adults work per year, and 0.765 school-sickness days avoided per household with a school-aged child per year [Motu, 2022](https://motu-www.motu.org.nz/wpapers/22_14.pdf).
+
+Older New Zealand trial evidence supports the direction of effect: the Housing, Insulation and Health Study reports that adults in insulated houses were significantly less likely to report sick days off work and children were less likely to have days off school [He Kāinga Oranga, Housing, Insulation and Health Study](https://www.healthyhousing.org.nz/our-research/past-research/housing-insulation-and-health-study). This is useful for triangulation but is not post-2017 evidence [He Kāinga Oranga, Housing, Insulation and Health Study](https://www.healthyhousing.org.nz/our-research/past-research/housing-insulation-and-health-study).
+
+## Surprising or load-bearing claims
+
+| Claim | Source 1 | Source 2 | Confidence |
+|---|---|---|---|
+| The 1,450 excess-winter-deaths figure should not be described as deaths caused by cold housing. | [Telfar-Barnard et al., 2024](https://link.springer.com/article/10.1007/s00484-023-02573-6) | [Riggs et al., 2021](https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/) gives a separate causal-attribution estimate for housing conditions | High |
+| The defensible housing-attributable death count is much lower than EWM: about 162 deaths/year for crowding, cold, damp or mould, or 229/year when home fall hazards are included. | [Riggs et al., 2021](https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/) | [Howden-Chapman et al., 2021](https://www.healthyhousing.org.nz/sites/default/files/2021-11/HowdenChapman_etal_Housing_Health_Wellbeing.pdf) summarises the same Riggs et al. estimate; no independent national re-run found | Medium |
+| Current programme evidence shows large health returns, but it does not update the national attributable-burden estimate. | [Health NZ, 2024](https://static.info.content.health.nz/docs/publications/Healthy-Homes-Initiative-Five-year-outcomes-evaluation.pdf) | [Motu, 2022](https://motu-www.motu.org.nz/wpapers/22_14.pdf) provides an independent programme CBA with positive BCRs | Medium |
+| A current school-absence estimate exists, but it is caveated: 5,309 fewer medical-absence school days/year in HHI children, not significant under robust standard errors. | [Health NZ, 2024](https://static.info.content.health.nz/docs/publications/Healthy-Homes-Initiative-Five-year-outcomes-evaluation.pdf) | [Motu, 2022](https://motu-www.motu.org.nz/wpapers/22_14.pdf) uses earlier insulation-derived school-day assumptions, not fresh post-2017 school-attendance evidence | Medium |
+
+## What would change this conclusion
+
+- A public Ministry of Health, Health NZ, Stats NZ IDI, or peer-reviewed update that re-runs Riggs et al.'s population-attributable-fraction model using post-2017 hospitalisation, mortality, 2023 Census housing-quality, and current exposure-response assumptions would supersede the CPI-uplifted 2017 estimate.
+- A national study linking cold/damp exposure, indoor temperature monitoring, school attendance, work attendance, GP visits, prescriptions, hospitalisations and mortality would tighten the currently separate evidence streams.
+- A source that cleanly separates costs for cold/damp/mould/crowding from fall hazards in a current national model would change the practical headline number, because the NZ$141 million direct public-sector figure in Riggs et al. includes home fall hazards.
+- I could not verify a post-2017 national housing-attributable mortality/cost update from Ministry of Health or Health NZ; the strongest post-2017 evidence I found is programme evaluation rather than national burden modelling.
+- I could not verify a Ministry of Education public dataset that attributes school absence nationally to cold/damp housing; the best school-absence estimate found is the Health NZ HHI linked-administrative-data evaluation.
+
+## Open follow-up questions
+
+- Can the Riggs et al. model be reproduced with 2023 Census damp/mould variables, current hospitalisation data, and current mortality data using the IDI?
+- How much of the Healthy Homes Initiative's all-cause hospitalisation reduction is specifically attributable to warmth/dryness interventions versus entitlement checks, repairs, relocation, bedding, curtains, and other bundled supports?
+- Are private-rental Healthy Homes Standards compliance dates measurably changing hospitalisations, school absence, and damp/mould exposure after 1 July 2025?
+
+## Sources
+
+1. Telfar-Barnard L, Baker MG, Wilson N, Hales S, Howden-Chapman P. "The rise and fall of excess winter mortality in New Zealand from 1876 to 2020." *International Journal of Biometeorology* 68, 89-100. Published 27 November 2023, accessed 3 July 2026. Fetched with `curl -L` after Springer redirects and WebSearch. https://link.springer.com/article/10.1007/s00484-023-02573-6
+2. Riggs L, Keall M, Howden-Chapman P, Baker MG. "Environmental burden of disease from unsafe and substandard housing, New Zealand, 2010-2017." *Bulletin of the World Health Organization* 99(4), 259-270. Published 2021, accessed 3 July 2026. Fetched with `curl -L`; WebFetch showed a PMC browser-check page but curl returned article HTML. https://pmc.ncbi.nlm.nih.gov/articles/PMC8085632/
+3. Stats NZ. "Consumers price index: March 2026 quarter - index numbers - CSV." Accessed 3 July 2026 through the vendored `stats-nz` skill and direct CSV URL. https://www.stats.govt.nz/assets/Uploads/Consumers-price-index/Consumers-price-index-March-2026-quarter/Download-data/consumers-price-index-march-2026-quarter-index-numbers.csv
+4. Health New Zealand | Te Whatu Ora. "Healthy Homes Initiative: Five-year outcomes evaluation." Published 2024, accessed 3 July 2026. Fetched with `curl -L` and `pdftotext`. https://static.info.content.health.nz/docs/publications/Healthy-Homes-Initiative-Five-year-outcomes-evaluation.pdf
+5. Health New Zealand | Te Whatu Ora. "Healthy Homes Initiative." Accessed 3 July 2026. Fetched with WebFetch and `curl -L`. https://www.healthnz.govt.nz/about-us/what-we-do/programmes-and-initiatives/healthy-homes-initiative
+6. Energy Efficiency and Conservation Authority. "Warmer Kiwi Homes Research and Evaluation." Published May 2023, accessed 3 July 2026. Fetched with WebFetch and `curl -L`. https://www.eeca.govt.nz/insights/eeca-insights/warmer-kiwi-homes-research-and-evaluation/
+7. Fyfe C, Grimes A, Minehan S, Taptiklis P. "Evaluation of the Warmer Kiwis Homes Programme: Full Report including Cost Benefit Analysis." Motu Working Paper 22-14. Published December 2022, accessed 3 July 2026. Fetched with WebFetch and `curl -L`; extracted with `pdftotext`. https://motu-www.motu.org.nz/wpapers/22_14.pdf
+8. Taptiklis P, Fyfe C, Grimes A, Minehan S, Benison T. "A New Zealand Heat Pump Retrofit Programme: Warmer, Drier, Happier, Cheaper." *Journal of the Royal Society of New Zealand* 56(2). Published 2026, accessed 3 July 2026. Fetched with `curl -L`; WebFetch showed a PMC browser-check page but curl returned article HTML. https://pmc.ncbi.nlm.nih.gov/articles/PMC13052806/
+9. Environmental Health Intelligence New Zealand. "Living in damp dwellings." May 2025, accessed 3 July 2026. Fetched with WebFetch and `curl -L`; extracted with `pdftotext`. https://www.ehinz.ac.nz/assets/Surveillance-reports/Released_2025/Damp-dwellings-surveillance-report-2023.pdf
+10. Environmental Health Intelligence New Zealand. "Dampness and mould in New Zealand households: a tenure-based analysis." July 2025, accessed 3 July 2026. Fetched with WebFetch and `curl -L`; extracted with `pdftotext`. https://www.ehinz.ac.nz/assets/Surveillance-reports/Released_2025/Dampness-and-mould-in-New-Zealand-households-a-tenure-based-analysis.pdf
+11. Howden-Chapman P, Bennett J, Edwards R, Jacobs D, Nathan K, Ormandy D. "The effects of housing on health and well-being in Aotearoa New Zealand." *New Zealand Population Review* 47, 16-32. Published 2021, accessed 3 July 2026. Fetched with WebFetch. https://www.healthyhousing.org.nz/sites/default/files/2021-11/HowdenChapman_etal_Housing_Health_Wellbeing.pdf
+12. He Kāinga Oranga. "Housing, Insulation and Health Study." Accessed 3 July 2026. Fetched with WebFetch. https://www.healthyhousing.org.nz/our-research/past-research/housing-insulation-and-health-study


### PR DESCRIPTION
Closes #330. Stream: #244. Reconciles excess-winter-mortality and housing-attributable-disease estimates for cold/damp NZ homes, with current programme evidence and school/work-day caveats.