### PR TITLE
docs: fix duplicated AUTOMATION.md link in AGENTS.md autopilot intro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,8 +188,7 @@ skill you add makes the next contributor's research faster.
 
 ## Run it on autopilot
 
-Six scripts wrap your `codex`, `claude`, or `hermes` CLI so you can put spare tokens to work — `frame_work.sh` (frame new streams, capability-floored), `start_work.sh` (do), `review_work.sh` (review), `synthesize_work.sh` (stream rollups), `merge_ready.sh` (maintainer merges), `reap.sh` (free stale claims); see [docs/AUTOMATION.md](docs/AUTOMATION.md)
-without babysitting each step — see [`docs/AUTOMATION.md`](docs/AUTOMATION.md):
+Six scripts wrap your `codex`, `claude`, or `hermes` CLI so you can put spare tokens to work without babysitting each step — `frame_work.sh` (frame new streams, capability-floored), `start_work.sh` (do), `review_work.sh` (review), `synthesize_work.sh` (stream rollups), `merge_ready.sh` (maintainer merges), `reap.sh` (free stale claims); see [`docs/AUTOMATION.md`](docs/AUTOMATION.md):
 
 - **`./frame_work.sh`** — claims discover roots only (the general fleet never
   does), writes the framing analysis as a PR, and opens the child research


### PR DESCRIPTION
## What this is

Follow-up to #383 (the frame_work.sh / ADR-0014 change for #379).

**Stage:** docs / tooling (no research artifact)
**Domain:** other (project docs)

## Summary

The adversarial review that passed #383 flagged one non-blocking nit: AGENTS.md's "Run it on autopilot" intro linked `docs/AUTOMATION.md` twice across an awkwardly split sentence ("…free stale claims); see [docs/AUTOMATION.md] without babysitting each step — see [docs/AUTOMATION.md]:"). #383 merged before the cleanup could land on its branch, so this one-line follow-up merges the fragments into a single sentence with a single link. No behavioural change; prose only.

## Method checklist

- [ ] Every factual claim has a source (inline) — *n/a: one-line prose cleanup, no claims*
- [ ] Surprising / load-bearing claims have **two** independent sources — *n/a*
- [ ] Confidence marked **High / Medium / Low** (findings) — *n/a: no finding*
- [ ] I stated what would change the conclusion and what I couldn't verify — *n/a*
- [x] No personal or identifying data; no overstated or fabricated claims
- [x] Files are in the right place and follow the relevant template

## For the reviewer

Diff is one sentence in AGENTS.md; compare against the nit in #383's review. Nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wfyvD3wYBv5SMLvVLFkpJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017wfyvD3wYBv5SMLvVLFkpJ)_