### PR TITLE
add autopilot.sh — one command: alternate review+work, idle back-off, auto-pull main

### DIFF
--- a/autopilot.sh
+++ b/autopilot.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# autopilot.sh — ONE command that keeps both sides of the queue moving.
+#
+# Run only produce (start_work.sh) and you flood the review queue; run only
+# review (review_work.sh) and nothing new gets made. autopilot alternates —
+# it REVIEWS other people's PRs, then does ONE piece of work, then repeats —
+# so research and review stay balanced instead of one starving the other.
+# It's what you tell everyone to run: one script, both jobs.
+#
+# It is NOT a merge of the two runners: it's a thin conductor that calls the
+# existing, tested start_work.sh / review_work.sh with MAX=1 POLL_SECONDS=0 (do
+# one item, exit instead of polling) and owns only the alternation, the ratio,
+# the idle back-off, and pulling latest main each cycle. All the real behaviour
+# — claiming, status labels, worktrees, the PR, the merge gate — still lives in
+# those scripts, unchanged. See docs/adr/0015-autopilot-alternates-review-and-work.md.
+#
+# THE INTEGRITY RULE STILL HOLDS: an adversarial review may not be by the PR's
+# author. So run the REVIEW side under a DISTINCT identity via REVIEW_GITHUB_TOKEN
+# (a second account / bot PAT with write) — work runs as your normal gh identity,
+# review runs as the token's identity. Without REVIEW_GITHUB_TOKEN it runs
+# WORK-ONLY and warns (reviewing your own PRs is a no-op the gate rejects).
+#
+# Usage:
+#   REVIEW_GITHUB_TOKEN=<bot-pat> ./autopilot.sh            # balanced (claude)
+#   REVIEW_GITHUB_TOKEN=<bot-pat> ./autopilot.sh codex      # use codex
+#   REVIEW_GITHUB_TOKEN=<bot-pat> REVIEW_PER_WORK=3 ./autopilot.sh
+#   ./autopilot.sh                                          # work-only (no token)
+#   MAX_CYCLES=5 ./autopilot.sh                             # stop after 5 cycles
+#   PULL=0 ./autopilot.sh                                   # don't auto-pull main
+#
+# Args: [claude|codex|hermes] [--model <name>]   (forwarded to both runners)
+# Env:  REVIEW_GITHUB_TOKEN  REVIEW_PER_WORK(=2)  POLL_SECONDS(=120)
+#       MAX_CYCLES(=0)  PULL(=1)  MAIN_BRANCH(=main)  + everything the runners read
+set -euo pipefail
+cd "$(dirname "$0")"
+source "scripts/fg-common.sh"
+
+REVIEW_PER_WORK="${REVIEW_PER_WORK:-2}"   # review passes per work pass — bias to review; it's the bottleneck
+POLL_SECONDS="${POLL_SECONDS:-120}"       # idle wait between cycles when the whole queue is empty
+MAX_CYCLES="${MAX_CYCLES:-0}"             # 0 = run forever
+PULL="${PULL:-1}"                         # git-pull latest main each cycle (0 to disable)
+MAIN_BRANCH="${MAIN_BRANCH:-main}"
+
+trap 'rule; warn "autopilot stopping."; exit 130' INT TERM
+
+if [ -z "${REVIEW_GITHUB_TOKEN:-}" ]; then
+  warn "REVIEW_GITHUB_TOKEN is not set — running WORK-ONLY (no review passes)."
+  warn "To balance the queue, set REVIEW_GITHUB_TOKEN to a DISTINCT GitHub identity with write access."
+fi
+
+# Run ONE runner pass and report whether it actually DID something. The runners
+# exit 0 whether they processed an item OR found an empty queue, so we can't use
+# the exit code alone — instead detect the empty-queue sentinel line each runner
+# prints (review_work.sh: "No open PRs needing review."; start_work.sh: "Queue
+# empty — no rework…"). Returns 0 = did work, 1 = idle (or errored).
+run_pass() {  # $@ = command to run
+  local out rc; out="$(mktemp)"
+  set +e; "$@" 2>&1 | tee "$out"; rc=${PIPESTATUS[0]}; set -e
+  if grep -qE "No open PRs needing review\.|Queue empty — no rework" "$out"; then
+    rm -f "$out"; return 1
+  fi
+  rm -f "$out"
+  [ "$rc" -eq 0 ]
+}
+
+cycle=0
+while :; do
+  cycle=$((cycle + 1))
+  rule; info "${c_bold}autopilot cycle $cycle${c_reset}  (review×${REVIEW_PER_WORK} → work×1)"
+
+  # Pull latest main each cycle so operators automatically pick up script and
+  # pipeline improvements without a manual git pull. git swaps files by atomic
+  # rename, so the RUNNING autopilot keeps executing its current (open) inode —
+  # no mid-run corruption — while the runner subprocesses launched below read the
+  # freshly-updated code immediately; autopilot's own update applies next restart.
+  if [ "$PULL" = 1 ]; then
+    if git fetch --quiet origin "$MAIN_BRANCH" 2>/dev/null && git merge --ff-only --quiet FETCH_HEAD 2>/dev/null; then
+      log "Pulled latest origin/$MAIN_BRANCH."
+    else
+      warn "Couldn't fast-forward to origin/$MAIN_BRANCH (local changes / not on $MAIN_BRANCH / offline) — staying on current code."
+    fi
+  fi
+
+  did_something=0
+
+  # Review side (distinct identity), review-first so we drain before adding.
+  if [ -n "${REVIEW_GITHUB_TOKEN:-}" ]; then
+    for _ in $(seq 1 "$REVIEW_PER_WORK"); do
+      info "review pass…"
+      run_pass env MAX=1 POLL_SECONDS=0 ./review_work.sh "$@" && did_something=1
+    done
+  fi
+
+  # Work side (your normal identity).
+  info "work pass…"
+  run_pass env MAX=1 POLL_SECONDS=0 ./start_work.sh "$@" && did_something=1
+
+  if [ "$MAX_CYCLES" != 0 ] && [ "$cycle" -ge "$MAX_CYCLES" ]; then
+    ok "Reached MAX_CYCLES=$MAX_CYCLES — stopping."; break
+  fi
+
+  # Both queues were empty this cycle — nap before looking again.
+  if [ "$did_something" = 0 ]; then
+    log "Nothing to review or work right now. Sleeping ${POLL_SECONDS}s… (Ctrl-C to stop)"
+    sleep "$POLL_SECONDS"
+  fi
+done

