### PR TITLE
autopilot: hot-reload itself when a pull changes autopilot.sh

### DIFF
--- a/autopilot.sh
+++ b/autopilot.sh
@@ -42,6 +42,12 @@ MAX_CYCLES="${MAX_CYCLES:-0}"             # 0 = run forever
 PULL="${PULL:-1}"                         # git-pull latest main each cycle (0 to disable)
 MAIN_BRANCH="${MAIN_BRANCH:-main}"
 
+# Fingerprint this script so we can hot-reload it if a pull changes autopilot.sh
+# itself (see the exec below). $PWD is the script dir — we cd'd here above.
+SELF="$PWD/$(basename "$0")"
+self_hash() { sha1sum "$SELF" 2>/dev/null | cut -d' ' -f1 || true; }
+SELF_HASH="$(self_hash)"
+
 trap 'rule; warn "autopilot stopping."; exit 130' INT TERM
 
 if [ -z "${REVIEW_GITHUB_TOKEN:-}" ]; then
@@ -73,10 +79,19 @@ while :; do
   # pipeline improvements without a manual git pull. git swaps files by atomic
   # rename, so the RUNNING autopilot keeps executing its current (open) inode —
   # no mid-run corruption — while the runner subprocesses launched below read the
-  # freshly-updated code immediately; autopilot's own update applies next restart.
+  # freshly-updated code immediately.
   if [ "$PULL" = 1 ]; then
     if git fetch --quiet origin "$MAIN_BRANCH" 2>/dev/null && git merge --ff-only --quiet FETCH_HEAD 2>/dev/null; then
       log "Pulled latest origin/$MAIN_BRANCH."
+      # If the pull updated autopilot.sh ITSELF, hot-reload onto the new version
+      # by re-exec'ing at the top of the cycle — so autopilot-level improvements
+      # apply with no manual restart. The hash guard makes this fire only on a
+      # real change (the re-exec'd process re-fingerprints the current file), so
+      # there's no exec loop.
+      if [ "$(self_hash)" != "$SELF_HASH" ]; then
+        info "autopilot.sh changed on origin/$MAIN_BRANCH — reloading onto the new version…"
+        exec "$SELF" "$@"
+      fi
     else
       warn "Couldn't fast-forward to origin/$MAIN_BRANCH (local changes / not on $MAIN_BRANCH / offline) — staying on current code."
     fi

--- a/docs/adr/0015-autopilot-alternates-review-and-work.md
+++ b/docs/adr/0015-autopilot-alternates-review-and-work.md
@@ -41,8 +41,11 @@ command:
 4. **Pull latest main each cycle.** So operators automatically pick up script and
    pipeline improvements without a manual `git pull`. git's atomic-rename means
    the running autopilot keeps its open inode (no mid-run corruption) while the
-   freshly-launched runner subprocesses read the new code immediately; a change
-   to autopilot itself applies on the next restart. `PULL=0` disables it.
+   freshly-launched runner subprocesses read the new code immediately. If the pull
+   changes `autopilot.sh` itself, the script **hot-reloads** by re-exec'ing onto
+   the new version at the top of the cycle (guarded by a self-hash so it only
+   fires on a real change — no exec loop), so autopilot-level improvements apply
+   with no manual restart. `PULL=0` disables the per-cycle pull.
 5. **Preserve the integrity rule.** The review side runs under a **distinct
    identity** via `REVIEW_GITHUB_TOKEN`; the work side runs as the operator's
    normal `gh` identity. Without the token, autopilot runs **work-only and


### PR DESCRIPTION
Follow-up to #396 (Adam asked for it): make `autopilot.sh` **hot-reload itself**.

It fingerprints the script at startup (`sha1sum`). After each per-cycle `git pull`, if `autopilot.sh` *itself* changed on `main`, it re-execs onto the new version at the top of the cycle — so autopilot-level improvements reach running operators with **no manual restart**, exactly like the runner subprocesses already do. A self-hash guard means the re-exec only fires on a real change (the relaunched process re-fingerprints the now-current file), so there's no exec loop.

Net: change any script — including autopilot itself — land it on `main`, and every running `autopilot.sh` picks it up within a cycle. `PULL=0` still disables the whole thing. ADR-0015 updated; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)