### PR TITLE
leaderboard: consolidate Richard Fortune to one identity

### DIFF
--- a/research/findings/child-welfare/nz-child-protection-gaps-framing.md
+++ b/research/findings/child-welfare/nz-child-protection-gaps-framing.md
@@ -3,7 +3,7 @@ title: "NZ's child-protection system has documented, officially-acknowledged gap
 domain: "child-welfare"
 issue: "#259"
 confidence: "Medium"
-author: "richard-fortune"
+author: "richardofortune"
 agent: "claude"
 model: "claude-opus-4-8"
 date: "2026-07-03"

--- a/research/findings/civic-transparency/oia-request-types-police-corrections-nhc.md
+++ b/research/findings/civic-transparency/oia-request-types-police-corrections-nhc.md
@@ -3,7 +3,7 @@ title: "Police, Corrections and the Natural Hazards Commission (ex-EQC) each run
 domain: "civic-transparency"
 issue: "#238"
 confidence: "Medium"
-author: "Richard Fortune"
+author: "richardofortune"
 agent: "claude"
 model: "claude-opus-4-8"
 date: "2026-07-03"

--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -54,6 +54,19 @@ function person(u) {
   return u ? { login: u.login, avatar: u.avatar_url, url: u.html_url } : null;
 }
 
+// Fold known alternate author spellings onto one canonical GitHub login, so a
+// contributor who ran an agent under different git credentials (e.g. an
+// overnight run with no GH creds) doesn't split into several leaderboard
+// people. Keyed by lowercased alias. Add a row here when it recurs.
+const AUTHOR_ALIASES = {
+  "richard-fortune": "richardofortune",
+  "richard fortune": "richardofortune",
+};
+function canonicalAuthor(a) {
+  const s = String(a || "").replace(/^@/, "").trim();
+  return AUTHOR_ALIASES[s.toLowerCase()] || s;
+}
+
 async function main() {
   console.log(`Building snapshot for ${REPO}${TOKEN ? " (authenticated)" : " (unauthenticated)"}`);
 
@@ -284,7 +297,7 @@ async function main() {
     const harness = f.agent || "human";
     a.agents[harness] = (a.agents[harness] || 0) + 1;
     if (f.model) a.models[f.model] = (a.models[f.model] || 0) + 1;
-    const login = String(f.author || "").replace(/^@/, "");
+    const login = canonicalAuthor(f.author);
     if (login && login !== "unknown" && !a.people.has(login)) a.people.set(login, { login, avatar: `https://github.com/${login}.png`, url: `https://github.com/${login}` });
   }
   for (const d of streamDocs) {
@@ -324,7 +337,7 @@ async function main() {
   for (const p of prs) { const r = ensure(p.author); if (r) { r.prsOpened++; if (p.merged) r.prsMerged++; bumpActivity(r, p.updatedAt); } }
   for (const c of commitContributors) { const r = ensure(person(c)); if (r) r.commits += c.contributions || 0; }
   for (const f of findings) {
-    const login = f.author && f.author !== "unknown" ? f.author.replace(/^@/, "") : null;
+    const login = f.author && f.author !== "unknown" ? canonicalAuthor(f.author) : null;
     if (!login) continue;
     if (!people.has(login)) people.set(login, newPerson(login, `https://github.com/${login}.png`, `https://github.com/${login}`));
     const r = people.get(login); r.findingsAuthored++; if (f.domain) r.domains.add(f.domain); bumpActivity(r, f.date);


### PR DESCRIPTION
**Why (Adam, in-channel):** Richard's overnight agent run had no GitHub creds, so two findings were authored as `Richard Fortune` / `richard-fortune` instead of his login — splitting him into **three** people on the leaderboard.

**Fix:**
1. Retag both findings' `author:` to his real login `richardofortune` (the `.md` is source of truth; leaderboard rebuilds from it).
2. Add `canonicalAuthor()` + an `AUTHOR_ALIASES` map in `build-data.mjs` so future credential-less variants fold onto the canonical login automatically instead of spawning duplicates.

Applied at both author-derivation sites (stream people + leaderboard). `node --check` clean; `npm run validate` passes (79 files). His points merge onto one row on the next Pages deploy — redeemable for Nark Credits in some glorious future. 😄

🤖 Generated with [Claude Code](https://claude.com/claude-code)