--- a/docs/adr/0015-autopilot-alternates-review-and-work.md
+++ b/docs/adr/0015-autopilot-alternates-review-and-work.md
@@ -1,0 +1,73 @@
+# ADR-0015: autopilot.sh — one command that alternates review and work
+
+- **Status:** proposed (a human maintainer ratifies on merge — agents do not self-ratify runner-architecture changes)
+- **Date:** 2026-07-04
+- **Deciders:** human maintainer (on merge); drafted by an agent on behalf of @adam91holt
+- **Supersedes:** the abandoned `autopilot` draft in PR #220 (which numbered itself ADR-0013, since taken by the pipeline-guardrails ADR)
+
+## Context
+
+The pipeline has two runners by design: `start_work.sh` *produces* work (opens
+PRs) and `review_work.sh` *adversarially reviews* it before it can merge. In
+practice contributors overwhelmingly run the produce side, so PRs pile up
+`in-review` faster than anyone reviews them — the review queue becomes the
+bottleneck. The project wants a single command it can tell everyone to run that
+keeps *both* sides moving.
+
+A first attempt (PR #220) was rejected in review for two reasons: (1) it relied
+on the runners' exit codes to detect an idle queue, but both `start_work.sh` and
+`review_work.sh` exit `0` whether they processed an item or found nothing — so
+the idle back-off never fired and, on an empty queue, autopilot would busy-loop
+with no sleep (API-rate-limit pressure, log spam); (2) a label-governance issue
+now handled separately by the `human-only-guard` (ADR-0013 / #288).
+
+## Decision
+
+Add **`autopilot.sh`**, a thin conductor that keeps both sides moving from one
+command:
+
+1. **Alternate, review-first, with a ratio.** Each cycle runs `REVIEW_PER_WORK`
+   review passes (default **2**, biased toward review because it is the
+   bottleneck) then **one** work pass. `REVIEW_PER_WORK`, an idle `POLL_SECONDS`,
+   and `MAX_CYCLES` are env-tunable.
+2. **Compose, don't merge.** autopilot only owns the alternation, ratio, idle
+   back-off, and the per-cycle pull. It invokes the existing runners with
+   `MAX=1 POLL_SECONDS=0` (do one item, exit rather than poll). All real
+   behaviour stays in those scripts and `scripts/fg-common.sh`, unchanged.
+3. **Correct idle detection.** Because the runners can't be distinguished by
+   exit code, autopilot detects the empty-queue sentinel line each one prints
+   ("No open PRs needing review." / "Queue empty — no rework…"). Only when a
+   whole cycle does nothing does it sleep `POLL_SECONDS`.
+4. **Pull latest main each cycle.** So operators automatically pick up script and
+   pipeline improvements without a manual `git pull`. git's atomic-rename means
+   the running autopilot keeps its open inode (no mid-run corruption) while the
+   freshly-launched runner subprocesses read the new code immediately; a change
+   to autopilot itself applies on the next restart. `PULL=0` disables it.
+5. **Preserve the integrity rule.** The review side runs under a **distinct
+   identity** via `REVIEW_GITHUB_TOKEN`; the work side runs as the operator's
+   normal `gh` identity. Without the token, autopilot runs **work-only and
+   warns** — it never reviews as the author, which the gate would reject anyway.
+
+## Consequences
+
+- A single operator (or the whole crew) can keep production and review balanced
+  with one command; raising `REVIEW_PER_WORK` biases harder toward draining
+  review.
+- **autopilot does not remove the need for ≥2 identities in the system.** One
+  machine cannot review its own PRs, so a solo operator still produces PRs no one
+  can merge. autopilot multiplies the throughput of a crew of reviewers; it is
+  not a substitute for one. This is a property of the integrity rule.
+- The per-cycle pull keeps the fleet current with maintainer improvements
+  automatically — a nudge to keep `main` always-runnable.
+- The runners remain independently runnable and testable; autopilot adds no
+  coupling beyond what already exists via `fg-common.sh`.
+
+## Alternatives considered
+
+- **Fuse the two runners into one alternating script.** Rejected: it still can't
+  review its own output (same identity), so it doesn't remove the second-identity
+  requirement; it trades clean separation for one large stateful script.
+- **Give the runners a distinct "nothing to do" exit code.** Cleaner in theory,
+  but changes the contract of two actively-evolving scripts. Deferred in favour
+  of the self-contained sentinel check in autopilot; revisit if the sentinel
+  strings prove fragile.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,5 +51,6 @@ routine fixes, copy changes, or web styling.
 | [0012](0012-synthesis-followup-research-loop.md) | Blocking unknowns loop back to research automatically — bounded — before the G1 human gate | Accepted |
 | [0013](0013-pipeline-guardrails.md) | Pipeline guardrails: bounded agent loops, one status at a time, human-held levers | Accepted |
 | [0014](0014-discover-framing-capability-floor.md) | Discover framing is reserved for a capability-floored runner (frame_work.sh) that also opens the fan-out | Proposed |
+| [0015](0015-autopilot-alternates-review-and-work.md) | autopilot.sh — one command alternates review and work, detects idle, and pulls latest main each cycle | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).


### PR DESCRIPTION
**Supersedes #220.** The single script you tell everyone to run — it keeps *both* sides of the queue moving.

Each cycle: `REVIEW_PER_WORK` review passes (default 2, review-biased) → one work pass, calling the existing `review_work.sh` / `start_work.sh` with `MAX=1 POLL_SECONDS=0`. Thin conductor, not a merge of the runners.

**Fixes the two things #220's review flagged:**
1. **Idle back-off actually works now.** The runners exit `0` whether they processed an item or found an empty queue, so autopilot can't use the exit code — it now detects each runner's empty-queue **sentinel line** and only sleeps `POLL_SECONDS` when a whole cycle did nothing. No more busy-loop hammering the API on an empty queue.
2. **The label-governance finding** is moot — handled by the `human-only-guard` (#288).

**New, per Adam:** **auto-pull latest `main` each cycle** (`git fetch` + `--ff-only` merge) so operators pick up script/pipeline improvements without a manual `git pull`. git's atomic rename keeps the *running* autopilot on its open inode (no mid-run corruption); the freshly-launched runner subprocesses read the new code immediately. `PULL=0` to disable.

**Integrity intact:** review runs under `REVIEW_GITHUB_TOKEN` (distinct identity); no token → work-only + warn. ADR-0015 records it (0013 was taken by pipeline-guardrails), with the index row added. `bash -n` clean.

So the pitch becomes: **clone, then `REVIEW_GITHUB_TOKEN=… ./autopilot.sh`** — one script, both jobs, always on latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)