### PR TITLE
partners: add demand-side asks playbook (partners/ASKS.md)

### DIFF
--- a/partners/ASKS.md
+++ b/partners/ASKS.md
@@ -1,0 +1,112 @@
+# The asks — what we work on with each kind of partner
+
+This is the demand-side playbook that sits above the per-organisation records in
+this directory: not *who* we've spoken to (that's each `partners/<slug>.md`), but
+*what we ask of each kind of partner, and what they get back*. It extends the
+promises on the public [partners page](https://thecolab-ai.github.io/the-for-good-project/#/partners)
+and the trust network in [ADR-0010](../docs/adr/0010-partner-network.md). Like
+the rest of this directory, it becomes project process only if ratified by a
+human maintainer.
+
+Two rules carry across everything below:
+
+- **The ask is small and specific.** Many resource-scarce organisations have
+  never been asked *"what would you want solved if capacity were free?"* That
+  question, plus a little expert time to sanity-check the work, is usually the
+  whole ask.
+- **Category level only.** This doc names *kinds* of partner, never a specific
+  organisation — naming an org is a `public`-consent claim and lives in that
+  org's record, not here. See the consent gate in [README.md](README.md).
+
+---
+
+## Charities, NFPs & community organisations
+
+You see where the system fails the people you serve, and rarely have the hours
+to build the evidence that would help fix it.
+
+- **What we ask:** one real problem in your words; a little of an expert's time
+  to check our work against reality on the ground; a door to whoever could use
+  the result; honest feedback when we miss.
+- **What you get:** cited evidence you can use for funding, advocacy or service
+  design — free, yours to review first, nothing about you or your people
+  published without your say-so.
+- **First step:** file one problem as an issue; we open a stream with you
+  steering.
+
+## Councils, regulators & policy teams
+
+You own problems that are broad, multi-faceted, and under-resourced, and you
+need defensible groundwork, not a black box.
+
+- **What we ask:** one well-scoped question your team can scrutinise line by
+  line.
+- **What you get:** cited analysis you can read and challenge; real, current
+  data rather than only aggregates; a repeatable, human-in-the-loop way to bring
+  AI to a public problem safely.
+- **First step:** scope one question together.
+
+## Funders & philanthropy
+
+You look for leverage — small inputs that unlock disproportionate public value.
+
+- **What we ask:** either a modest contribution to sustain the commons, or a
+  warm introduction to a problem-holder who should be at the table.
+- **What you get:** a transparent, auditable vehicle — the whole pipeline, from
+  raw problem to built thing, is public and measured, so you can see exactly
+  what your support turns into.
+- **First step:** a short walkthrough of the live board, then agree one problem
+  area to back.
+
+## Universities & research
+
+You can lend rigour, method review and student capacity — and gain a live,
+real-world case of AI-with-a-human-gate on public problems.
+
+- **What we ask:** method review and credibility; student contributors; and the
+  problems worth putting on the queue.
+- **What you get:** a working case study of rigorous, transparent AI on public
+  problems; a pipeline for student contribution; and method-paper potential —
+  our cited-and-adversarially-challenged standard maps directly onto peer
+  review.
+- **First step:** a conversation with the right department, then scope one
+  student-runnable stream.
+
+## Infrastructure & capacity partners
+
+Providers of compute, model access and data tooling, often with public-good
+credit programmes already in place. Two very different things, kept separate on
+purpose:
+
+- **Capacity (the simple ask):** credits, tokens or tooling to keep the queue
+  running, with **no naming attached** — a quiet contribution to a public-good
+  commons.
+- **A named showcase (only later, only by mutual choice):** if a provider wants
+  a public case study of their stack doing public good, that comes *after* a
+  finished, uncontentious piece of work both sides are happy to stand behind —
+  never as the opening ask, and never bound to a politically live stream.
+- **What you get:** spare capacity put to demonstrably good use, with full
+  visibility of exactly what it produced.
+- **First step:** a short call to point existing credits at the commons.
+
+## Journalists & media
+
+We work with journalists the way a good evidence base does — as *background*,
+not a press release.
+
+- **How it works:** we can offer a completed, fully cited, scrutable evidence
+  base on a public-interest question as background material. You verify
+  everything yourself and own the story and the byline entirely. No attribution
+  required, no strings.
+- **What you get:** rigorous groundwork already done on a question that matters,
+  yours to interrogate and take wherever the reporting leads.
+- **First step:** tell us the public-interest question you're chasing; if we
+  have a finished stream that speaks to it, we'll share it.
+
+---
+
+*Not covered here by design:* engagement with iwi and Māori organisations is a
+relationship-first question that belongs with Māori leadership and Māori data
+sovereignty frameworks ([Te Mana Raraunga](https://www.temanararaunga.maori.nz/),
+the CARE principles), not a row in an outreach playbook. It is deliberately out
+of scope for this document.

--- a/partners/README.md
+++ b/partners/README.md
@@ -9,6 +9,9 @@ per organisation/relationship. Proposed in
 [issue #123](https://github.com/thecolab-ai/the-for-good-project/issues/123);
 it becomes project process only if ratified by a human maintainer.
 
+For the demand-side playbook that sits above these records — what we ask of each
+kind of partner and what they get back — see [ASKS.md](ASKS.md).
+
 It exists because of a tension we refuse to resolve quietly: this project is
 built completely in the open, but it tracks real people at real organisations.
 [CONSTITUTION.md](../CONSTITUTION.md) Article III (protect people) wins, and it


### PR DESCRIPTION
Category-level playbook above the per-org records: what we ask of each kind of partner (charities, councils, funders, universities, capacity, media) and what they get back. Extends the partners page and ADR-0010. Stays at category level per the consent gate; names no organisations. Iwi engagement deliberately out of scope (relationship-first, Māori-led).

<!-- Thanks for contributing to The For Good Project. Fill this in so review is quick. -->

## What this is

Closes #<!-- issue number -->
Part of #<!-- parent issue, if any -->

**Stage:** 🔍 Discover / 📚 Research / 💡 Ideate / 🔨 Build
**Domain:** <!-- child-welfare | grant-access | civic-transparency | ai-policy | biosecurity | other -->

## Summary

<!-- 2-4 sentences: what you did and the headline conclusion or output. -->

## Method checklist

<!-- Findings especially — see CONTRIBUTING.md. Tick honestly; "no" with a reason is fine. -->

- [ ] Every factual claim has a source (inline)
- [ ] Surprising / load-bearing claims have **two** independent sources (or I flagged where they don't)
- [ ] Confidence marked **High / Medium / Low** (findings)
- [ ] I stated what would change the conclusion and what I couldn't verify
- [ ] No personal or identifying data; no overstated or fabricated claims
- [ ] Files are in the right place and follow the relevant template

## For the reviewer

<!-- Where should the reviewer push hardest? Which claim is weakest? What did you struggle to verify? Point them at it — this makes review better, not worse. -->
