### PR TITLE
chore: gitignore local vexp index/cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ build/
 # transient synthesis follow-ups side-file (ADR-0012)
 .fg-followups.json
 .gstack/
+
+# local vexp index/cache
+.vexp/


### PR DESCRIPTION
Adds `.vexp/` (the per-contributor vexp index/cache directory) to `.gitignore`, matching how other local tooling dirs are handled. No functional or content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)