### PR TITLE
build: fleet coordination + telemetry server and live mission-control dashboard (#398 Phase 1)

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.log
+.env

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.log
+.env
+fleet-state.json

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json package-lock.json ./
 RUN npm ci
 COPY tsconfig.json ./
 COPY src ./src
+COPY clients ./clients
 RUN npm run build && npm prune --omit=dev
 
 FROM node:22-alpine
@@ -13,6 +14,9 @@ ENV NODE_ENV=production
 WORKDIR /app
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
+# dist/redact.js imports ../clients/redact-patterns.mjs — the shared pattern
+# library used by both the server and the harness hook clients.
+COPY --from=build /app/clients ./clients
 COPY package.json ./
 RUN mkdir -p /data && chown node:node /data
 USER node

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,22 @@
+# For Good fleet server — single self-contained container (state is in-memory,
+# optionally snapshotted to a volume via STATE_FILE).
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build && npm prune --omit=dev
+
+FROM node:22-alpine
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+RUN mkdir -p /data && chown node:node /data
+USER node
+EXPOSE 8787
+HEALTHCHECK --interval=15s --timeout=3s --start-period=5s \
+  CMD wget -qO- http://127.0.0.1:8787/healthz >/dev/null || exit 1
+CMD ["node", "dist/index.js"]

--- a/server/README.md
+++ b/server/README.md
@@ -10,7 +10,7 @@ The coordination + telemetry server from [#398](https://github.com/thecolab-ai/t
 docker compose up -d          # server on :8787
 ```
 
-or without Docker:
+or without Docker (Node **22+** — the simulator uses the built-in global `WebSocket` client):
 
 ```bash
 npm install

--- a/server/README.md
+++ b/server/README.md
@@ -73,6 +73,29 @@ curl -s -X POST http://host:8787/api/v1/telemetry -H 'content-type: application/
 
 Presence expires ~90s after the last heartbeat; heartbeat every ~30s.
 
+### Harness hooks — plug a real session in ([`clients/`](clients/))
+
+Self-contained Node scripts (no npm install) that bridge a live harness session to the server. Both **no-op instantly unless `FLEET_SERVER` is set**, never block the session (3s timeouts, every failure swallowed, always exit 0), and only stream session *content* when `STREAM_LOGS=1` is also set — with client-side redaction before send and server-side redaction again.
+
+**Claude Code** — merge [`clients/claude-settings.example.json`](clients/claude-settings.example.json) into `~/.claude/settings.json` (or the project's `.claude/settings.local.json`), then run with `FLEET_SERVER` set:
+
+```bash
+FLEET_SERVER=http://host:8787 FLEET_HANDLE=<you> claude
+# add STREAM_LOGS=1 to also stream redacted session excerpts (loud consent warning printed)
+```
+
+Hook events → telemetry: `SessionStart` → hello/presence (model id from the payload); `PostToolUse` → tool-call counts by tool + WebFetch/WebSearch ok/error; `Stop` → token deltas parsed from the session transcript (cache reads excluded so the TPS gauge reflects fresh work) and, when opted in, a redacted excerpt of the assistant's latest message; `SessionEnd` → goodbye. Note the transcript format is internal to Claude Code and can change between versions — the parser fails soft to zero deltas if it does.
+
+**Codex** — point Codex's notify hook at the bridge in `~/.codex/config.toml`:
+
+```toml
+notify = ["node", "/path/to/the-for-good-project/server/clients/codex-notify.mjs"]
+```
+
+Codex only fires notify per completed turn, so its telemetry is coarser (presence + heartbeat + opt-in excerpt of the last assistant message; no per-tool or token counts). Set `FLEET_SERVER`, `FLEET_HANDLE`, `FLEET_MODEL` in the environment Codex runs in.
+
+**Log ingestion endpoint:** hook processes are one-shot, so they POST `{agentId, lines}` to `/api/v1/logs` instead of holding a WebSocket; it 403s unless the server runs with `ALLOW_LOG_STREAM=1`.
+
 ### Watchers ← server
 
 **WebSocket** `ws://host:8787/ws/watch` — receive `{ type: "snapshot", state }` on connect, then deltas: `agents` (full presence list), `fleet` (TPS + totals, ticked every 2s), `watchers`, `event`, and optionally `log`. Polling fallback: `GET /api/v1/state`, `GET /api/v1/metrics`, `GET /healthz`.
@@ -94,4 +117,4 @@ Presence expires ~90s after the last heartbeat; heartbeat every ~30s.
 
 - **Dispatch (Phases 2–3)** — soft hints then push assignment. The watcher/agent split and the `welcome` handshake leave room for a `hint`/`assign` message type.
 - **Auth** — parked, designs on file in #398.
-- **Autopilot wiring** — `autopilot.sh`/runner integration lands as its own change; `examples/agent-heartbeat.sh` is the shape of it.
+- **Autopilot wiring** — `autopilot.sh`/runner integration lands as its own change; `examples/agent-heartbeat.sh` is the shape of it, and the `clients/` hook scripts already cover any Claude Code / Codex session run inside this repo once configured.

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,97 @@
+# Fleet server — mission control for the worker fleet
+
+The coordination + telemetry server from [#398](https://github.com/thecolab-ai/the-for-good-project/issues/398), Phase 1: **telemetry in**. Workers (autopilot runs) connect and stream presence + heartbeats; the live dashboard connects as a *watcher* and gets the whole fleet in real time — who's online, what they're working on, and a fleet-wide **TPS (tokens/sec)** gauge in the spirit of Bitcoin hash-rate.
+
+**The non-negotiable principle:** GitHub stays the durable source of truth. This server is an optional accelerator — telemetry and (later) dispatch hints layered on top. Workers must keep functioning exactly as today when it's down, and every client here is written that way (telemetry calls no-op on failure).
+
+## Run it
+
+```bash
+docker compose up -d          # server on :8787
+```
+
+or without Docker:
+
+```bash
+npm install
+npm run dev                   # tsx watch, :8787
+```
+
+Demo it with fake agents (no real workers needed):
+
+```bash
+npm run simulate              # AGENTS=12 SERVER=ws://host:8787 to vary
+```
+
+Point the dashboard at it: set `VITE_LIVE_SERVER_URL=http://localhost:8787` when running `web/`, or in the browser `localStorage.setItem("forgood.liveServer", "http://localhost:8787")` on the deployed site.
+
+## Architecture decisions
+
+**TypeScript** — same language as `web/`, so the watcher protocol types are shared by mirror (`src/protocol.ts` ↔ `web/src/lib/live.ts`).
+
+**In-memory state, no database, no Redis.** Considered and rejected for now: every piece of state here is ephemeral by design — presence with 90s TTLs, a 60s sliding token window, a capped event feed. It all rebuilds from heartbeats within seconds of a restart, and #398 explicitly says *"keep it small and stateless where possible (GitHub holds state)"*. Redis would only earn its keep with multiple server replicas, which the fleet's realistic scale (tens of workers/watchers ≪ one Node process's capacity) doesn't justify — and it would double the ops burden of a project whose ethos is "clone it and run one script". The single thing worth keeping across restarts — lifetime totals + the event feed — is snapshotted to `STATE_FILE` on a volume. If we ever scale out, `FleetStore` is the seam: swap in a shared-store implementation behind the same interface.
+
+**Auth is parked** (maintainer decision on #398): connecting workers are assumed to be who they claim. The `hello` handshake is shaped so a challenge step (SSH-key signature or GitHub device flow — both designed in the issue) can slot in later without protocol changes.
+
+**Watcher privacy:** a watcher's IP is used once, in-process, to derive a rough location (city/country + coordinates rounded to ~11 km) via an offline GeoLite2 lookup (`geoip-lite` — the IP never leaves the process, no third-party geo API). The IP is never stored, never logged, and never sent to any client. Watchers appear to others only as `{ random id, city, country, rough coords, connectedAt }`.
+
+**Log streaming is default-OFF at both ends** (per #398): a worker must opt in (`STREAM_LOGS=1`) *and* the server must allow it (`ALLOW_LOG_STREAM=1`), and even then logs are redacted twice (worker-side and server-side, `src/redact.ts`) and only reach the public dashboard if `BROADCAST_LOGS=1` is *also* set. Heartbeats carry counts and rates, never content.
+
+## Protocol
+
+### Workers → server
+
+**WebSocket** `ws://host:8787/ws/agent` — send `hello` within 10s, then heartbeats:
+
+```jsonc
+{ "type": "hello", "handle": "adam91holt", "harness": "claude", "model": "claude-fable-5",
+  "task": { "kind": "work", "ref": "#231", "title": "School attendance interventions" } }
+// server replies: { "type": "welcome", "agentId": "…" }
+
+{ "type": "heartbeat",              // all counters are DELTAS since last heartbeat
+  "tokensIn": 3200, "tokensOut": 940,
+  "toolCalls": 5, "tools": { "bash": 3, "webfetch": 2 },
+  "fetchesOk": 2, "fetchesError": 0,
+  "skills": { "child-poverty-nz": 1 },
+  "errors": 0, "tasksCompleted": 0, "prsOpened": 0, "reviewsCompleted": 0 }
+
+{ "type": "task", "task": { "kind": "review", "ref": "#405", "title": "…" } }
+{ "type": "log", "lines": ["…"] }   // opt-in only, redacted, see above
+{ "type": "bye" }
+```
+
+**Plain HTTP** (for bash workers — see [`examples/agent-heartbeat.sh`](examples/agent-heartbeat.sh)):
+
+```bash
+curl -s -X POST http://host:8787/api/v1/telemetry -H 'content-type: application/json' -d '{
+  "agentId": "<from the first response, optional>",
+  "handle": "adam91holt", "harness": "claude", "model": "claude-fable-5",
+  "task": { "kind": "work", "ref": "#231" },
+  "heartbeat": { "tokensIn": 3200, "tokensOut": 940, "toolCalls": 5 }
+}'
+```
+
+Presence expires ~90s after the last heartbeat; heartbeat every ~30s.
+
+### Watchers ← server
+
+**WebSocket** `ws://host:8787/ws/watch` — receive `{ type: "snapshot", state }` on connect, then deltas: `agents` (full presence list), `fleet` (TPS + totals, ticked every 2s), `watchers`, `event`, and optionally `log`. Polling fallback: `GET /api/v1/state`, `GET /api/v1/metrics`, `GET /healthz`.
+
+## Configuration
+
+| Env | Default | What |
+|---|---|---|
+| `PORT` / `HOST` | `8787` / `0.0.0.0` | Listen address |
+| `STATE_FILE` | unset | JSON snapshot for totals + event feed (compose mounts a volume) |
+| `TRUST_PROXY` | `1` | Honour `X-Forwarded-For` for watcher geo behind a proxy |
+| `WATCHER_GEO` | `1` | Rough watcher location from IP (IP discarded immediately) |
+| `ALLOW_LOG_STREAM` | `0` | Accept opt-in log streams from workers |
+| `BROADCAST_LOGS` | `0` | Also forward (redacted) logs to watchers |
+| `CORS_ORIGIN` | `*` | Comma-separated allowed origins |
+| `AGENT_TTL_SECONDS` | `90` | Presence timeout without a heartbeat |
+
+## What's deliberately NOT here yet
+
+- **Dispatch (Phases 2–3)** — soft hints then push assignment. The watcher/agent split and the `welcome` handshake leave room for a `hint`/`assign` message type.
+- **Auth** — parked, designs on file in #398.
+- **Autopilot wiring** — `autopilot.sh`/runner integration lands as its own change; `examples/agent-heartbeat.sh` is the shape of it.

--- a/server/README.md
+++ b/server/README.md
@@ -37,7 +37,7 @@ Point the dashboard at it: set `VITE_LIVE_SERVER_URL=http://localhost:8787` when
 
 **Streamed logs are broadcast-only** — the server retains nothing: no log lines are stored in memory or on disk, they only fan out live to connected watchers (and only when `BROADCAST_LOGS=1`).
 
-**Log streaming is default-OFF at both ends** (per #398): a worker must opt in (`STREAM_LOGS=1`) *and* the server must allow it (`ALLOW_LOG_STREAM=1`), and even then logs are redacted twice (worker-side and server-side, `src/redact.ts`) and only reach the public dashboard if `BROADCAST_LOGS=1` is *also* set. Heartbeats carry counts and rates, never content.
+**Log streaming is default-OFF at both ends** (per #398): a worker must opt in (`STREAM_LOGS=1`) *and* the server must allow it (`ALLOW_LOG_STREAM=1`), and even then logs are redacted twice — worker-side and server-side, both from the ONE shared pattern library ([`clients/redact-patterns.mjs`](clients/redact-patterns.mjs)) so the two passes can never drift. Coverage: URL credentials (Postgres/MySQL/MongoDB/Redis/AMQP/any `scheme://user:pass@`), private-key/PGP/age blocks, AWS key ids + secret assignments, GitHub/GitLab/Slack/Discord/Telegram tokens and webhook URLs, OpenAI/Anthropic/HF/Stripe/Google/Azure/SendGrid/Twilio/npm/PyPI/Shopify/DigitalOcean/Databricks/Linear/Notion/Airtable token shapes, JWTs, auth headers, and any `NAME=value` where the name looks secret-bearing (quoted values included) — tested by `npm test` (`test/redact.test.mjs`), which deliberately accepts over-redaction. Logs only reach the public dashboard if `BROADCAST_LOGS=1` is *also* set. Heartbeats carry counts and rates, never content — and redaction remains best-effort harm reduction, not a guarantee.
 
 ## Protocol
 

--- a/server/README.md
+++ b/server/README.md
@@ -31,9 +31,11 @@ Point the dashboard at it: set `VITE_LIVE_SERVER_URL=http://localhost:8787` when
 
 **In-memory state, no database, no Redis.** Considered and rejected for now: every piece of state here is ephemeral by design — presence with 90s TTLs, a 60s sliding token window, a capped event feed. It all rebuilds from heartbeats within seconds of a restart, and #398 explicitly says *"keep it small and stateless where possible (GitHub holds state)"*. Redis would only earn its keep with multiple server replicas, which the fleet's realistic scale (tens of workers/watchers ≪ one Node process's capacity) doesn't justify — and it would double the ops burden of a project whose ethos is "clone it and run one script". The single thing worth keeping across restarts — lifetime totals + the event feed — is snapshotted to `STATE_FILE` on a volume. If we ever scale out, `FleetStore` is the seam: swap in a shared-store implementation behind the same interface.
 
-**Auth is parked** (maintainer decision on #398): connecting workers are assumed to be who they claim. The `hello` handshake is shaped so a challenge step (SSH-key signature or GitHub device flow — both designed in the issue) can slot in later without protocol changes.
+**Auth is parked** (maintainer decision on #398): connecting workers are assumed to be who they claim. The `hello` handshake is shaped so a challenge step (SSH-key signature or GitHub device flow — both designed in the issue) can slot in later without protocol changes. **Known exposure until then:** anyone who can reach the server can report presence/metrics under any handle. Cheap guards bound the blast radius — per-connection and per-IP rate limits, a `MAX_AGENTS` cap, and a WebSocket origin check (when `CORS_ORIGIN` isn't `*`) so a malicious web page can't use a visitor's browser to inject spoofed presence — but the telemetry itself is honour-system until auth lands. GitHub remains the source of truth for anything that matters.
 
-**Watcher privacy:** a watcher's IP is used once, in-process, to derive a rough location (city/country + coordinates rounded to ~11 km) via an offline GeoLite2 lookup (`geoip-lite` — the IP never leaves the process, no third-party geo API). The IP is never stored, never logged, and never sent to any client. Watchers appear to others only as `{ random id, city, country, rough coords, connectedAt }`.
+**Watcher privacy:** a watcher's IP is used once, in-process, to derive a rough location (city/country + coordinates rounded to ~11 km) via an offline GeoLite2 lookup (`geoip-lite` — the IP never leaves the process, no third-party geo API). The IP is never stored, never logged (request logging is scrubbed to method + url — Fastify's default serializer would otherwise emit `remoteAddress`), and never sent to any client. Watchers appear to others only as `{ random id, city, country, rough coords, connectedAt }`, and watcher-join notices are broadcast-only — they're never written to the persisted event feed.
+
+**Streamed logs are broadcast-only** — the server retains nothing: no log lines are stored in memory or on disk, they only fan out live to connected watchers (and only when `BROADCAST_LOGS=1`).
 
 **Log streaming is default-OFF at both ends** (per #398): a worker must opt in (`STREAM_LOGS=1`) *and* the server must allow it (`ALLOW_LOG_STREAM=1`), and even then logs are redacted twice (worker-side and server-side, `src/redact.ts`) and only reach the public dashboard if `BROADCAST_LOGS=1` is *also* set. Heartbeats carry counts and rates, never content.
 
@@ -112,6 +114,7 @@ Codex only fires notify per completed turn, so its telemetry is coarser (presenc
 | `BROADCAST_LOGS` | `0` | Also forward (redacted) logs to watchers |
 | `CORS_ORIGIN` | `*` | Comma-separated allowed origins |
 | `AGENT_TTL_SECONDS` | `90` | Presence timeout without a heartbeat |
+| `MAX_AGENTS` | `500` | Hard cap on tracked agents (anti-flood while auth is parked) |
 
 ## What's deliberately NOT here yet
 

--- a/server/clients/claude-code-hook.mjs
+++ b/server/clients/claude-code-hook.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Claude Code -> fleet server bridge, wired via Claude Code's hooks system.
+ * One script handles every event; see claude-settings.example.json for the
+ * settings.json wiring (SessionStart, PostToolUse, Stop, SessionEnd).
+ *
+ * What it sends (issue #398 Phase 1 telemetry):
+ *  - SessionStart  -> hello (presence: handle, harness, model)
+ *  - PostToolUse   -> heartbeat: +1 tool call, per-tool breakdown, and
+ *                     fetch ok/error for WebFetch/WebSearch
+ *  - Stop          -> heartbeat: token DELTAS read from the session
+ *                     transcript since the last Stop; plus — ONLY when
+ *                     STREAM_LOGS=1 — a small redacted excerpt of the
+ *                     assistant's latest message for the dashboard feed
+ *  - SessionEnd    -> goodbye
+ *
+ * No-ops instantly unless FLEET_SERVER is set, and never blocks the session:
+ * short timeouts, every failure swallowed, always exits 0.
+ */
+import { readFileSync } from "node:fs";
+import {
+  enabled,
+  loadState,
+  post,
+  saveState,
+  STREAM_LOGS,
+  toLogLines,
+  warnStreamingOnce,
+  HANDLE,
+} from "./fleet-common.mjs";
+
+if (!enabled()) process.exit(0);
+
+// Read the hook payload from stdin.
+let payload = {};
+try {
+  payload = JSON.parse(readFileSync(0, "utf8"));
+} catch {
+  process.exit(0);
+}
+
+const event = payload.hook_event_name ?? "";
+const sessionKey = `claude-${payload.session_id ?? "default"}`.slice(0, 80);
+let state = loadState(sessionKey);
+if (event === "SessionStart") state = warnStreamingOnce(state);
+
+const hello = {
+  handle: HANDLE || "unknown",
+  harness: "claude",
+  // SessionStart's payload carries the model id; later events fall back to
+  // whatever the state file captured, then env.
+  model:
+    payload.model || state.model || process.env.FLEET_MODEL || process.env.ANTHROPIC_MODEL || "claude",
+  ...(process.env.TASK_REF || process.env.TASK_TITLE
+    ? { task: { kind: process.env.TASK_KIND || "work", ref: process.env.TASK_REF, title: process.env.TASK_TITLE } }
+    : {}),
+};
+
+/** Every telemetry POST is an upsert (hello + heartbeat), so presence works
+ *  even if hooks were installed mid-session and SessionStart never fired. */
+async function send(heartbeat) {
+  const resp = await post("/api/v1/telemetry", {
+    ...(state.agentId ? { agentId: state.agentId } : {}),
+    ...hello,
+    ...(heartbeat ? { heartbeat } : {}),
+  });
+  if (resp?.agentId) state.agentId = resp.agentId;
+}
+
+/** Parse new transcript lines since the last read; return token deltas and
+ *  the latest assistant text (for the opt-in log stream). */
+function readTranscriptDelta() {
+  const out = { tokensIn: 0, tokensOut: 0, lastText: "" };
+  const path = payload.transcript_path;
+  if (!path) return out;
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return out;
+  }
+  const offset = Number.isFinite(state.offset) && state.offset <= raw.length ? state.offset : 0;
+  state.offset = raw.length;
+  for (const line of raw.slice(offset).split("\n")) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (entry.type !== "assistant") continue;
+    const usage = entry.message?.usage;
+    if (usage) {
+      // Cache reads are excluded: they'd inflate "intelligence at work" by
+      // orders of magnitude. Fresh input + cache writes + output only.
+      out.tokensIn += (usage.input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0);
+      out.tokensOut += usage.output_tokens ?? 0;
+    }
+    const text = (entry.message?.content ?? [])
+      .filter((c) => c?.type === "text" && c.text)
+      .map((c) => c.text)
+      .join("\n");
+    if (text.trim()) out.lastText = text;
+  }
+  return out;
+}
+
+if (payload.model) state.model = payload.model;
+
+switch (event) {
+  case "SessionStart": {
+    await send();
+    break;
+  }
+  case "PostToolUse": {
+    const tool = String(payload.tool_name ?? "unknown").slice(0, 64);
+    const heartbeat = { toolCalls: 1, tools: { [tool]: 1 } };
+    if (tool === "WebFetch" || tool === "WebSearch") {
+      const failed =
+        payload.tool_response?.is_error === true ||
+        (typeof payload.tool_response === "string" && /^error/i.test(payload.tool_response));
+      heartbeat[failed ? "fetchesError" : "fetchesOk"] = 1;
+    }
+    await send(heartbeat);
+    break;
+  }
+  case "Stop": {
+    const delta = readTranscriptDelta();
+    await send({ tokensIn: delta.tokensIn, tokensOut: delta.tokensOut });
+    if (STREAM_LOGS && state.agentId && delta.lastText) {
+      await post("/api/v1/logs", { agentId: state.agentId, lines: toLogLines(delta.lastText) });
+    }
+    break;
+  }
+  case "SessionEnd": {
+    if (state.agentId) await post("/api/v1/goodbye", { agentId: state.agentId });
+    break;
+  }
+  default:
+    break;
+}
+
+saveState(sessionKey, state);
+process.exit(0);

--- a/server/clients/claude-code-hook.mjs
+++ b/server/clients/claude-code-hook.mjs
@@ -79,7 +79,14 @@ function readTranscriptDelta() {
   } catch {
     return out;
   }
-  const offset = Number.isFinite(state.offset) && state.offset <= raw.length ? state.offset : 0;
+  if (Number.isFinite(state.offset) && state.offset > raw.length) {
+    // Transcript shrank (truncated/rotated) — re-parsing from 0 would
+    // double-count every prior token into this delta. Skip this tick and
+    // resume counting from the new end.
+    state.offset = raw.length;
+    return out;
+  }
+  const offset = Number.isFinite(state.offset) ? state.offset : 0;
   state.offset = raw.length;
   for (const line of raw.slice(offset).split("\n")) {
     if (!line.trim()) continue;

--- a/server/clients/claude-settings.example.json
+++ b/server/clients/claude-settings.example.json
@@ -1,0 +1,34 @@
+{
+  "$comment": "Fleet telemetry hooks for Claude Code — merge the `hooks` block into your ~/.claude/settings.json or the project's .claude/settings.local.json. They no-op instantly unless FLEET_SERVER is set in your environment; add STREAM_LOGS=1 (plus a server started with ALLOW_LOG_STREAM=1) to also stream redacted session excerpts.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR}/server/clients/claude-code-hook.mjs\"", "timeout": 10 }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR}/server/clients/claude-code-hook.mjs\"", "timeout": 10 }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR}/server/clients/claude-code-hook.mjs\"", "timeout": 10 }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR}/server/clients/claude-code-hook.mjs\"", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/server/clients/codex-notify.mjs
+++ b/server/clients/codex-notify.mjs
@@ -45,10 +45,10 @@ const hello = {
     : {}),
 };
 
+// Hello-only upsert: refreshes presence without a no-op heartbeat frame.
 const resp = await post("/api/v1/telemetry", {
   ...(state.agentId ? { agentId: state.agentId } : {}),
   ...hello,
-  heartbeat: { tasksCompleted: 0 },
 });
 if (resp?.agentId) state.agentId = resp.agentId;
 

--- a/server/clients/codex-notify.mjs
+++ b/server/clients/codex-notify.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Codex CLI -> fleet server bridge, wired via Codex's `notify` hook.
+ * In ~/.codex/config.toml:
+ *
+ *   notify = ["node", "/path/to/the-for-good-project/server/clients/codex-notify.mjs"]
+ *
+ * Codex invokes it with one JSON argument per event (currently
+ * `agent-turn-complete`, carrying the turn's last assistant message). We turn
+ * that into presence + a heartbeat, and — ONLY when STREAM_LOGS=1 — a small
+ * redacted excerpt of the assistant's message for the dashboard feed.
+ *
+ * No-ops instantly unless FLEET_SERVER is set. Never blocks Codex: every
+ * network call is fire-and-forget with a short timeout.
+ *
+ * Telemetry is coarser than the Claude Code hook client: Codex's notify only
+ * fires per turn, so there are no per-tool-call counts or token deltas here.
+ */
+import { enabled, loadState, post, saveState, STREAM_LOGS, toLogLines, warnStreamingOnce, HANDLE } from "./fleet-common.mjs";
+
+if (!enabled()) process.exit(0);
+
+let event = {};
+try {
+  event = JSON.parse(process.argv[2] ?? "{}");
+} catch {
+  process.exit(0);
+}
+
+// Codex payload keys are kebab-case; be liberal in what we accept.
+const get = (obj, ...keys) => keys.map((k) => obj?.[k]).find((v) => v !== undefined);
+const type = get(event, "type") ?? "";
+if (type && type !== "agent-turn-complete") process.exit(0);
+
+const sessionKey = `codex-${get(event, "conversation-id", "conversation_id", "turn-id", "turn_id") ?? "default"}`.slice(0, 80);
+let state = loadState(sessionKey);
+state = warnStreamingOnce(state);
+
+const hello = {
+  handle: HANDLE || "unknown",
+  harness: "codex",
+  model: process.env.FLEET_MODEL || process.env.MODEL || "codex",
+  ...(process.env.TASK_REF || process.env.TASK_TITLE
+    ? { task: { kind: "work", ref: process.env.TASK_REF, title: process.env.TASK_TITLE } }
+    : {}),
+};
+
+const resp = await post("/api/v1/telemetry", {
+  ...(state.agentId ? { agentId: state.agentId } : {}),
+  ...hello,
+  heartbeat: { tasksCompleted: 0 },
+});
+if (resp?.agentId) state.agentId = resp.agentId;
+
+const lastMessage = get(event, "last-assistant-message", "last_assistant_message");
+if (STREAM_LOGS && state.agentId && typeof lastMessage === "string" && lastMessage.trim()) {
+  await post("/api/v1/logs", { agentId: state.agentId, lines: toLogLines(lastMessage) });
+}
+
+saveState(sessionKey, state);
+process.exit(0);

--- a/server/clients/fleet-common.mjs
+++ b/server/clients/fleet-common.mjs
@@ -1,0 +1,112 @@
+/**
+ * Shared plumbing for the harness hook clients (Claude Code hooks, Codex
+ * notify). Self-contained: Node >= 18 stdlib only, no npm install needed —
+ * these scripts run inside contributors' harness sessions.
+ *
+ * Fail-open by design: if FLEET_SERVER is unset or unreachable, every call
+ * no-ops fast and exits 0. Telemetry must never block or break real work —
+ * GitHub stays the source of truth (#398).
+ */
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const FLEET_SERVER = (process.env.FLEET_SERVER ?? "").replace(/\/+$/, "");
+export const STREAM_LOGS = process.env.STREAM_LOGS === "1";
+export const HANDLE = process.env.FLEET_HANDLE || process.env.HANDLE || "";
+export const POST_TIMEOUT_MS = 3000;
+
+export function enabled() {
+  return FLEET_SERVER.length > 0;
+}
+
+/** POST JSON to the fleet server; swallow every failure. Returns parsed body or null. */
+export async function post(path, body) {
+  if (!enabled()) return null;
+  try {
+    const res = await fetch(`${FLEET_SERVER}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(POST_TIMEOUT_MS),
+    });
+    return res.ok ? await res.json() : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-session state (agentId + transcript read offset), so each one-shot hook
+// invocation can resume where the previous one left off.
+
+function stateDir() {
+  const dir = join(tmpdir(), "fg-fleet");
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+  return dir;
+}
+
+export function loadState(sessionKey) {
+  try {
+    return JSON.parse(readFileSync(join(stateDir(), `${sessionKey}.json`), "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+export function saveState(sessionKey, state) {
+  try {
+    writeFileSync(join(stateDir(), `${sessionKey}.json`), JSON.stringify(state));
+  } catch {
+    /* best effort */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Client-side redaction — mirrors server/src/redact.ts (the server redacts
+// again; this keeps secrets from ever leaving the machine). Harm-reduction,
+// not a guarantee: the real protection is that log streaming is default-off.
+
+const REDACTED = "[redacted]";
+const PATTERNS = [
+  /\bgh[pousr]_[A-Za-z0-9_]{16,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{16,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\baws_secret_access_key\s*[=:]\s*\S+/gi,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\b/g,
+  /\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/g,
+  /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY)[A-Z0-9_]*\s*[=:]\s*[^\s"']+/gi,
+];
+
+export function redact(text) {
+  let out = String(text);
+  for (const re of PATTERNS) out = out.replace(re, REDACTED);
+  return out;
+}
+
+/** Trim a block of session text into a small, redacted set of lines. */
+export function toLogLines(text, maxLines = 12, maxLen = 500) {
+  return redact(text)
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .slice(-maxLines)
+    .map((l) => (l.length > maxLen ? `${l.slice(0, maxLen)}…` : l));
+}
+
+/** One-time loud consent warning when log streaming is on (issue #398). */
+export function warnStreamingOnce(state) {
+  if (!STREAM_LOGS || state.warned) return state;
+  process.stderr.write(
+    `[fleet] STREAM_LOGS=1 — your session transcript excerpts will be streamed to ${FLEET_SERVER}. ` +
+      `Redaction is best-effort, NOT a guarantee; don't run this on a machine with sensitive material.\n`,
+  );
+  return { ...state, warned: true };
+}

--- a/server/clients/fleet-common.mjs
+++ b/server/clients/fleet-common.mjs
@@ -82,11 +82,15 @@ const PATTERNS = [
   /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\b/g,
   /\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi,
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/g,
-  /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY)[A-Z0-9_]*\s*[=:]\s*[^\s"']+/gi,
+  /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY)[A-Z0-9_]*"?\s*[=:]\s*("[^"]*"|'[^']*'|\S+)/gi,
 ];
 
+// URL userinfo credentials ("postgres://user:s3cr3t@host") — keep the scheme
+// and user, scrub the password.
+const URL_CREDS = /\b([a-z][a-z0-9+.-]*:\/\/[^\s/:@]+):([^\s/@]+)@/gi;
+
 export function redact(text) {
-  let out = String(text);
+  let out = String(text).replace(URL_CREDS, `$1:${REDACTED}@`);
   for (const re of PATTERNS) out = out.replace(re, REDACTED);
   return out;
 }

--- a/server/clients/fleet-common.mjs
+++ b/server/clients/fleet-common.mjs
@@ -10,6 +10,7 @@
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { redactText } from "./redact-patterns.mjs";
 
 export const FLEET_SERVER = (process.env.FLEET_SERVER ?? "").replace(/\/+$/, "");
 export const STREAM_LOGS = process.env.STREAM_LOGS === "1";
@@ -67,32 +68,14 @@ export function saveState(sessionKey, state) {
 }
 
 // ---------------------------------------------------------------------------
-// Client-side redaction — mirrors server/src/redact.ts (the server redacts
-// again; this keeps secrets from ever leaving the machine). Harm-reduction,
-// not a guarantee: the real protection is that log streaming is default-off.
-
-const REDACTED = "[redacted]";
-const PATTERNS = [
-  /\bgh[pousr]_[A-Za-z0-9_]{16,}\b/g,
-  /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
-  /\bsk-[A-Za-z0-9_-]{16,}\b/g,
-  /\bAKIA[0-9A-Z]{16}\b/g,
-  /\baws_secret_access_key\s*[=:]\s*\S+/gi,
-  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
-  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\b/g,
-  /\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi,
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/g,
-  /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY)[A-Z0-9_]*"?\s*[=:]\s*("[^"]*"|'[^']*'|\S+)/gi,
-];
-
-// URL userinfo credentials ("postgres://user:s3cr3t@host") — keep the scheme
-// and user, scrub the password.
-const URL_CREDS = /\b([a-z][a-z0-9+.-]*:\/\/[^\s/:@]+):([^\s/@]+)@/gi;
+// Client-side redaction — the pattern library is shared with the server
+// (./redact-patterns.mjs), so both sides always scrub identically. This pass
+// keeps secrets from ever leaving the machine; the server redacts again.
+// Harm-reduction, not a guarantee: the real protection is that log streaming
+// is default-off.
 
 export function redact(text) {
-  let out = String(text).replace(URL_CREDS, `$1:${REDACTED}@`);
-  for (const re of PATTERNS) out = out.replace(re, REDACTED);
-  return out;
+  return redactText(text);
 }
 
 /** Trim a block of session text into a small, redacted set of lines. */

--- a/server/clients/redact-patterns.d.mts
+++ b/server/clients/redact-patterns.d.mts
@@ -1,0 +1,2 @@
+export declare const REDACTED: string;
+export declare function redactText(text: string): string;

--- a/server/clients/redact-patterns.mjs
+++ b/server/clients/redact-patterns.mjs
@@ -1,0 +1,95 @@
+/**
+ * THE single source of truth for secret redaction — imported by both the
+ * server (src/redact.ts) and the harness hook clients (fleet-common.mjs), so
+ * the two can never drift. Plain Node stdlib, no dependencies.
+ *
+ * Philosophy: redact aggressively on unambiguous secret SHAPES (vendor
+ * prefixes, key blocks, URL credentials) and on secret-bearing NAMES
+ * (FOO_TOKEN=…), and accept some over-redaction — a false positive costs a
+ * garbled feed line; a false negative costs someone's credentials. This is
+ * still harm-reduction, not a guarantee: the real protection is that log
+ * streaming is default-off at both ends (#398).
+ */
+
+export const REDACTED = "[redacted]";
+
+// URL userinfo credentials ("postgres://user:s3cr3t@host") — covers Postgres,
+// MySQL, MongoDB (incl. +srv), Redis, AMQP, SMTP, and any scheme://user:pass@.
+// Applied first and keeps scheme+user so the line stays readable.
+const URL_CREDS = /\b([a-z][a-z0-9+.-]*:\/\/[^\s/:@]+):([^\s/@]+)@/gi;
+
+const PATTERNS = [
+  // --- key/cert blocks (multi-line, may be truncated mid-stream) ----------
+  // RSA/EC/DSA/OPENSSH/PGP private keys and PGP block variant.
+  /-----BEGIN [A-Z ]*PRIVATE KEY(?: BLOCK)?-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY(?: BLOCK)?-----|$)/g,
+  /\bAGE-SECRET-KEY-1[A-Z0-9]{20,}\b/g,
+
+  // --- AWS -----------------------------------------------------------------
+  // Access key ids (all documented prefixes) — the id alone aids pairing
+  // attacks, so scrub it too.
+  /\b(?:AKIA|ASIA|ABIA|ACCA|AGPA|AIDA|AIPA|ANPA|ANVA|AROA)[0-9A-Z]{16}\b/g,
+  /\baws_?(?:secret_?access_?key|session_?token)\b"?\s*[=:]\s*("[^"]*"|'[^']*'|\S+)/gi,
+
+  // --- GitHub / GitLab -------------------------------------------------------
+  /\bgh[pousr]_[A-Za-z0-9_]{16,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
+  /\bglpat-[A-Za-z0-9_-]{16,}\b/g,
+
+  // --- OpenAI / Anthropic / AI platforms ------------------------------------
+  // sk- covers OpenAI (sk-, sk-proj-), Anthropic (sk-ant-), Stripe secret
+  // keys (sk_live_/sk_test_ via the underscore variant below).
+  /\bsk-[A-Za-z0-9_-]{16,}\b/g,
+  /\bhf_[A-Za-z0-9]{20,}\b/g,
+  /\bgsk_[A-Za-z0-9]{20,}\b/g,
+
+  // --- Stripe ---------------------------------------------------------------
+  /\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}\b/g,
+  /\bwhsec_[A-Za-z0-9]{16,}\b/g,
+
+  // --- Google Cloud -----------------------------------------------------------
+  /\bAIza[0-9A-Za-z_-]{35}\b/g,
+  /\bya29\.[0-9A-Za-z_-]{20,}\b/g,
+
+  // --- Azure ------------------------------------------------------------------
+  // Storage/Service Bus connection strings and SAS signatures.
+  /\b(?:Account|SharedAccess)Key=[A-Za-z0-9+/=]{16,}/gi,
+  /[?&]sig=[A-Za-z0-9%+/=]{20,}/gi,
+
+  // --- Chat/webhook URLs (the URL IS the credential) ---------------------------
+  /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/_-]+/g,
+  /https:\/\/(?:\w+\.)?discord(?:app)?\.com\/api\/webhooks\/\d+\/[\w-]+/g,
+  /\bxox[baprse]-[A-Za-z0-9-]{10,}\b/g,
+  /\b\d{8,10}:AA[A-Za-z0-9_-]{30,}\b/g, // Telegram bot tokens
+
+  // --- Package registries / dev SaaS -------------------------------------------
+  /\bnpm_[A-Za-z0-9]{30,}\b/g,
+  /\bpypi-[A-Za-z0-9_-]{16,}\b/g,
+  /\bdop_v1_[a-f0-9]{40,}\b/g, // DigitalOcean
+  /\bdoo_v1_[a-f0-9]{40,}\b/g,
+  /\bshp(?:at|ss|ca)_[a-f0-9]{16,}\b/g, // Shopify
+  /\bSG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b/g, // SendGrid
+  /\bkey-[0-9a-f]{32}\b/g, // Mailgun
+  /\bdapi[0-9a-f]{32}\b/g, // Databricks
+  /\blin_api_[A-Za-z0-9]{20,}\b/g, // Linear
+  /\bntn_[A-Za-z0-9]{20,}\b/g, // Notion
+  /\bpat[A-Za-z0-9]{14}\.[a-f0-9]{64}\b/g, // Airtable PAT
+  /\bSK[0-9a-f]{32}\b/g, // Twilio API key SID
+
+  // --- JWTs (three base64url segments) ------------------------------------------
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\b/g,
+
+  // --- Authorization headers ------------------------------------------------------
+  /\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi,
+
+  // --- Generic secret-bearing NAME = value (env/JSON/YAML/CLI) --------------------
+  // Catches quoted and unquoted values. _PWD requires the underscore so
+  // ordinary shell `PWD=/home/x` lines survive. Runs LAST — vendor patterns
+  // above give more precise replacements first.
+  /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|CREDENTIALS?|API_?KEY|PRIVATE_?KEY|ACCESS_?KEY|SECRET_?KEY|SIGNING_?KEY|ENCRYPTION_?KEY|MASTER_?KEY|SSH_?KEY|LICENSE_?KEY|_PWD|_DSN)[A-Z0-9_]*"?\s*[=:]\s*("[^"]*"|'[^']*'|\S+)/gi,
+];
+
+export function redactText(text) {
+  let out = String(text).replace(URL_CREDS, `$1:${REDACTED}@`);
+  for (const re of PATTERNS) out = out.replace(re, REDACTED);
+  return out;
+}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,22 @@
+# Run the fleet server:  docker compose up -d
+# State is in-memory by design (presence rebuilds from heartbeats); the volume
+# only preserves lifetime totals + the event feed across restarts.
+services:
+  fleet-server:
+    build: .
+    ports:
+      - "${PORT:-8787}:8787"
+    environment:
+      STATE_FILE: /data/fleet-state.json
+      TRUST_PROXY: "1"
+      WATCHER_GEO: "1"
+      # Log streaming stays default-OFF (issue #398): flip both deliberately.
+      ALLOW_LOG_STREAM: "0"
+      BROADCAST_LOGS: "0"
+      CORS_ORIGIN: "*"
+    volumes:
+      - fleet-state:/data
+    restart: unless-stopped
+
+volumes:
+  fleet-state:

--- a/server/examples/agent-heartbeat.sh
+++ b/server/examples/agent-heartbeat.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Minimal curl-based worker client for the fleet server — the shape of what
+# autopilot.sh will call each cycle. Pure HTTP: no WebSocket needed, and if the
+# server is down every call no-ops (|| true) so the worker never blocks on it.
+# GitHub remains the source of truth; this is telemetry only.
+#
+# Usage:
+#   FLEET_SERVER=http://localhost:8787 HANDLE=you HARNESS=claude MODEL=claude-fable-5 \
+#     ./agent-heartbeat.sh
+set -euo pipefail
+
+FLEET_SERVER="${FLEET_SERVER:-http://127.0.0.1:8787}"
+HANDLE="${HANDLE:-$(git config user.name 2>/dev/null || echo unknown)}"
+HARNESS="${HARNESS:-claude}"
+MODEL="${MODEL:-unknown}"
+AGENT_ID_FILE="${AGENT_ID_FILE:-/tmp/fg-agent-id}"
+
+# post <json> — returns the response body, never fails the caller.
+post() {
+  curl -sS -m 5 -X POST "$FLEET_SERVER/api/v1/telemetry" \
+    -H 'content-type: application/json' -d "$1" 2>/dev/null || true
+}
+
+AGENT_ID="$(cat "$AGENT_ID_FILE" 2>/dev/null || true)"
+
+# Hello + heartbeat in one post. Counters are DELTAS since the last post.
+body=$(cat <<JSON
+{
+  $( [ -n "$AGENT_ID" ] && printf '"agentId": "%s",' "$AGENT_ID" )
+  "handle": "$HANDLE",
+  "harness": "$HARNESS",
+  "model": "$MODEL",
+  "task": { "kind": "work", "ref": "${TASK_REF:-}", "title": "${TASK_TITLE:-}" },
+  "heartbeat": {
+    "tokensIn": ${TOKENS_IN:-0},
+    "tokensOut": ${TOKENS_OUT:-0},
+    "toolCalls": ${TOOL_CALLS:-0}
+  }
+}
+JSON
+)
+
+resp="$(post "$body")"
+# Persist the agentId the server issued so subsequent posts reuse the session.
+id="$(printf '%s' "$resp" | sed -n 's/.*"agentId":"\([^"]*\)".*/\1/p')"
+[ -n "$id" ] && printf '%s' "$id" > "$AGENT_ID_FILE"
+echo "fleet server: ${resp:-unreachable (continuing without telemetry)}"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,1679 @@
+{
+  "name": "forgood-fleet-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "forgood-fleet-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@fastify/cors": "^11.0.1",
+        "@fastify/websocket": "^11.0.2",
+        "fastify": "^5.2.1",
+        "geoip-lite": "^1.4.10",
+        "zod": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/geoip-lite": "^1.4.4",
+        "@types/node": "^22.10.0",
+        "@types/ws": "^8.5.13",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/cors": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
+      "integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/websocket": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-11.2.0.tgz",
+      "integrity": "sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.3",
+        "fastify-plugin": "^5.0.0",
+        "ws": "^8.16.0"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geoip-lite": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/geoip-lite/-/geoip-lite-1.4.4.tgz",
+      "integrity": "sha512-2uVfn+C6bX/H356H6mjxsWUA5u8LO8dJgSBIRO/NFlpMe4DESzacutD/rKYrTDKm1Ugv78b4Wz1KvpHrlv3jSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
+      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
+      "integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.9.0.tgz",
+      "integrity": "sha512-VMS5lE0zj+MZlJpQa3Qv5iGjfun0H2N7VRgoBwpcTNQ2bdIQpv7fDpb+HGteGbicBsGkzGS+X+hdx9mmrfWuHQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.6.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/geoip-lite": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.4.10.tgz",
+      "integrity": "sha512-4N69uhpS3KFd97m00wiFEefwa+L+HT5xZbzPhwu+sDawStg6UN/dPwWtUfkQuZkGIY1Cj7wDVp80IsqNtGMi2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "2.1 - 2.6.4",
+        "chalk": "4.1 - 4.1.2",
+        "iconv-lite": "0.4.13 - 0.6.3",
+        "ip-address": "5.8.9 - 5.9.4",
+        "lazy": "1.0.11",
+        "rimraf": "2.5.2 - 2.7.1",
+        "yauzl": "2.9.2 - 2.10.0"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "lodash": "^4.17.15",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "simulate": "node scripts/simulate.mjs",
+    "test": "node --test \"test/*.test.mjs\"",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "forgood-fleet-server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Coordination + telemetry server for the For Good worker fleet — live presence, TPS gauge, watcher presence (#398, Phase 1)",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "simulate": "node scripts/simulate.mjs",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.0.1",
+    "@fastify/websocket": "^11.0.2",
+    "fastify": "^5.2.1",
+    "geoip-lite": "^1.4.10",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/geoip-lite": "^1.4.4",
+    "@types/node": "^22.10.0",
+    "@types/ws": "^8.5.13",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "description": "Coordination + telemetry server for the For Good worker fleet — live presence, TPS gauge, watcher presence (#398, Phase 1)",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/server/scripts/simulate.mjs
+++ b/server/scripts/simulate.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Fleet simulator — connects fake agents over the real WS protocol so you can
+ * develop the dashboard (and demo the server) without live workers.
+ *
+ *   node scripts/simulate.mjs                # 5 agents against localhost
+ *   AGENTS=12 SERVER=ws://host:8787 node scripts/simulate.mjs
+ *
+ * Uses Node's built-in WebSocket client (Node >= 21) — no dependencies.
+ */
+const SERVER = process.env.SERVER ?? "ws://127.0.0.1:8787";
+const AGENT_COUNT = Number(process.env.AGENTS ?? 5);
+
+const HANDLES = ["adam91holt", "gligorkot", "thecolab-clawd", "kea-worker", "tui-worker", "ruru-worker", "moa-worker", "weka-worker", "kaka-worker", "kiwi-worker", "takahe-worker", "hihi-worker"];
+const HARNESSES = ["claude", "codex", "hermes"];
+const MODELS = {
+  claude: ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5"],
+  codex: ["gpt-5.3-codex", "o5-mini"],
+  hermes: ["hermes-4-405b"],
+};
+const TASKS = [
+  { kind: "work", ref: "#231", title: "School attendance interventions — what works in NZ" },
+  { kind: "work", ref: "#312", title: "Foodbank demand vs supply data, 2020-2025" },
+  { kind: "review", ref: "#405", title: "review: rental WOF pilot outcomes" },
+  { kind: "work", ref: "#287", title: "Kea population trend synthesis" },
+  { kind: "review", ref: "#399", title: "review: civic-transparency LGOIMA response times" },
+  { kind: "frame", ref: "#410", title: "framing: youth mental health waitlists" },
+  { kind: "work", ref: "#356", title: "Predator Free 2050 progress audit" },
+  { kind: "synth", ref: "#120", title: "stream synthesis: housing quality" },
+];
+const TOOLS = ["bash", "edit", "read", "webfetch", "gh", "grep"];
+const SKILLS = ["child-poverty-nz", "deprivation-nz", "data-govt-nz", "geonet-nz", "lawa-nz"];
+
+const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+function startAgent(i) {
+  const handle = HANDLES[i % HANDLES.length];
+  const harness = pick(HARNESSES);
+  const model = pick(MODELS[harness]);
+  const ws = new WebSocket(`${SERVER}/ws/agent`);
+  let timer;
+
+  ws.addEventListener("open", () => {
+    ws.send(JSON.stringify({ type: "hello", handle, harness, model, task: pick(TASKS), version: "sim-0.1" }));
+    console.log(`[sim] ${handle} online (${harness} · ${model})`);
+    timer = setInterval(() => {
+      // A plausible working rhythm: bursts of tokens, occasional milestones.
+      const busy = Math.random() > 0.25;
+      const hb = {
+        type: "heartbeat",
+        tokensIn: busy ? Math.floor(Math.random() * 4000) : 0,
+        tokensOut: busy ? Math.floor(Math.random() * 1500) : 0,
+        toolCalls: busy ? Math.floor(Math.random() * 6) : 0,
+        tools: busy ? { [pick(TOOLS)]: 1 + Math.floor(Math.random() * 3) } : {},
+        fetchesOk: Math.random() > 0.6 ? 1 : 0,
+        fetchesError: Math.random() > 0.93 ? 1 : 0,
+        skills: Math.random() > 0.85 ? { [pick(SKILLS)]: 1 } : {},
+        errors: Math.random() > 0.97 ? 1 : 0,
+        prsOpened: Math.random() > 0.985 ? 1 : 0,
+        reviewsCompleted: Math.random() > 0.985 ? 1 : 0,
+        tasksCompleted: Math.random() > 0.99 ? 1 : 0,
+      };
+      if (Math.random() > 0.97) hb.task = pick(TASKS);
+      ws.send(JSON.stringify(hb));
+    }, 3000 + Math.random() * 3000);
+  });
+
+  ws.addEventListener("close", () => {
+    clearInterval(timer);
+    console.log(`[sim] ${handle} disconnected — reconnecting in 5s`);
+    setTimeout(() => startAgent(i), 5000);
+  });
+  ws.addEventListener("error", () => ws.close());
+}
+
+console.log(`[sim] starting ${AGENT_COUNT} fake agents against ${SERVER}`);
+for (let i = 0; i < AGENT_COUNT; i++) setTimeout(() => startAgent(i), i * 800);

--- a/server/scripts/simulate.mjs
+++ b/server/scripts/simulate.mjs
@@ -6,8 +6,15 @@
  *   node scripts/simulate.mjs                # 5 agents against localhost
  *   AGENTS=12 SERVER=ws://host:8787 node scripts/simulate.mjs
  *
- * Uses Node's built-in WebSocket client (Node >= 21) — no dependencies.
+ * Uses Node's built-in WebSocket client (Node >= 22, matching this package's
+ * engines floor) — no dependencies.
  */
+if (typeof WebSocket === "undefined") {
+  console.error("simulate.mjs needs the global WebSocket client (Node >= 21; this package requires Node >= 22).");
+  console.error(`You are running Node ${process.version} — upgrade, or use Docker: docker compose up`);
+  process.exit(1);
+}
+
 const SERVER = process.env.SERVER ?? "ws://127.0.0.1:8787";
 const AGENT_COUNT = Number(process.env.AGENTS ?? 5);
 

--- a/server/src/agent-ws.ts
+++ b/server/src/agent-ws.ts
@@ -1,0 +1,118 @@
+/**
+ * /ws/agent — the worker-facing socket. Protocol: the client sends `hello`
+ * within 10s of connecting, then `heartbeat` / `task` / `log` messages.
+ * Identity is assumed-trust for now (auth is parked per the decision on #398);
+ * the transport is designed so a challenge step can slot in after `hello`.
+ */
+import type { FastifyInstance } from "fastify";
+import type { WebSocket } from "ws";
+import { config } from "./config.js";
+import { agentMessageSchema } from "./protocol.js";
+import { redactLines } from "./redact.js";
+import type { FleetStore } from "./state.js";
+
+const HELLO_TIMEOUT_MS = 10_000;
+const PING_INTERVAL_MS = 25_000;
+
+/** Cheap per-connection flood guard: allow a burst, refill per second. */
+class RateLimiter {
+  private allowance: number = config.maxMessagesPerSecond;
+  private last = Date.now();
+
+  allow(): boolean {
+    const now = Date.now();
+    this.allowance = Math.min(
+      config.maxMessagesPerSecond,
+      this.allowance + ((now - this.last) / 1000) * config.maxMessagesPerSecond,
+    );
+    this.last = now;
+    if (this.allowance < 1) return false;
+    this.allowance -= 1;
+    return true;
+  }
+}
+
+export function registerAgentSocket(app: FastifyInstance, store: FleetStore): void {
+  app.get("/ws/agent", { websocket: true }, (socket: WebSocket) => {
+    let agentId: string | null = null;
+    let alive = true;
+    const limiter = new RateLimiter();
+
+    const helloTimer = setTimeout(() => {
+      if (!agentId) socket.close(4000, "no hello");
+    }, HELLO_TIMEOUT_MS);
+
+    const pinger = setInterval(() => {
+      if (!alive) {
+        socket.terminate();
+        return;
+      }
+      alive = false;
+      socket.ping();
+    }, PING_INTERVAL_MS);
+
+    socket.on("pong", () => {
+      alive = true;
+      if (agentId) store.touchAgent(agentId);
+    });
+
+    socket.on("message", (data, isBinary) => {
+      if (isBinary || !limiter.allow()) return;
+      const raw = data.toString();
+      if (raw.length > config.maxMessageBytes) return;
+
+      let msg;
+      try {
+        msg = agentMessageSchema.parse(JSON.parse(raw));
+      } catch {
+        socket.send(JSON.stringify({ type: "error", error: "invalid message" }));
+        return;
+      }
+      alive = true;
+
+      switch (msg.type) {
+        case "hello": {
+          agentId = store.upsertAgent(msg, "ws", agentId ?? undefined);
+          clearTimeout(helloTimer);
+          socket.send(JSON.stringify({ type: "welcome", agentId }));
+          break;
+        }
+        case "heartbeat": {
+          if (!agentId) return;
+          const { type: _type, ...hb } = msg;
+          store.applyHeartbeat(agentId, hb);
+          break;
+        }
+        case "task": {
+          if (agentId) store.updateTask(agentId, msg.task);
+          break;
+        }
+        case "log": {
+          if (!agentId) return;
+          if (!config.allowLogStream) {
+            socket.send(JSON.stringify({ type: "error", error: "log streaming disabled on this server" }));
+            return;
+          }
+          const rec = store.getAgent(agentId);
+          if (rec) store.appendLogs(agentId, rec.handle, redactLines(msg.lines));
+          store.touchAgent(agentId);
+          break;
+        }
+        case "bye": {
+          if (agentId) store.markAgentOffline(agentId, "disconnected");
+          agentId = null;
+          socket.close(1000, "bye");
+          break;
+        }
+      }
+    });
+
+    socket.on("close", () => {
+      clearTimeout(helloTimer);
+      clearInterval(pinger);
+      if (agentId) store.markAgentOffline(agentId, "disconnected");
+    });
+
+    socket.on("error", () => socket.terminate());
+  });
+}

--- a/server/src/agent-ws.ts
+++ b/server/src/agent-ws.ts
@@ -4,9 +4,10 @@
  * Identity is assumed-trust for now (auth is parked per the decision on #398);
  * the transport is designed so a challenge step can slot in after `hello`.
  */
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { WebSocket } from "ws";
 import { config } from "./config.js";
+import { originAllowed, RateLimiter } from "./guards.js";
 import { agentMessageSchema } from "./protocol.js";
 import { redactLines } from "./redact.js";
 import type { FleetStore } from "./state.js";
@@ -14,26 +15,12 @@ import type { FleetStore } from "./state.js";
 const HELLO_TIMEOUT_MS = 10_000;
 const PING_INTERVAL_MS = 25_000;
 
-/** Cheap per-connection flood guard: allow a burst, refill per second. */
-class RateLimiter {
-  private allowance: number = config.maxMessagesPerSecond;
-  private last = Date.now();
-
-  allow(): boolean {
-    const now = Date.now();
-    this.allowance = Math.min(
-      config.maxMessagesPerSecond,
-      this.allowance + ((now - this.last) / 1000) * config.maxMessagesPerSecond,
-    );
-    this.last = now;
-    if (this.allowance < 1) return false;
-    this.allowance -= 1;
-    return true;
-  }
-}
-
 export function registerAgentSocket(app: FastifyInstance, store: FleetStore): void {
-  app.get("/ws/agent", { websocket: true }, (socket: WebSocket) => {
+  app.get("/ws/agent", { websocket: true }, (socket: WebSocket, req: FastifyRequest) => {
+    if (!originAllowed(req)) {
+      socket.close(4403, "origin not allowed");
+      return;
+    }
     let agentId: string | null = null;
     let alive = true;
     const limiter = new RateLimiter();
@@ -72,7 +59,13 @@ export function registerAgentSocket(app: FastifyInstance, store: FleetStore): vo
 
       switch (msg.type) {
         case "hello": {
-          agentId = store.upsertAgent(msg, "ws", agentId ?? undefined);
+          const id = store.upsertAgent(msg, "ws", agentId ?? undefined);
+          if (!id) {
+            socket.send(JSON.stringify({ type: "error", error: "fleet full" }));
+            socket.close(1013, "fleet full");
+            return;
+          }
+          agentId = id;
           clearTimeout(helloTimer);
           socket.send(JSON.stringify({ type: "welcome", agentId }));
           break;

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,56 @@
+function num(v: string | undefined, fallback: number): number {
+  const n = v ? Number(v) : NaN;
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function bool(v: string | undefined, fallback: boolean): boolean {
+  if (v === undefined || v === "") return fallback;
+  return v === "1" || v.toLowerCase() === "true" || v.toLowerCase() === "yes";
+}
+
+export const config = {
+  port: num(process.env.PORT, 8787),
+  host: process.env.HOST ?? "0.0.0.0",
+
+  // Optional JSON snapshot for lifetime totals + the event feed, so a redeploy
+  // doesn't zero the public counters. Presence/TPS state is deliberately
+  // ephemeral — it rebuilds from heartbeats within seconds. Unset = no
+  // persistence at all.
+  stateFile: process.env.STATE_FILE || undefined,
+  stateSaveSeconds: num(process.env.STATE_SAVE_SECONDS, 30),
+
+  // Comma-separated list of allowed origins, or "*" (default) for any.
+  corsOrigin: process.env.CORS_ORIGIN ?? "*",
+
+  // Behind a reverse proxy / load balancer, trust X-Forwarded-For so watcher
+  // geo works on the real client IP rather than the proxy's.
+  trustProxy: bool(process.env.TRUST_PROXY, true),
+
+  // Rough watcher geolocation (city/country from IP, IP discarded immediately).
+  watcherGeo: bool(process.env.WATCHER_GEO, true),
+
+  // Session-log streaming is opt-in at BOTH ends (issue #398): the worker must
+  // opt in with STREAM_LOGS=1, and the server must allow it here. Even then,
+  // logs only reach the public dashboard if broadcastLogs is ALSO on.
+  allowLogStream: bool(process.env.ALLOW_LOG_STREAM, false),
+  broadcastLogs: bool(process.env.BROADCAST_LOGS, false),
+
+  // An agent missing heartbeats for this long is considered offline.
+  agentTtlSeconds: num(process.env.AGENT_TTL_SECONDS, 90),
+  watcherTtlSeconds: num(process.env.WATCHER_TTL_SECONDS, 75),
+
+  // TPS is computed over a sliding window of small buckets.
+  tpsWindowSeconds: 60,
+  tpsBucketSeconds: 10,
+
+  maxEventFeed: num(process.env.MAX_EVENT_FEED, 200),
+
+  // Per-connection inbound limits — telemetry is small; anything bigger is a bug
+  // or abuse.
+  maxMessageBytes: 64 * 1024,
+  maxMessagesPerSecond: 20,
+
+  // Streamed logs: keep at most this many recent lines per agent, short-lived.
+  logLinesPerAgent: 500,
+  logTtlSeconds: 3600,
+} as const;

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -46,11 +46,16 @@ export const config = {
   maxEventFeed: num(process.env.MAX_EVENT_FEED, 200),
 
   // Per-connection inbound limits — telemetry is small; anything bigger is a bug
-  // or abuse.
+  // or abuse. The same per-second budget applies per-IP on the HTTP routes.
   maxMessageBytes: 64 * 1024,
   maxMessagesPerSecond: 20,
 
-  // Streamed logs: keep at most this many recent lines per agent, short-lived.
-  logLinesPerAgent: 500,
-  logTtlSeconds: 3600,
+  // Hard ceiling on tracked agents — presence is unauthenticated until the
+  // parked auth lands, so cap what a flood of hellos can allocate.
+  maxAgents: num(process.env.MAX_AGENTS, 500),
+
+  // Coalesce agent-presence broadcasts: heartbeats mark the list dirty and a
+  // flush follows within this window, instead of one whole-fleet frame per
+  // heartbeat (per-tool-call hooks make those very frequent).
+  agentsFlushMs: 750,
 } as const;

--- a/server/src/geo.ts
+++ b/server/src/geo.ts
@@ -27,7 +27,6 @@ export function roughLocate(ip: string | undefined): RoughLocation | null {
   const [lat, lon] = hit.ll ?? [];
   return {
     city: hit.city || undefined,
-    region: hit.region || undefined,
     country: hit.country || undefined,
     lat: typeof lat === "number" ? rough(lat) : undefined,
     lon: typeof lon === "number" ? rough(lon) : undefined,

--- a/server/src/geo.ts
+++ b/server/src/geo.ts
@@ -1,0 +1,41 @@
+/**
+ * Rough watcher geolocation. The contract (#398 + maintainer ask): we may use
+ * a watcher's IP to derive an approximate location for the dashboard, but the
+ * IP itself is never stored, never logged, and never sent to any client or
+ * third party. geoip-lite resolves entirely offline from a bundled MaxMind
+ * GeoLite2 snapshot, so the IP never leaves this process.
+ */
+import geoip from "geoip-lite";
+import type { RoughLocation } from "./protocol.js";
+
+/** Round to ~0.1 degree (≈11 km) so the location can't identify a household. */
+function rough(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+export function roughLocate(ip: string | undefined): RoughLocation | null {
+  if (!ip) return null;
+  // Normalise IPv4-mapped IPv6 addresses ("::ffff:1.2.3.4").
+  const clean = ip.startsWith("::ffff:") ? ip.slice(7) : ip;
+  let hit: ReturnType<typeof geoip.lookup>;
+  try {
+    hit = geoip.lookup(clean);
+  } catch {
+    return null;
+  }
+  if (!hit) return null;
+  const [lat, lon] = hit.ll ?? [];
+  return {
+    city: hit.city || undefined,
+    region: hit.region || undefined,
+    country: hit.country || undefined,
+    lat: typeof lat === "number" ? rough(lat) : undefined,
+    lon: typeof lon === "number" ? rough(lon) : undefined,
+  };
+}
+
+export function describeLocation(loc: RoughLocation | null): string {
+  if (!loc) return "somewhere on Earth";
+  const parts = [loc.city, loc.country].filter(Boolean);
+  return parts.length ? parts.join(", ") : "somewhere on Earth";
+}

--- a/server/src/guards.ts
+++ b/server/src/guards.ts
@@ -1,0 +1,56 @@
+/**
+ * Abuse guards. Auth is parked (assumed trust, #398), so these are the cheap
+ * lines of defence: bound what any one connection/IP can send, and stop
+ * drive-by browser pages from opening sockets cross-origin.
+ */
+import type { FastifyRequest } from "fastify";
+import { config } from "./config.js";
+
+/** Token bucket: allow a burst of `perSecond`, refill continuously. */
+export class RateLimiter {
+  private allowance: number;
+  private last = Date.now();
+
+  constructor(private readonly perSecond: number = config.maxMessagesPerSecond) {
+    this.allowance = perSecond;
+  }
+
+  allow(): boolean {
+    const now = Date.now();
+    this.allowance = Math.min(this.perSecond, this.allowance + ((now - this.last) / 1000) * this.perSecond);
+    this.last = now;
+    if (this.allowance < 1) return false;
+    this.allowance -= 1;
+    return true;
+  }
+}
+
+/** Per-IP buckets for the HTTP routes (the WS routes get one per connection).
+ *  Bounded: the whole map resets if it ever grows suspiciously large — losing
+ *  rate state under attack is preferable to unbounded memory. */
+export class IpRateLimiter {
+  private readonly buckets = new Map<string, RateLimiter>();
+
+  allow(ip: string): boolean {
+    if (this.buckets.size > 10_000) this.buckets.clear();
+    let bucket = this.buckets.get(ip);
+    if (!bucket) {
+      bucket = new RateLimiter();
+      this.buckets.set(ip, bucket);
+    }
+    return bucket.allow();
+  }
+}
+
+/**
+ * WebSocket upgrades don't go through CORS, so enforce the same origin
+ * allowlist by hand. Non-browser clients (workers, curl) send no Origin
+ * header and are allowed — this guard is specifically against a malicious
+ * web page using a visitor's browser to inject spoofed presence.
+ */
+export function originAllowed(req: FastifyRequest): boolean {
+  if (config.corsOrigin === "*") return true;
+  const origin = req.headers.origin;
+  if (!origin) return true;
+  return config.corsOrigin.split(",").some((o) => o.trim() === origin);
+}

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -1,0 +1,45 @@
+/**
+ * REST surface — a polling fallback for the dashboard and a plain-curl path
+ * for bash workers (autopilot.sh) that don't want to hold a WebSocket open.
+ */
+import type { FastifyInstance } from "fastify";
+import { telemetryPostSchema } from "./protocol.js";
+import type { FleetStore } from "./state.js";
+
+export function registerHttpRoutes(app: FastifyInstance, store: FleetStore): void {
+  app.get("/healthz", async () => ({ ok: true, agents: store.listAgents().length }));
+
+  /** Full current state — same shape as the WS `snapshot` message body. */
+  app.get("/api/v1/state", async () => store.snapshot());
+
+  /** Just the fleet metrics, cheap to poll for embeds/badges. */
+  app.get("/api/v1/metrics", async () => store.fleetMetrics());
+
+  /**
+   * Curl-friendly worker telemetry: hello fields + optional heartbeat deltas
+   * in one POST. First post returns an `agentId`; include it on subsequent
+   * posts to keep the session stable. Presence expires by TTL if posts stop.
+   */
+  app.post("/api/v1/telemetry", async (req, reply) => {
+    const parsed = telemetryPostSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" });
+    }
+    const { agentId, heartbeat, ...hello } = parsed.data;
+    // Unknown/expired agentId (e.g. server restarted): fall through to a fresh
+    // session rather than erroring the worker.
+    const knownId = agentId && store.getAgent(agentId) ? agentId : undefined;
+    const id = store.upsertAgent({ type: "hello", ...hello }, "http", knownId);
+    if (heartbeat) store.applyHeartbeat(id, heartbeat);
+    return { ok: true, agentId: id };
+  });
+
+  /** Clean sign-off for HTTP workers (optional — TTL handles the rest). */
+  app.post<{ Body: { agentId?: string } }>("/api/v1/goodbye", async (req) => {
+    const agentId = req.body?.agentId;
+    if (typeof agentId === "string" && store.getAgent(agentId)) {
+      store.markAgentOffline(agentId, "disconnected");
+    }
+    return { ok: true };
+  });
+}

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -4,11 +4,16 @@
  */
 import type { FastifyInstance } from "fastify";
 import { config } from "./config.js";
+import { IpRateLimiter } from "./guards.js";
 import { logPostSchema, telemetryPostSchema } from "./protocol.js";
 import { redactLines } from "./redact.js";
 import type { FleetStore } from "./state.js";
 
 export function registerHttpRoutes(app: FastifyInstance, store: FleetStore): void {
+  // The WS routes get a per-connection limiter; the plain-HTTP ingestion
+  // routes need the same budget per source IP or they're a free flood path.
+  const limiter = new IpRateLimiter();
+  const rateLimited = (ip: string) => !limiter.allow(ip);
   app.get("/healthz", async () => ({ ok: true, agents: store.listAgents().length }));
 
   /** Full current state — same shape as the WS `snapshot` message body. */
@@ -23,6 +28,7 @@ export function registerHttpRoutes(app: FastifyInstance, store: FleetStore): voi
    * posts to keep the session stable. Presence expires by TTL if posts stop.
    */
   app.post("/api/v1/telemetry", async (req, reply) => {
+    if (rateLimited(req.ip)) return reply.code(429).send({ ok: false, error: "slow down" });
     const parsed = telemetryPostSchema.safeParse(req.body);
     if (!parsed.success) {
       return reply.code(400).send({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" });
@@ -32,6 +38,7 @@ export function registerHttpRoutes(app: FastifyInstance, store: FleetStore): voi
     // session rather than erroring the worker.
     const knownId = agentId && store.getAgent(agentId) ? agentId : undefined;
     const id = store.upsertAgent({ type: "hello", ...hello }, "http", knownId);
+    if (!id) return reply.code(503).send({ ok: false, error: "fleet full" });
     if (heartbeat) store.applyHeartbeat(id, heartbeat);
     return { ok: true, agentId: id };
   });
@@ -43,6 +50,7 @@ export function registerHttpRoutes(app: FastifyInstance, store: FleetStore): voi
    * have opted in, and lines are redacted AGAIN here as defence in depth.
    */
   app.post("/api/v1/logs", async (req, reply) => {
+    if (rateLimited(req.ip)) return reply.code(429).send({ ok: false, error: "slow down" });
     if (!config.allowLogStream) {
       return reply.code(403).send({ ok: false, error: "log streaming disabled on this server" });
     }

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -3,7 +3,9 @@
  * for bash workers (autopilot.sh) that don't want to hold a WebSocket open.
  */
 import type { FastifyInstance } from "fastify";
-import { telemetryPostSchema } from "./protocol.js";
+import { config } from "./config.js";
+import { logPostSchema, telemetryPostSchema } from "./protocol.js";
+import { redactLines } from "./redact.js";
 import type { FleetStore } from "./state.js";
 
 export function registerHttpRoutes(app: FastifyInstance, store: FleetStore): void {
@@ -32,6 +34,27 @@ export function registerHttpRoutes(app: FastifyInstance, store: FleetStore): voi
     const id = store.upsertAgent({ type: "hello", ...hello }, "http", knownId);
     if (heartbeat) store.applyHeartbeat(id, heartbeat);
     return { ok: true, agentId: id };
+  });
+
+  /**
+   * Opt-in session-log ingestion for hook-based workers (Claude Code hooks,
+   * Codex notify) — one-shot processes that can't hold a WebSocket. Same
+   * gates as the WS `log` message: the server must allow it, the worker must
+   * have opted in, and lines are redacted AGAIN here as defence in depth.
+   */
+  app.post("/api/v1/logs", async (req, reply) => {
+    if (!config.allowLogStream) {
+      return reply.code(403).send({ ok: false, error: "log streaming disabled on this server" });
+    }
+    const parsed = logPostSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" });
+    }
+    const rec = store.getAgent(parsed.data.agentId);
+    if (!rec) return reply.code(404).send({ ok: false, error: "unknown agentId" });
+    store.appendLogs(rec.id, rec.handle, redactLines(parsed.data.lines));
+    store.touchAgent(rec.id);
+    return { ok: true };
   });
 
   /** Clean sign-off for HTTP workers (optional — TTL handles the rest). */

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,67 @@
+/**
+ * For Good fleet server — coordination + telemetry for the worker fleet
+ * (issue #398, Phase 1: telemetry in, presence, TPS, watcher presence).
+ *
+ * Deliberately an OPTIONAL accelerator: GitHub stays the source of truth and
+ * autopilot degrades gracefully to the pull model when this server is absent.
+ */
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import websocket from "@fastify/websocket";
+import { config } from "./config.js";
+import { registerAgentSocket } from "./agent-ws.js";
+import { registerWatchSocket } from "./watch-ws.js";
+import { registerHttpRoutes } from "./http.js";
+import { FleetStore } from "./state.js";
+
+const SWEEP_INTERVAL_MS = 10_000;
+
+async function main(): Promise<void> {
+  const store = new FleetStore(config.stateFile);
+
+  const app = Fastify({
+    logger: { level: process.env.LOG_LEVEL ?? "info" },
+    trustProxy: config.trustProxy,
+    bodyLimit: config.maxMessageBytes,
+  });
+
+  await app.register(cors, {
+    origin: config.corsOrigin === "*" ? true : config.corsOrigin.split(",").map((s) => s.trim()),
+  });
+  await app.register(websocket, {
+    options: { maxPayload: config.maxMessageBytes },
+  });
+
+  registerHttpRoutes(app, store);
+  registerAgentSocket(app, store);
+  registerWatchSocket(app, store);
+
+  const sweeper = setInterval(() => {
+    store.sweepAgents();
+    store.sweepWatchers();
+  }, SWEEP_INTERVAL_MS);
+
+  const saver = config.stateFile ? setInterval(() => store.save(), config.stateSaveSeconds * 1000) : null;
+
+  const shutdown = async (signal: string) => {
+    app.log.info({ signal }, "shutting down");
+    clearInterval(sweeper);
+    if (saver) clearInterval(saver);
+    store.save();
+    await app.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+
+  await app.listen({ port: config.port, host: config.host });
+  app.log.info(
+    { logStream: config.allowLogStream, broadcastLogs: config.broadcastLogs, watcherGeo: config.watcherGeo },
+    "fleet server up",
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,7 +20,17 @@ async function main(): Promise<void> {
   const store = new FleetStore(config.stateFile);
 
   const app = Fastify({
-    logger: { level: process.env.LOG_LEVEL ?? "info" },
+    // The privacy contract says client IPs are NEVER logged — Fastify's
+    // default request serializer would emit remoteAddress (the real viewer IP
+    // once trustProxy resolves X-Forwarded-For), so scrub request logs down
+    // to method + url and log nothing per-response.
+    logger: {
+      level: process.env.LOG_LEVEL ?? "info",
+      serializers: {
+        req: (req) => ({ method: req.method, url: req.url }),
+      },
+    },
+    disableRequestLogging: true,
     trustProxy: config.trustProxy,
     bodyLimit: config.maxMessageBytes,
   });

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -145,7 +145,6 @@ export interface AgentPresence {
 
 export interface RoughLocation {
   city?: string;
-  region?: string;
   country?: string;
   /** Rounded to ~0.1 degree (≈11 km) — deliberately imprecise. */
   lat?: number;

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -91,6 +91,13 @@ export const agentMessageSchema = z.discriminatedUnion("type", [
 ]);
 export type AgentMessage = z.infer<typeof agentMessageSchema>;
 
+/** HTTP log ingestion for hook-based workers (one-shot processes that can't
+ *  hold a WebSocket). Same opt-in gates as the WS `log` message. */
+export const logPostSchema = z.object({
+  agentId: z.string().uuid(),
+  lines: z.array(z.string().max(2000)).min(1).max(50),
+});
+
 /** HTTP fallback body for curl-based workers: hello fields + optional
  *  heartbeat fields in one POST. `agentId` keeps the session stable across
  *  posts — the server issues one on the first post if omitted. */

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -1,0 +1,201 @@
+/**
+ * Wire protocol for the fleet server (#398, Phase 1 — telemetry + presence).
+ *
+ * Two kinds of client:
+ *  - AGENTS (autopilot workers) connect to /ws/agent — or POST to
+ *    /api/v1/telemetry from plain bash — and stream heartbeats: counts and
+ *    rates, never content (except the opt-in, redacted log stream).
+ *  - WATCHERS (dashboard viewers) connect to /ws/watch and receive a snapshot
+ *    followed by live updates. Watchers are presence too: we take a rough
+ *    city-level location from their IP, then discard the IP. The IP is never
+ *    stored and never sent to anyone.
+ *
+ * The web dashboard keeps a mirror of the server->watcher types in
+ * web/src/lib/live.ts — update both together.
+ */
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Shared shapes
+
+export const HARNESSES = ["claude", "codex", "hermes"] as const;
+
+export const taskInfoSchema = z.object({
+  kind: z.enum(["work", "review", "frame", "synth", "idle"]).default("work"),
+  /** Issue/PR reference like "#123" — public data only. */
+  ref: z.string().max(32).optional(),
+  title: z.string().max(300).optional(),
+});
+export type TaskInfo = z.infer<typeof taskInfoSchema>;
+
+const count = z.number().int().min(0).max(1_000_000_000);
+const countMap = z.record(z.string().max(64), count);
+
+// ---------------------------------------------------------------------------
+// Agent -> server messages
+
+export const helloSchema = z.object({
+  type: z.literal("hello"),
+  /** Public GitHub handle. Identity is assumed-trust for now (auth parked). */
+  handle: z.string().min(1).max(64),
+  harness: z.string().min(1).max(32),
+  model: z.string().min(1).max(128),
+  task: taskInfoSchema.optional(),
+  version: z.string().max(64).optional(),
+});
+export type Hello = z.infer<typeof helloSchema>;
+
+/**
+ * All counters are DELTAS since the previous heartbeat, so workers don't have
+ * to track what the server has seen. Counts and rates only — no content.
+ */
+export const heartbeatSchema = z.object({
+  type: z.literal("heartbeat"),
+  task: taskInfoSchema.optional(),
+  tokensIn: count.optional(),
+  tokensOut: count.optional(),
+  toolCalls: count.optional(),
+  /** Per-tool call counts, e.g. { bash: 3, edit: 1, webfetch: 2 }. */
+  tools: countMap.optional(),
+  fetchesOk: count.optional(),
+  fetchesError: count.optional(),
+  /** Per-skill invocation counts (Colab skills). */
+  skills: countMap.optional(),
+  errors: count.optional(),
+  tasksCompleted: count.optional(),
+  prsOpened: count.optional(),
+  reviewsCompleted: count.optional(),
+});
+export type Heartbeat = z.infer<typeof heartbeatSchema>;
+
+export const taskUpdateSchema = z.object({
+  type: z.literal("task"),
+  task: taskInfoSchema,
+});
+
+/** Opt-in only (STREAM_LOGS=1 worker-side AND ALLOW_LOG_STREAM=1 server-side).
+ *  Redacted before send; the server redacts AGAIN as defence in depth. */
+export const logSchema = z.object({
+  type: z.literal("log"),
+  lines: z.array(z.string().max(2000)).max(50),
+});
+
+export const byeSchema = z.object({ type: z.literal("bye") });
+
+export const agentMessageSchema = z.discriminatedUnion("type", [
+  helloSchema,
+  heartbeatSchema,
+  taskUpdateSchema,
+  logSchema,
+  byeSchema,
+]);
+export type AgentMessage = z.infer<typeof agentMessageSchema>;
+
+/** HTTP fallback body for curl-based workers: hello fields + optional
+ *  heartbeat fields in one POST. `agentId` keeps the session stable across
+ *  posts — the server issues one on the first post if omitted. */
+export const telemetryPostSchema = z.object({
+  agentId: z.string().uuid().optional(),
+  handle: z.string().min(1).max(64),
+  harness: z.string().min(1).max(32),
+  model: z.string().min(1).max(128),
+  version: z.string().max(64).optional(),
+  task: taskInfoSchema.optional(),
+  heartbeat: heartbeatSchema.omit({ type: true }).optional(),
+});
+export type TelemetryPost = z.infer<typeof telemetryPostSchema>;
+
+// ---------------------------------------------------------------------------
+// Server-side state shapes (broadcast to watchers)
+
+export interface SessionCounters {
+  tokensIn: number;
+  tokensOut: number;
+  toolCalls: number;
+  tools: Record<string, number>;
+  fetchesOk: number;
+  fetchesError: number;
+  skills: Record<string, number>;
+  errors: number;
+  tasksCompleted: number;
+  prsOpened: number;
+  reviewsCompleted: number;
+}
+
+export interface AgentPresence {
+  id: string;
+  handle: string;
+  harness: string;
+  model: string;
+  transport: "ws" | "http";
+  connectedAt: string;
+  lastSeen: string;
+  task: TaskInfo | null;
+  session: SessionCounters;
+  /** Current tokens/sec for this agent over the sliding window. */
+  tps: number;
+}
+
+export interface RoughLocation {
+  city?: string;
+  region?: string;
+  country?: string;
+  /** Rounded to ~0.1 degree (≈11 km) — deliberately imprecise. */
+  lat?: number;
+  lon?: number;
+}
+
+export interface WatcherSummary {
+  count: number;
+  locations: Array<RoughLocation & { id: string; connectedAt: string }>;
+}
+
+export interface FleetMetrics {
+  /** Fleet-wide tokens/sec over the sliding window. */
+  tps: number;
+  tpsByModel: Record<string, number>;
+  tpsByHarness: Record<string, number>;
+  activeAgents: number;
+  watcherCount: number;
+  totals: SessionCounters;
+  serverTime: string;
+}
+
+export type EventKind =
+  | "agent_online"
+  | "agent_offline"
+  | "task_started"
+  | "pr_opened"
+  | "review_done"
+  | "task_done"
+  | "watcher_joined";
+
+export interface EventItem {
+  id: string;
+  at: string;
+  kind: EventKind;
+  /** Human-readable one-liner, safe for public display. */
+  text: string;
+  handle?: string;
+  harness?: string;
+  ref?: string;
+}
+
+export interface FleetSnapshot {
+  agents: AgentPresence[];
+  watchers: WatcherSummary;
+  fleet: FleetMetrics;
+  events: EventItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Server -> watcher messages
+
+export type ServerMessage =
+  | { type: "snapshot"; state: FleetSnapshot }
+  | { type: "agents"; agents: AgentPresence[] }
+  | { type: "fleet"; fleet: FleetMetrics }
+  | { type: "watchers"; watchers: WatcherSummary }
+  | { type: "event"; event: EventItem }
+  | { type: "log"; agentId: string; handle: string; lines: string[] }
+  | { type: "pong" };

--- a/server/src/redact.ts
+++ b/server/src/redact.ts
@@ -1,45 +1,17 @@
 /**
- * Best-effort secret scrubbing for the opt-in log stream (#398). Workers are
- * expected to redact before sending; this runs AGAIN server-side as defence in
- * depth. Redaction is harm-reduction, not a guarantee — the real protection is
- * that log streaming is default-off at both ends.
+ * Server-side secret scrubbing for the opt-in log stream (#398). The actual
+ * pattern library lives in ../clients/redact-patterns.mjs — ONE source shared
+ * with the harness hook clients, so client- and server-side redaction can
+ * never drift apart. This runs as the second pass (defence in depth); workers
+ * redact before sending. Harm-reduction, not a guarantee — the real
+ * protection is that log streaming is default-off at both ends.
  */
-
-const REDACTED = "[redacted]";
-
-const PATTERNS: RegExp[] = [
-  // GitHub tokens: ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained PATs.
-  /\bgh[pousr]_[A-Za-z0-9_]{16,}\b/g,
-  /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
-  // Anthropic / OpenAI-style API keys.
-  /\bsk-[A-Za-z0-9_-]{16,}\b/g,
-  // AWS access key ids and secret-looking pairs.
-  /\bAKIA[0-9A-Z]{16}\b/g,
-  /\baws_secret_access_key\s*[=:]\s*\S+/gi,
-  // Slack tokens.
-  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
-  // JWTs (three base64url segments).
-  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\b/g,
-  // Authorization headers.
-  /\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi,
-  // Private key blocks.
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/g,
-  // .env / JSON / YAML-style assignments where the name looks secret-bearing.
-  // The value alternation must catch quoted values too — `PASSWORD="x y"` and
-  // `"password": "hunter2"` are the most common secret shapes in transcripts.
-  /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY)[A-Z0-9_]*"?\s*[=:]\s*("[^"]*"|'[^']*'|\S+)/gi,
-];
-
-// URL userinfo credentials ("postgres://user:s3cr3t@host") — keep the scheme
-// and user, scrub the password.
-const URL_CREDS = /\b([a-z][a-z0-9+.-]*:\/\/[^\s/:@]+):([^\s/@]+)@/gi;
+import { redactText } from "../clients/redact-patterns.mjs";
 
 export function redact(text: string): string {
-  let out = text.replace(URL_CREDS, `$1:${REDACTED}@`);
-  for (const re of PATTERNS) out = out.replace(re, REDACTED);
-  return out;
+  return redactText(text);
 }
 
 export function redactLines(lines: string[]): string[] {
-  return lines.map(redact);
+  return lines.map(redactText);
 }

--- a/server/src/redact.ts
+++ b/server/src/redact.ts
@@ -1,0 +1,39 @@
+/**
+ * Best-effort secret scrubbing for the opt-in log stream (#398). Workers are
+ * expected to redact before sending; this runs AGAIN server-side as defence in
+ * depth. Redaction is harm-reduction, not a guarantee — the real protection is
+ * that log streaming is default-off at both ends.
+ */
+
+const REDACTED = "[redacted]";
+
+const PATTERNS: RegExp[] = [
+  // GitHub tokens: ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained PATs.
+  /\bgh[pousr]_[A-Za-z0-9_]{16,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
+  // Anthropic / OpenAI-style API keys.
+  /\bsk-[A-Za-z0-9_-]{16,}\b/g,
+  // AWS access key ids and secret-looking pairs.
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\baws_secret_access_key\s*[=:]\s*\S+/gi,
+  // Slack tokens.
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
+  // JWTs (three base64url segments).
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}\b/g,
+  // Authorization headers.
+  /\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi,
+  // Private key blocks.
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/g,
+  // .env-style assignments where the name looks secret-bearing.
+  /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY)[A-Z0-9_]*\s*[=:]\s*[^\s"']+/gi,
+];
+
+export function redact(text: string): string {
+  let out = text;
+  for (const re of PATTERNS) out = out.replace(re, REDACTED);
+  return out;
+}
+
+export function redactLines(lines: string[]): string[] {
+  return lines.map(redact);
+}

--- a/server/src/redact.ts
+++ b/server/src/redact.ts
@@ -24,12 +24,18 @@ const PATTERNS: RegExp[] = [
   /\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{16,}/gi,
   // Private key blocks.
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/g,
-  // .env-style assignments where the name looks secret-bearing.
-  /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY)[A-Z0-9_]*\s*[=:]\s*[^\s"']+/gi,
+  // .env / JSON / YAML-style assignments where the name looks secret-bearing.
+  // The value alternation must catch quoted values too — `PASSWORD="x y"` and
+  // `"password": "hunter2"` are the most common secret shapes in transcripts.
+  /\b[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|API_?KEY|PRIVATE_?KEY)[A-Z0-9_]*"?\s*[=:]\s*("[^"]*"|'[^']*'|\S+)/gi,
 ];
 
+// URL userinfo credentials ("postgres://user:s3cr3t@host") — keep the scheme
+// and user, scrub the password.
+const URL_CREDS = /\b([a-z][a-z0-9+.-]*:\/\/[^\s/:@]+):([^\s/@]+)@/gi;
+
 export function redact(text: string): string {
-  let out = text;
+  let out = text.replace(URL_CREDS, `$1:${REDACTED}@`);
   for (const re of PATTERNS) out = out.replace(re, REDACTED);
   return out;
 }

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -1,0 +1,435 @@
+/**
+ * In-memory fleet state. GitHub remains the durable source of truth for work
+ * (issues/PRs/labels) — everything here is ephemeral telemetry: presence with
+ * TTLs, a sliding window of token buckets for the TPS gauge, and a capped
+ * event feed. Presence rebuilds itself from heartbeats within seconds of a
+ * restart, so a database would add ops weight for nothing (#398: "keep it
+ * small and stateless where possible — GitHub holds state").
+ *
+ * The only state worth keeping across restarts — lifetime totals and the
+ * event feed — is optionally snapshotted to STATE_FILE. If the fleet ever
+ * outgrows one server process, swap this class for a shared-store
+ * implementation behind the same interface; nothing else needs to change.
+ */
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { config } from "./config.js";
+import type {
+  AgentPresence,
+  EventItem,
+  EventKind,
+  FleetMetrics,
+  FleetSnapshot,
+  Heartbeat,
+  Hello,
+  RoughLocation,
+  ServerMessage,
+  SessionCounters,
+  TaskInfo,
+  WatcherSummary,
+} from "./protocol.js";
+
+function emptyCounters(): SessionCounters {
+  return {
+    tokensIn: 0,
+    tokensOut: 0,
+    toolCalls: 0,
+    tools: {},
+    fetchesOk: 0,
+    fetchesError: 0,
+    skills: {},
+    errors: 0,
+    tasksCompleted: 0,
+    prsOpened: 0,
+    reviewsCompleted: 0,
+  };
+}
+
+/** Stored agent record = broadcast presence + a rolling token trail used to
+ *  compute the agent's own tokens/sec, + the expiry deadline. */
+interface AgentRecord extends Omit<AgentPresence, "tps"> {
+  recent: Array<{ t: number; tokens: number }>;
+  expiresAt: number;
+}
+
+interface WatcherRecord {
+  id: string;
+  connectedAt: string;
+  location: RoughLocation | null;
+  expiresAt: number;
+}
+
+interface TpsBucket {
+  total: number;
+  byModel: Record<string, number>;
+  byHarness: Record<string, number>;
+}
+
+interface PersistedState {
+  totals: SessionCounters;
+  events: EventItem[];
+}
+
+function agentTps(rec: AgentRecord, now: number): number {
+  const windowMs = config.tpsWindowSeconds * 1000;
+  const tokens = rec.recent.reduce((s, p) => (now - p.t <= windowMs ? s + p.tokens : s), 0);
+  return Math.round((tokens / config.tpsWindowSeconds) * 10) / 10;
+}
+
+function toPresence(rec: AgentRecord, now: number): AgentPresence {
+  const { recent: _recent, expiresAt: _expiresAt, ...presence } = rec;
+  return { ...presence, tps: agentTps(rec, now) };
+}
+
+const rate = (n: number) => Math.round((n / config.tpsWindowSeconds) * 10) / 10;
+
+/** Emits "message" with a ServerMessage whenever watchers should hear about a
+ *  change — the watch hub subscribes and fans out to its sockets. */
+export class FleetStore extends EventEmitter {
+  private readonly agents = new Map<string, AgentRecord>();
+  private readonly watchers = new Map<string, WatcherRecord>();
+  /** bucket index (unix seconds / bucket size) -> token counts */
+  private readonly tpsBuckets = new Map<number, TpsBucket>();
+  private totals: SessionCounters = emptyCounters();
+  private events: EventItem[] = [];
+  /** Short-lived opt-in log tail per agent, pruned when the agent goes. */
+  private readonly logs = new Map<string, Array<{ at: number; line: string }>>();
+  private dirty = false;
+
+  constructor(private readonly stateFile?: string) {
+    super();
+    this.setMaxListeners(0);
+    if (stateFile) this.load(stateFile);
+  }
+
+  private publish(msg: ServerMessage): void {
+    this.emit("message", msg);
+  }
+
+  // -------------------------------------------------------------- agents
+
+  upsertAgent(hello: Hello, transport: "ws" | "http", id?: string): string {
+    const agentId = id ?? randomUUID();
+    const existing = this.agents.get(agentId);
+    const now = Date.now();
+    const nowIso = new Date(now).toISOString();
+    const rec: AgentRecord = existing ?? {
+      id: agentId,
+      handle: hello.handle,
+      harness: hello.harness,
+      model: hello.model,
+      transport,
+      connectedAt: nowIso,
+      lastSeen: nowIso,
+      task: hello.task ?? null,
+      session: emptyCounters(),
+      recent: [],
+      expiresAt: 0,
+    };
+    rec.handle = hello.handle;
+    rec.harness = hello.harness;
+    rec.model = hello.model;
+    rec.lastSeen = nowIso;
+    rec.expiresAt = now + config.agentTtlSeconds * 1000;
+    if (hello.task) rec.task = hello.task;
+    this.agents.set(agentId, rec);
+    if (!existing) {
+      this.addEvent("agent_online", `@${hello.handle} came online (${hello.harness} · ${hello.model})`, {
+        handle: hello.handle,
+        harness: hello.harness,
+      });
+      if (hello.task && (hello.task.ref || hello.task.title)) this.emitTaskEvent(rec, hello.task);
+    }
+    this.publishAgents();
+    return agentId;
+  }
+
+  getAgent(id: string): AgentRecord | undefined {
+    return this.agents.get(id);
+  }
+
+  applyHeartbeat(id: string, hb: Omit<Heartbeat, "type">): AgentRecord | null {
+    const rec = this.agents.get(id);
+    if (!rec) return null;
+    const now = Date.now();
+    rec.lastSeen = new Date(now).toISOString();
+    rec.expiresAt = now + config.agentTtlSeconds * 1000;
+
+    const s = rec.session;
+    s.tokensIn += hb.tokensIn ?? 0;
+    s.tokensOut += hb.tokensOut ?? 0;
+    s.toolCalls += hb.toolCalls ?? 0;
+    s.fetchesOk += hb.fetchesOk ?? 0;
+    s.fetchesError += hb.fetchesError ?? 0;
+    s.errors += hb.errors ?? 0;
+    s.tasksCompleted += hb.tasksCompleted ?? 0;
+    s.prsOpened += hb.prsOpened ?? 0;
+    s.reviewsCompleted += hb.reviewsCompleted ?? 0;
+    for (const [tool, n] of Object.entries(hb.tools ?? {})) s.tools[tool] = (s.tools[tool] ?? 0) + n;
+    for (const [skill, n] of Object.entries(hb.skills ?? {})) s.skills[skill] = (s.skills[skill] ?? 0) + n;
+
+    const tokens = (hb.tokensIn ?? 0) + (hb.tokensOut ?? 0);
+    const windowMs = config.tpsWindowSeconds * 1000;
+    rec.recent = rec.recent.filter((p) => now - p.t <= windowMs);
+    if (tokens > 0) rec.recent.push({ t: now, tokens });
+
+    if (hb.task) {
+      const changed = hb.task.ref !== rec.task?.ref || hb.task.kind !== rec.task?.kind;
+      rec.task = hb.task;
+      if (changed && (hb.task.ref || hb.task.title)) this.emitTaskEvent(rec, hb.task);
+    }
+
+    this.recordThroughput(rec, hb, tokens);
+    this.emitMilestones(rec, hb);
+    this.publishAgents();
+    return rec;
+  }
+
+  updateTask(id: string, task: TaskInfo): void {
+    const rec = this.agents.get(id);
+    if (!rec) return;
+    const changed = task.ref !== rec.task?.ref || task.kind !== rec.task?.kind;
+    rec.task = task;
+    rec.lastSeen = new Date().toISOString();
+    rec.expiresAt = Date.now() + config.agentTtlSeconds * 1000;
+    if (changed && (task.ref || task.title)) this.emitTaskEvent(rec, task);
+    this.publishAgents();
+  }
+
+  /** Any inbound traffic from a live socket counts as a sign of life. */
+  touchAgent(id: string): void {
+    const rec = this.agents.get(id);
+    if (rec) rec.expiresAt = Date.now() + config.agentTtlSeconds * 1000;
+  }
+
+  private emitTaskEvent(rec: AgentRecord, task: TaskInfo): void {
+    if (task.kind === "idle") return;
+    const verb =
+      task.kind === "review" ? "reviewing" : task.kind === "frame" ? "framing" : task.kind === "synth" ? "synthesising" : "working on";
+    const what = [task.ref, task.title].filter(Boolean).join(" — ");
+    this.addEvent("task_started", `@${rec.handle} started ${verb} ${what}`.trim(), {
+      handle: rec.handle,
+      harness: rec.harness,
+      ref: task.ref,
+    });
+  }
+
+  private emitMilestones(rec: AgentRecord, hb: Omit<Heartbeat, "type">): void {
+    const meta = { handle: rec.handle, harness: rec.harness, ref: rec.task?.ref };
+    if (hb.prsOpened) this.addEvent("pr_opened", `@${rec.handle} opened a PR${rec.task?.ref ? ` for ${rec.task.ref}` : ""}`, meta);
+    if (hb.reviewsCompleted) this.addEvent("review_done", `@${rec.handle} completed a review${rec.task?.ref ? ` on ${rec.task.ref}` : ""}`, meta);
+    if (hb.tasksCompleted) this.addEvent("task_done", `@${rec.handle} finished a task${rec.task?.ref ? ` (${rec.task.ref})` : ""}`, meta);
+  }
+
+  markAgentOffline(id: string, reason: "disconnected" | "timed out"): void {
+    const rec = this.agents.get(id);
+    if (!rec) return;
+    this.agents.delete(id);
+    this.logs.delete(id);
+    this.addEvent("agent_offline", `@${rec.handle} went offline (${reason})`, {
+      handle: rec.handle,
+      harness: rec.harness,
+    });
+    this.publishAgents();
+  }
+
+  /** Reap agents whose TTL expired (HTTP workers that stopped posting, or WS
+   *  drops we never saw). */
+  sweepAgents(): void {
+    const now = Date.now();
+    for (const [id, rec] of this.agents) {
+      if (rec.expiresAt < now) this.markAgentOffline(id, "timed out");
+    }
+  }
+
+  listAgents(): AgentPresence[] {
+    const now = Date.now();
+    return [...this.agents.values()]
+      .map((rec) => toPresence(rec, now))
+      .sort((a, b) => a.connectedAt.localeCompare(b.connectedAt));
+  }
+
+  private publishAgents(): void {
+    this.publish({ type: "agents", agents: this.listAgents() });
+  }
+
+  // ---------------------------------------------------------- throughput
+
+  private recordThroughput(rec: AgentRecord, hb: Omit<Heartbeat, "type">, tokens: number): void {
+    if (tokens > 0) {
+      const bucketId = Math.floor(Date.now() / 1000 / config.tpsBucketSeconds);
+      let bucket = this.tpsBuckets.get(bucketId);
+      if (!bucket) {
+        bucket = { total: 0, byModel: {}, byHarness: {} };
+        this.tpsBuckets.set(bucketId, bucket);
+      }
+      bucket.total += tokens;
+      bucket.byModel[rec.model] = (bucket.byModel[rec.model] ?? 0) + tokens;
+      bucket.byHarness[rec.harness] = (bucket.byHarness[rec.harness] ?? 0) + tokens;
+    }
+    const t = this.totals;
+    t.tokensIn += hb.tokensIn ?? 0;
+    t.tokensOut += hb.tokensOut ?? 0;
+    t.toolCalls += hb.toolCalls ?? 0;
+    t.fetchesOk += hb.fetchesOk ?? 0;
+    t.fetchesError += hb.fetchesError ?? 0;
+    t.errors += hb.errors ?? 0;
+    t.tasksCompleted += hb.tasksCompleted ?? 0;
+    t.prsOpened += hb.prsOpened ?? 0;
+    t.reviewsCompleted += hb.reviewsCompleted ?? 0;
+    for (const [tool, n] of Object.entries(hb.tools ?? {})) t.tools[tool] = (t.tools[tool] ?? 0) + n;
+    for (const [skill, n] of Object.entries(hb.skills ?? {})) t.skills[skill] = (t.skills[skill] ?? 0) + n;
+    this.dirty = true;
+  }
+
+  fleetMetrics(): FleetMetrics {
+    const currentBucket = Math.floor(Date.now() / 1000 / config.tpsBucketSeconds);
+    const bucketCount = Math.ceil(config.tpsWindowSeconds / config.tpsBucketSeconds);
+    let total = 0;
+    const byModel: Record<string, number> = {};
+    const byHarness: Record<string, number> = {};
+    for (let i = 0; i < bucketCount; i++) {
+      const bucket = this.tpsBuckets.get(currentBucket - i);
+      if (!bucket) continue;
+      total += bucket.total;
+      for (const [k, v] of Object.entries(bucket.byModel)) byModel[k] = (byModel[k] ?? 0) + v;
+      for (const [k, v] of Object.entries(bucket.byHarness)) byHarness[k] = (byHarness[k] ?? 0) + v;
+    }
+    // Prune buckets that have slid out of every window.
+    for (const id of this.tpsBuckets.keys()) {
+      if (id < currentBucket - bucketCount * 2) this.tpsBuckets.delete(id);
+    }
+    return {
+      tps: rate(total),
+      tpsByModel: Object.fromEntries(Object.entries(byModel).map(([k, v]) => [k, rate(v)])),
+      tpsByHarness: Object.fromEntries(Object.entries(byHarness).map(([k, v]) => [k, rate(v)])),
+      activeAgents: this.agents.size,
+      watcherCount: this.watchers.size,
+      totals: this.totals,
+      serverTime: new Date().toISOString(),
+    };
+  }
+
+  // ------------------------------------------------------------ watchers
+
+  addWatcher(location: RoughLocation | null): WatcherRecord {
+    const rec: WatcherRecord = {
+      id: randomUUID(),
+      connectedAt: new Date().toISOString(),
+      location,
+      expiresAt: Date.now() + config.watcherTtlSeconds * 1000,
+    };
+    this.watchers.set(rec.id, rec);
+    this.publishWatchers();
+    return rec;
+  }
+
+  touchWatcher(id: string): void {
+    const rec = this.watchers.get(id);
+    if (rec) rec.expiresAt = Date.now() + config.watcherTtlSeconds * 1000;
+  }
+
+  removeWatcher(id: string): void {
+    if (this.watchers.delete(id)) this.publishWatchers();
+  }
+
+  sweepWatchers(): void {
+    const now = Date.now();
+    let removed = false;
+    for (const [id, rec] of this.watchers) {
+      if (rec.expiresAt < now) {
+        this.watchers.delete(id);
+        removed = true;
+      }
+    }
+    if (removed) this.publishWatchers();
+  }
+
+  watcherSummary(): WatcherSummary {
+    // Only the rough location and a random id leave the server — never an IP,
+    // never anything derived from one beyond city/country/rounded coords.
+    const locations = [...this.watchers.values()]
+      .slice(0, 100)
+      .map((rec) => ({ id: rec.id, connectedAt: rec.connectedAt, ...(rec.location ?? {}) }));
+    return { count: this.watchers.size, locations };
+  }
+
+  private publishWatchers(): void {
+    this.publish({ type: "watchers", watchers: this.watcherSummary() });
+  }
+
+  // -------------------------------------------------------------- events
+
+  addEvent(kind: EventKind, text: string, meta: { handle?: string; harness?: string; ref?: string | undefined }): EventItem {
+    const event: EventItem = {
+      id: randomUUID(),
+      at: new Date().toISOString(),
+      kind,
+      text,
+      ...(meta.handle ? { handle: meta.handle } : {}),
+      ...(meta.harness ? { harness: meta.harness } : {}),
+      ...(meta.ref ? { ref: meta.ref } : {}),
+    };
+    this.events.unshift(event);
+    if (this.events.length > config.maxEventFeed) this.events.length = config.maxEventFeed;
+    this.dirty = true;
+    this.publish({ type: "event", event });
+    return event;
+  }
+
+  recentEvents(limit = 50): EventItem[] {
+    return this.events.slice(0, limit);
+  }
+
+  // ---------------------------------------------------------------- logs
+
+  appendLogs(agentId: string, handle: string, lines: string[]): void {
+    const now = Date.now();
+    const tail = this.logs.get(agentId) ?? [];
+    tail.unshift(...lines.map((line) => ({ at: now, line })));
+    if (tail.length > config.logLinesPerAgent) tail.length = config.logLinesPerAgent;
+    this.logs.set(agentId, tail);
+    if (config.broadcastLogs) this.publish({ type: "log", agentId, handle, lines });
+  }
+
+  // ------------------------------------------------------------ snapshot
+
+  snapshot(): FleetSnapshot {
+    return {
+      agents: this.listAgents(),
+      watchers: this.watcherSummary(),
+      fleet: this.fleetMetrics(),
+      events: this.recentEvents(),
+    };
+  }
+
+  // -------------------------------------------------- optional persistence
+
+  private load(file: string): void {
+    try {
+      const parsed = JSON.parse(readFileSync(file, "utf8")) as Partial<PersistedState>;
+      if (parsed.totals) this.totals = { ...emptyCounters(), ...parsed.totals };
+      if (Array.isArray(parsed.events)) this.events = parsed.events.slice(0, config.maxEventFeed);
+    } catch {
+      // First boot (no file yet) or corrupt snapshot — start fresh; this is
+      // vanity-counter state, never correctness state.
+    }
+  }
+
+  /** Persist lifetime totals + the event feed so a redeploy doesn't zero the
+   *  public counters. Called on an interval and on shutdown. */
+  save(): void {
+    if (!this.stateFile || !this.dirty) return;
+    try {
+      const state: PersistedState = { totals: this.totals, events: this.events };
+      const tmp = `${this.stateFile}.tmp`;
+      writeFileSync(tmp, JSON.stringify(state));
+      renameSync(tmp, this.stateFile);
+      this.dirty = false;
+    } catch (err) {
+      // Non-fatal: run without persistence rather than crash the fleet feed.
+      console.error("state save failed:", err);
+    }
+  }
+}

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -93,9 +93,8 @@ export class FleetStore extends EventEmitter {
   private readonly tpsBuckets = new Map<number, TpsBucket>();
   private totals: SessionCounters = emptyCounters();
   private events: EventItem[] = [];
-  /** Short-lived opt-in log tail per agent, pruned when the agent goes. */
-  private readonly logs = new Map<string, Array<{ at: number; line: string }>>();
   private dirty = false;
+  private agentsFlushTimer: NodeJS.Timeout | null = null;
 
   constructor(private readonly stateFile?: string) {
     super();
@@ -109,9 +108,13 @@ export class FleetStore extends EventEmitter {
 
   // -------------------------------------------------------------- agents
 
-  upsertAgent(hello: Hello, transport: "ws" | "http", id?: string): string {
+  /** Returns null when the fleet is at maxAgents and this would be a NEW
+   *  agent — presence is unauthenticated until auth lands, so allocation from
+   *  a flood of hellos has to be bounded. */
+  upsertAgent(hello: Hello, transport: "ws" | "http", id?: string): string | null {
     const agentId = id ?? randomUUID();
     const existing = this.agents.get(agentId);
+    if (!existing && this.agents.size >= config.maxAgents) return null;
     const now = Date.now();
     const nowIso = new Date(now).toISOString();
     const rec: AgentRecord = existing ?? {
@@ -226,7 +229,6 @@ export class FleetStore extends EventEmitter {
     const rec = this.agents.get(id);
     if (!rec) return;
     this.agents.delete(id);
-    this.logs.delete(id);
     this.addEvent("agent_offline", `@${rec.handle} went offline (${reason})`, {
       handle: rec.handle,
       harness: rec.harness,
@@ -250,8 +252,16 @@ export class FleetStore extends EventEmitter {
       .sort((a, b) => a.connectedAt.localeCompare(b.connectedAt));
   }
 
+  /** Coalesced: heartbeats arrive per tool call once the harness hooks are
+   *  wired, so publishing the whole fleet per heartbeat would be an
+   *  O(agents × watchers) storm. Mark dirty, flush at most once per window. */
   private publishAgents(): void {
-    this.publish({ type: "agents", agents: this.listAgents() });
+    if (this.agentsFlushTimer) return;
+    this.agentsFlushTimer = setTimeout(() => {
+      this.agentsFlushTimer = null;
+      this.publish({ type: "agents", agents: this.listAgents() });
+    }, config.agentsFlushMs);
+    this.agentsFlushTimer.unref?.();
   }
 
   // ---------------------------------------------------------- throughput
@@ -347,11 +357,16 @@ export class FleetStore extends EventEmitter {
   }
 
   watcherSummary(): WatcherSummary {
-    // Only the rough location and a random id leave the server — never an IP,
-    // never anything derived from one beyond city/country/rounded coords.
-    const locations = [...this.watchers.values()]
-      .slice(0, 100)
-      .map((rec) => ({ id: rec.id, connectedAt: rec.connectedAt, ...(rec.location ?? {}) }));
+    // Only these explicit fields leave the server about a watcher — never an
+    // IP, never anything derived from one beyond city/country/rounded coords.
+    const locations = [...this.watchers.values()].slice(0, 100).map((rec) => ({
+      id: rec.id,
+      connectedAt: rec.connectedAt,
+      city: rec.location?.city,
+      country: rec.location?.country,
+      lat: rec.location?.lat,
+      lon: rec.location?.lon,
+    }));
     return { count: this.watchers.size, locations };
   }
 
@@ -378,18 +393,33 @@ export class FleetStore extends EventEmitter {
     return event;
   }
 
+  /** Broadcast-only, NOT stored in the capped feed: high-churn notices (like
+   *  watcher joins) would otherwise evict real fleet events and persist to
+   *  STATE_FILE via the snapshot. Live watchers still see them. */
+  ephemeralEvent(kind: EventKind, text: string, meta: { handle?: string; harness?: string }): void {
+    this.publish({
+      type: "event",
+      event: {
+        id: randomUUID(),
+        at: new Date().toISOString(),
+        kind,
+        text,
+        ...(meta.handle ? { handle: meta.handle } : {}),
+        ...(meta.harness ? { harness: meta.harness } : {}),
+      },
+    });
+  }
+
   recentEvents(limit = 50): EventItem[] {
     return this.events.slice(0, limit);
   }
 
   // ---------------------------------------------------------------- logs
 
+  /** Logs are broadcast-only — nothing is retained server-side. Retention was
+   *  considered and dropped: the stream is theatre/debugging, and keeping
+   *  transcript excerpts in RAM that nothing reads is pure liability. */
   appendLogs(agentId: string, handle: string, lines: string[]): void {
-    const now = Date.now();
-    const tail = this.logs.get(agentId) ?? [];
-    tail.unshift(...lines.map((line) => ({ at: now, line })));
-    if (tail.length > config.logLinesPerAgent) tail.length = config.logLinesPerAgent;
-    this.logs.set(agentId, tail);
     if (config.broadcastLogs) this.publish({ type: "log", agentId, handle, lines });
   }
 

--- a/server/src/watch-ws.ts
+++ b/server/src/watch-ws.ts
@@ -11,6 +11,7 @@ import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { WebSocket } from "ws";
 import { config } from "./config.js";
 import { describeLocation, roughLocate } from "./geo.js";
+import { originAllowed } from "./guards.js";
 import type { ServerMessage } from "./protocol.js";
 import type { FleetStore } from "./state.js";
 
@@ -41,14 +42,20 @@ export function registerWatchSocket(app: FastifyInstance, store: FleetStore): vo
   });
 
   app.get("/ws/watch", { websocket: true }, (socket: WebSocket, req: FastifyRequest) => {
+    if (!originAllowed(req)) {
+      socket.close(4403, "origin not allowed");
+      return;
+    }
     // req.ip honours X-Forwarded-For when trustProxy is on. Used once, here,
     // for the rough lookup — never retained.
     const location = config.watcherGeo ? roughLocate(req.ip) : null;
     const watcher = store.addWatcher(location);
     sockets.add(socket);
 
+    // Ephemeral: watcher joins are fun live but would crowd real fleet events
+    // out of the capped, persisted feed.
     if (location?.city || location?.country) {
-      store.addEvent("watcher_joined", `someone from ${describeLocation(location)} is watching`, {});
+      store.ephemeralEvent("watcher_joined", `someone from ${describeLocation(location)} is watching`, {});
     }
 
     socket.send(JSON.stringify({ type: "snapshot", state: store.snapshot() } satisfies ServerMessage));

--- a/server/src/watch-ws.ts
+++ b/server/src/watch-ws.ts
@@ -1,0 +1,89 @@
+/**
+ * /ws/watch — the dashboard-facing socket. On connect the watcher gets a full
+ * snapshot, then live deltas as the store changes, plus a periodic `fleet`
+ * tick so the TPS gauge moves even between agent heartbeats.
+ *
+ * Watchers are presence too: we resolve a rough city-level location from the
+ * connecting IP (offline lookup), then the IP is discarded — it is never
+ * stored, logged, or sent to any client.
+ */
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import type { WebSocket } from "ws";
+import { config } from "./config.js";
+import { describeLocation, roughLocate } from "./geo.js";
+import type { ServerMessage } from "./protocol.js";
+import type { FleetStore } from "./state.js";
+
+const PING_INTERVAL_MS = 25_000;
+const FLEET_TICK_MS = 2_000;
+
+export function registerWatchSocket(app: FastifyInstance, store: FleetStore): void {
+  const sockets = new Set<WebSocket>();
+
+  const fanout = (msg: ServerMessage) => {
+    if (msg.type === "log" && !config.broadcastLogs) return;
+    const payload = JSON.stringify(msg);
+    for (const socket of sockets) {
+      if (socket.readyState === socket.OPEN) socket.send(payload);
+    }
+  };
+  store.on("message", fanout);
+
+  // Periodic fleet tick: keeps the TPS gauge sliding down as buckets age out,
+  // not just jumping on heartbeats.
+  const ticker = setInterval(() => {
+    if (sockets.size > 0) fanout({ type: "fleet", fleet: store.fleetMetrics() });
+  }, FLEET_TICK_MS);
+
+  app.addHook("onClose", () => {
+    clearInterval(ticker);
+    store.off("message", fanout);
+  });
+
+  app.get("/ws/watch", { websocket: true }, (socket: WebSocket, req: FastifyRequest) => {
+    // req.ip honours X-Forwarded-For when trustProxy is on. Used once, here,
+    // for the rough lookup — never retained.
+    const location = config.watcherGeo ? roughLocate(req.ip) : null;
+    const watcher = store.addWatcher(location);
+    sockets.add(socket);
+
+    if (location?.city || location?.country) {
+      store.addEvent("watcher_joined", `someone from ${describeLocation(location)} is watching`, {});
+    }
+
+    socket.send(JSON.stringify({ type: "snapshot", state: store.snapshot() } satisfies ServerMessage));
+
+    let alive = true;
+    const pinger = setInterval(() => {
+      if (!alive) {
+        socket.terminate();
+        return;
+      }
+      alive = false;
+      socket.ping();
+      store.touchWatcher(watcher.id);
+    }, PING_INTERVAL_MS);
+
+    socket.on("pong", () => {
+      alive = true;
+      store.touchWatcher(watcher.id);
+    });
+
+    socket.on("message", (data, isBinary) => {
+      alive = true;
+      store.touchWatcher(watcher.id);
+      // Watchers are read-only; the only accepted message is a keepalive ping.
+      if (!isBinary && data.toString().includes('"ping"')) {
+        socket.send(JSON.stringify({ type: "pong" } satisfies ServerMessage));
+      }
+    });
+
+    socket.on("close", () => {
+      clearInterval(pinger);
+      sockets.delete(socket);
+      store.removeWatcher(watcher.id);
+    });
+
+    socket.on("error", () => socket.terminate());
+  });
+}

--- a/server/test/redact.test.mjs
+++ b/server/test/redact.test.mjs
@@ -1,0 +1,109 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { redactText, REDACTED } from "../clients/redact-patterns.mjs";
+
+// Fixtures are assembled at runtime via j() so that none of these fake
+// credentials appear contiguously in the source — GitHub push protection
+// (rightly) refuses files containing things that look like live secrets.
+const j = (...parts) => parts.join("");
+
+/** The secret substring must be gone after redaction. */
+function gone(input, secret) {
+  const out = redactText(input);
+  assert.ok(!out.includes(secret), `leaked ${JSON.stringify(secret)} in ${JSON.stringify(out)}`);
+}
+
+/** The line must pass through completely unchanged. */
+function untouched(input) {
+  assert.equal(redactText(input), input);
+}
+
+test("URL credentials (postgres/mysql/mongodb/redis/amqp)", () => {
+  gone(j(`DATABASE_URL="postgres://app:`, `s3cr3t@db.internal:5432/prod"`), "s3cr3t");
+  gone(j("mysql://root:", "hunter2@127.0.0.1/x"), "hunter2");
+  gone(j("mongodb+srv://svc:", "p%40ss@cluster0.example.net/db"), "p%40ss");
+  gone(j("redis://default:", "redispw@cache:6379"), "redispw");
+  gone(j("amqp://guest:", "guestpw@mq:5672"), "guestpw");
+  // user survives, password doesn't
+  assert.equal(redactText(j("postgres://app:", "pw@h")), `postgres://app:${REDACTED}@h`);
+});
+
+test("AWS", () => {
+  gone(j("aws configure set aws_access_key_id AKIA", "IOSFODNN7EXAMPLE"), "IOSFODNN7EXAMPLE");
+  gone(j("ASIA", "Y34FZKBOKMUTVV7A is a session key id"), "Y34FZKBOKMUTVV7A");
+  gone(j("aws_secret_access_key = ", `"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"`), "wJalrXUtnFEMI");
+  gone(j("AWS_SESSION_TOKEN=", "FQoGZXIvYXdzEBYaDzKcqLu9k1111EXAMPLE"), "FQoGZXIvYXdzEBYa");
+});
+
+test("private key and age/PGP blocks", () => {
+  gone(j("-----BEGIN RSA PRIVATE KEY-----\n", "MIIEow==", "\n-----END RSA PRIVATE KEY-----"), "MIIEow==");
+  gone(j("-----BEGIN OPENSSH PRIVATE KEY-----\n", "b3BlbnNzaA=="), "b3BlbnNzaA==");
+  gone(j("-----BEGIN PGP PRIVATE KEY BLOCK-----\n", "lQdGBF==", "\n-----END PGP PRIVATE KEY BLOCK-----"), "lQdGBF==");
+  gone(j("AGE-SECRET-KEY-1", "QQPZRW9DECISION8FANCYSTRINGVALUE0XYZ"), "QQPZRW9DECISION8");
+});
+
+test("GitHub / GitLab", () => {
+  gone(j("token ghp_", "abcdefghijklmnopqrstuvwxyz123456"), "abcdefghijklmnopqrstuvwxyz123456");
+  gone(j("github_pat_", "11ABCDEFG0_abcdefghijklmnopqrstuvwxyz"), "11ABCDEFG0");
+  gone(j("glpat-", "XyZabc123defGHI456jkl"), "XyZabc123defGHI456jkl");
+});
+
+test("AI / SaaS vendor tokens", () => {
+  gone(j("sk-", "ant-api03-abcdefghijklmnopqrstuvwx"), "ant-api03");
+  gone(j("OPENAI: sk-", "proj-AbCdEfGhIjKlMnOpQrSt"), "proj-AbCdEfGh");
+  gone(j("hf_", "AbCdEfGhIjKlMnOpQrStUv"), "AbCdEfGhIjKlMnOpQrStUv");
+  gone(j("stripe sk_live_", "4eC39HqLyjWDarjtT1zdp7dc"), "4eC39HqLyjWDarjtT1zdp7dc");
+  gone(j("whsec_", "AbCdEfGhIjKlMnOpQrSt"), "AbCdEfGhIjKlMnOpQrSt");
+  gone(j("key AIza", "SyA-1234567890abcdefghijklmnopqrstu in config"), "SyA-1234567890");
+  gone(j("ya29", ".a0AbCdEfGhIjKlMnOpQrStUvWxYz123"), ".a0AbCdEfGh");
+  gone(j("SG", ".AbCdEfGhIjKlMnOp_r.QrStUvWxYz0123456789-_abc"), ".AbCdEfGhIjKlMnOp_r");
+  gone(j("npm_", "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789"), "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789");
+  gone(j("dapi", "0123456789abcdef0123456789abcdef"), "0123456789abcdef0123456789abcdef");
+});
+
+test("Azure connection strings and SAS", () => {
+  gone(
+    j("DefaultEndpointsProtocol=https;AccountName=x;AccountKey=", "AbCdeFgH0123456789==;EndpointSuffix=core.windows.net"),
+    "AbCdeFgH0123456789",
+  );
+  gone(j("https://acc.blob.core.windows.net/c/b?sv=2021&sig=", "AbCdEf%2BgHiJkLmNoPqRsTuVw%3D%3D"), "AbCdEf%2BgHiJkLm");
+});
+
+test("webhook URLs are credentials", () => {
+  gone(j("https://hooks.slack.com/services/", "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"), "T00000000");
+  gone(j("https://discord.com/api/webhooks/", "123456789012345678/aBcDeF-gHiJkLmN"), "aBcDeF-gHiJkLmN");
+  gone(j("xoxb-", "1234567890-abcdefghijkl"), "1234567890-abcdefghijkl");
+  gone(j("110201543:AA", "HdqTcvCH1vGWJxfSeofSAs0K5PALDsaw"), "HdqTcvCH1vGWJxfSeofSAs0K5PALDsaw");
+});
+
+test("JWTs and auth headers", () => {
+  gone(
+    j("Authorization: Bearer eyJ", "hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N"),
+    "dozjgNryP4J3jVmNHl0w5N",
+  );
+  gone(j("basic ", "dXNlcjpwYXNzd29yZDEyMw=="), "dXNlcjpwYXNzd29yZDEyMw==");
+});
+
+test("secret-bearing name = value, quoted and unquoted", () => {
+  gone(j(`MY_SECRET="`, `hunter2"`), "hunter2");
+  gone(j(`"password": "`, `hunter2"`), "hunter2");
+  gone(j("export DB_PASSWORD='", "topsecret'"), "topsecret");
+  gone(j("PASSPHRASE: ", "correct-horse-battery"), "correct-horse-battery");
+  gone(j("MYSQL_PWD=", "rootpw123"), "rootpw123");
+  gone(j("SENTRY_DSN=https://", "abc123@o0.ingest.sentry.io/1"), "abc123");
+  gone(j("SIGNING_KEY: ", "0xdeadbeefcafe"), "0xdeadbeefcafe");
+});
+
+test("normal text is untouched", () => {
+  untouched("no secrets here at all");
+  untouched("see https://example.com/path?x=1 for docs");
+  untouched("commit 3f786850e387550fdab836ed7e6dc881de23001b fixed it");
+  untouched("PWD=/home/user/the-for-good-project");
+  untouched("monkey=banana tastes fine");
+});
+
+test("acceptable over-redaction: names that merely CONTAIN a secret keyword", () => {
+  // TOKENIZER contains TOKEN, so it matches the name rule. We accept this
+  // trade deliberately — a garbled feed line beats a leaked credential.
+  assert.ok(redactText("TOKENIZER=whitespace").includes(REDACTED));
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/web/README.md
+++ b/web/README.md
@@ -40,6 +40,10 @@ Routes are defined in [src/App.tsx](src/App.tsx). The main views are:
 
 The `/submit` route currently redirects to `/live`; problem submission is handled through GitHub issue templates.
 
+## Live Fleet Data (Optional)
+
+The Live page can additionally show real-time mission control — worker presence, a fleet tokens/sec gauge, watcher presence — when a [fleet server](../server/README.md) is reachable. Point the app at one with `VITE_LIVE_SERVER_URL=http://host:8787` at build time, or on a deployed site via `localStorage.setItem("forgood.liveServer", "http://host:8787")`. With no server configured or reachable, the page falls back to the GitHub snapshot feed exactly as before. The watcher protocol types in [src/lib/live.ts](src/lib/live.ts) mirror [../server/src/protocol.ts](../server/src/protocol.ts) — update both together.
+
 ## Data Flow
 
 The dashboard should reflect the Markdown and GitHub state in this repo:

--- a/web/src/components/live/AgentGrid.tsx
+++ b/web/src/components/live/AgentGrid.tsx
@@ -1,0 +1,114 @@
+import { Line, LineChart, ResponsiveContainer, YAxis } from "recharts";
+import { Bot, GitPullRequest, Hammer, Layers, Search, Wrench } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Card, CardContent } from "@/components/ui/card";
+import { initials, relativeTime } from "@/lib/format";
+import { compactNumber, type AgentPresence } from "@/lib/live";
+import { harnessColor, useIsDark } from "./harness";
+
+const KIND_META = {
+  work: { icon: Hammer, verb: "working on" },
+  review: { icon: Search, verb: "reviewing" },
+  frame: { icon: Layers, verb: "framing" },
+  synth: { icon: Layers, verb: "synthesising" },
+  idle: { icon: Bot, verb: "idle" },
+} as const;
+
+function AgentCard({ agent, trail }: { agent: AgentPresence; trail: number[] }) {
+  const dark = useIsDark();
+  const color = harnessColor(agent.harness, dark);
+  const kind = KIND_META[agent.task?.kind ?? "idle"] ?? KIND_META.idle;
+  const KindIcon = kind.icon;
+  const s = agent.session;
+  const fetches = s.fetchesOk + s.fetchesError;
+  const trailData = trail.map((tps, i) => ({ i, tps }));
+
+  return (
+    <Card className="animate-fade-in">
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <a href={`https://github.com/${agent.handle}`} target="_blank" rel="noreferrer" className="flex min-w-0 items-center gap-2.5">
+            <span className="relative inline-block shrink-0">
+              <Avatar className="h-9 w-9 ring-2" style={{ ["--tw-ring-color" as string]: color }}>
+                <AvatarImage src={`https://github.com/${agent.handle}.png?size=72`} alt={agent.handle} />
+                <AvatarFallback>{initials(agent.handle)}</AvatarFallback>
+              </Avatar>
+              <span className="absolute -bottom-0.5 -right-0.5 rounded-full p-0.5 text-white ring-2 ring-background" style={{ backgroundColor: color }}>
+                <Bot className="h-2.5 w-2.5" />
+              </span>
+            </span>
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium">@{agent.handle}</span>
+              <span className="block truncate font-mono text-[11px] text-muted-foreground">{agent.model}</span>
+            </span>
+          </a>
+          <div className="shrink-0 text-right">
+            <div className="text-lg font-semibold tabular-nums leading-tight">{compactNumber(agent.tps)}</div>
+            <div className="text-[10px] text-muted-foreground">tok/s</div>
+          </div>
+        </div>
+
+        <div className="mt-3 flex items-start gap-1.5 text-xs text-muted-foreground">
+          <KindIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" style={{ color }} />
+          <span className="min-w-0">
+            {kind.verb}{" "}
+            {agent.task?.ref ? (
+              <a
+                href={`https://github.com/thecolab-ai/the-for-good-project/issues/${agent.task.ref.replace("#", "")}`}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium text-foreground hover:underline"
+              >
+                {agent.task.ref}
+              </a>
+            ) : null}
+            {agent.task?.title ? <span className="block truncate text-foreground/80">{agent.task.title}</span> : null}
+          </span>
+        </div>
+
+        {trailData.length > 2 ? (
+          <div className="mt-2 h-8">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={trailData} margin={{ top: 2, right: 0, bottom: 2, left: 0 }}>
+                <YAxis hide domain={[0, "auto"]} />
+                <Line type="monotone" dataKey="tps" stroke={color} strokeWidth={2} dot={false} isAnimationActive={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        ) : null}
+
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <Wrench className="h-3 w-3" /> {compactNumber(s.toolCalls)} tool calls
+          </span>
+          <span className="tabular-nums">{compactNumber(s.tokensIn + s.tokensOut)} tokens</span>
+          {fetches > 0 ? <span className="tabular-nums">{Math.round((s.fetchesOk / fetches) * 100)}% fetch ok</span> : null}
+          {s.prsOpened > 0 ? (
+            <span className="inline-flex items-center gap-1">
+              <GitPullRequest className="h-3 w-3" /> {s.prsOpened}
+            </span>
+          ) : null}
+          <span className="ml-auto">{relativeTime(agent.lastSeen)}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AgentGrid({ agents, trails }: { agents: AgentPresence[]; trails: Record<string, number[]> }) {
+  if (!agents.length) {
+    return (
+      <div className="rounded-lg border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+        No workers connected right now. The fleet reports in here the moment someone runs autopilot with
+        telemetry enabled — GitHub keeps working either way.
+      </div>
+    );
+  }
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {agents.map((agent) => (
+        <AgentCard key={agent.id} agent={agent} trail={trails[agent.id] ?? []} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/live/FleetPulse.tsx
+++ b/web/src/components/live/FleetPulse.tsx
@@ -1,0 +1,79 @@
+import { Area, AreaChart, ResponsiveContainer, Tooltip, YAxis } from "recharts";
+import { Card, CardContent } from "@/components/ui/card";
+import { compactNumber, type FleetMetrics, type TpsPoint } from "@/lib/live";
+import { harnessColor, harnessOrder, useIsDark } from "./harness";
+
+/**
+ * The fleet's heartbeat: one hero figure (tokens/sec across every connected
+ * worker, hash-rate style) over a live area chart, with the per-harness split
+ * as a direct-labeled legend row underneath.
+ */
+export function FleetPulse({ fleet, history }: { fleet: FleetMetrics | null; history: TpsPoint[] }) {
+  const dark = useIsDark();
+  const accent = harnessColor("claude", dark);
+  const tps = fleet?.tps ?? 0;
+  const harnesses = harnessOrder(Object.keys(fleet?.tpsByHarness ?? {}));
+
+  return (
+    <Card className="relative overflow-hidden">
+      <CardContent className="p-5">
+        <div className="text-sm font-medium text-muted-foreground">Fleet throughput</div>
+        <div className="mt-1 flex items-baseline gap-2">
+          <span className="font-sans text-5xl font-semibold tabular-nums leading-none">{compactNumber(tps)}</span>
+          <span className="text-sm text-muted-foreground">tokens/sec</span>
+          {tps > 0 ? (
+            <span className="relative ml-1 flex h-2 w-2 self-center">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" style={{ backgroundColor: accent }} />
+              <span className="relative inline-flex h-2 w-2 rounded-full" style={{ backgroundColor: accent }} />
+            </span>
+          ) : null}
+        </div>
+
+        <div className="mt-3 h-24">
+          {history.length > 1 ? (
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={history} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
+                <defs>
+                  <linearGradient id="tpsFill" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={accent} stopOpacity={0.28} />
+                    <stop offset="100%" stopColor={accent} stopOpacity={0.02} />
+                  </linearGradient>
+                </defs>
+                <YAxis hide domain={[0, "auto"]} />
+                <Tooltip
+                  cursor={{ stroke: accent, strokeWidth: 1, strokeDasharray: "3 3" }}
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const p = payload[0].payload as TpsPoint;
+                    return (
+                      <div className="rounded-md border border-border bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-md">
+                        <div className="font-medium tabular-nums">{compactNumber(p.tps)} tok/s</div>
+                        <div className="text-muted-foreground">{new Date(p.t).toLocaleTimeString()}</div>
+                      </div>
+                    );
+                  }}
+                />
+                <Area type="monotone" dataKey="tps" stroke={accent} strokeWidth={2} fill="url(#tpsFill)" isAnimationActive={false} />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+              gathering ticks…
+            </div>
+          )}
+        </div>
+
+        {harnesses.length > 0 ? (
+          <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+            {harnesses.map((h) => (
+              <span key={h} className="inline-flex items-center gap-1.5 text-muted-foreground">
+                <span className="h-2 w-2 rounded-full" style={{ backgroundColor: harnessColor(h, dark) }} />
+                {h} <span className="font-medium tabular-nums text-foreground">{compactNumber(fleet?.tpsByHarness[h] ?? 0)}</span> tok/s
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/live/LiveEventFeed.tsx
+++ b/web/src/components/live/LiveEventFeed.tsx
@@ -1,0 +1,45 @@
+import { Bot, CheckCircle2, Eye, GitPullRequest, LogOut, Play, Search } from "lucide-react";
+import { relativeTime } from "@/lib/format";
+import type { EventItem } from "@/lib/live";
+import { harnessColor, useIsDark } from "./harness";
+
+const EVENT_META = {
+  agent_online: { icon: Bot, label: "online" },
+  agent_offline: { icon: LogOut, label: "offline" },
+  task_started: { icon: Play, label: "started" },
+  pr_opened: { icon: GitPullRequest, label: "PR" },
+  review_done: { icon: Search, label: "review" },
+  task_done: { icon: CheckCircle2, label: "done" },
+  watcher_joined: { icon: Eye, label: "watcher" },
+} as const;
+
+/** The rolling fleet event stream: connects, task starts, PRs, reviews. */
+export function LiveEventFeed({ events }: { events: EventItem[] }) {
+  const dark = useIsDark();
+  if (!events.length) {
+    return <div className="p-6 text-center text-sm text-muted-foreground">No fleet events yet.</div>;
+  }
+  return (
+    <ul className="divide-y divide-border">
+      {events.map((e) => {
+        const meta = EVENT_META[e.kind] ?? EVENT_META.task_started;
+        const Icon = meta.icon;
+        const color = e.harness ? harnessColor(e.harness, dark) : undefined;
+        return (
+          <li key={e.id} className="flex items-start gap-2.5 py-2.5 text-sm">
+            <span
+              className="mt-0.5 rounded-full p-1"
+              style={color ? { backgroundColor: `${color}1a`, color } : undefined}
+            >
+              <Icon className="h-3.5 w-3.5" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-foreground/90">{e.text}</span>
+              <span className="text-xs text-muted-foreground">{relativeTime(e.at)}</span>
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/web/src/components/live/WatcherStrip.tsx
+++ b/web/src/components/live/WatcherStrip.tsx
@@ -1,0 +1,32 @@
+import { Eye, Globe } from "lucide-react";
+import type { WatcherSummary } from "@/lib/live";
+
+/** Who else is watching mission control right now. Locations are city-level
+ *  approximations derived server-side; IPs never leave the server. */
+export function WatcherStrip({ watchers }: { watchers: WatcherSummary }) {
+  // Roll identical rough locations together: "Auckland, NZ ×3".
+  const places = new Map<string, number>();
+  for (const w of watchers.locations) {
+    const label = [w.city, w.country].filter(Boolean).join(", ");
+    if (label) places.set(label, (places.get(label) ?? 0) + 1);
+  }
+  const anonymous = watchers.count - [...places.values()].reduce((a, b) => a + b, 0);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+      <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+        <Eye className="h-3.5 w-3.5" />
+        {watchers.count} watching
+      </span>
+      {[...places.entries()].slice(0, 8).map(([place, n]) => (
+        <span key={place} className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5">
+          <Globe className="h-3 w-3" />
+          {place}
+          {n > 1 ? ` ×${n}` : ""}
+        </span>
+      ))}
+      {anonymous > 0 && places.size > 0 ? <span>+{anonymous} elsewhere</span> : null}
+      <span className="text-[10px] opacity-70">locations approximate</span>
+    </div>
+  );
+}

--- a/web/src/components/live/harness.ts
+++ b/web/src/components/live/harness.ts
@@ -1,0 +1,49 @@
+/**
+ * Chart colors for the live fleet views. Harness identity is categorical:
+ * fixed slot order (claude -> codex -> hermes -> other), never cycled.
+ * Both palettes were validated with the dataviz six-checks script against the
+ * card surfaces (#FFFFFF light, #1f1c1a dark): lightness band, chroma floor,
+ * adjacent-pair CVD separation, and >=3:1 contrast all pass.
+ */
+import { useEffect, useState } from "react";
+
+const LIGHT: Record<string, string> = {
+  claude: "#0284C7",
+  codex: "#C2410C",
+  hermes: "#7C3AED",
+};
+const DARK: Record<string, string> = {
+  claude: "#0294D8",
+  codex: "#EA580C",
+  hermes: "#8B5CF6",
+};
+// Anything beyond the three known harnesses folds into neutral, per the
+// fixed-order rule (a 4th series is never a generated hue).
+const OTHER_LIGHT = "#57534E";
+const OTHER_DARK = "#A8A29E";
+
+export function harnessColor(harness: string, dark: boolean): string {
+  const palette = dark ? DARK : LIGHT;
+  return palette[harness] ?? (dark ? OTHER_DARK : OTHER_LIGHT);
+}
+
+/** Known harnesses in the fixed display order; unknown ones append after. */
+export function harnessOrder(present: string[]): string[] {
+  const known = ["claude", "codex", "hermes"].filter((h) => present.includes(h));
+  const unknown = present.filter((h) => !["claude", "codex", "hermes"].includes(h)).sort();
+  return [...known, ...unknown];
+}
+
+/** Tracks the site theme (the `dark` class on <html>) so SVG charts re-color
+ *  when the user toggles it. */
+export function useIsDark(): boolean {
+  const [dark, setDark] = useState(() => document.documentElement.classList.contains("dark"));
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setDark(document.documentElement.classList.contains("dark"));
+    });
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+  return dark;
+}

--- a/web/src/lib/live.ts
+++ b/web/src/lib/live.ts
@@ -46,7 +46,6 @@ export interface AgentPresence {
 
 export interface RoughLocation {
   city?: string;
-  region?: string;
   country?: string;
   lat?: number;
   lon?: number;

--- a/web/src/lib/live.ts
+++ b/web/src/lib/live.ts
@@ -1,0 +1,276 @@
+/**
+ * Live fleet connection — the watcher side of the fleet server (issue #398).
+ *
+ * Types here MIRROR server/src/protocol.ts (server -> watcher direction);
+ * update both together. The dashboard degrades gracefully: no server
+ * configured or reachable -> the Live page falls back to the GitHub snapshot
+ * feed exactly as before.
+ */
+import { useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Protocol mirror
+
+export interface TaskInfo {
+  kind: "work" | "review" | "frame" | "synth" | "idle";
+  ref?: string;
+  title?: string;
+}
+
+export interface SessionCounters {
+  tokensIn: number;
+  tokensOut: number;
+  toolCalls: number;
+  tools: Record<string, number>;
+  fetchesOk: number;
+  fetchesError: number;
+  skills: Record<string, number>;
+  errors: number;
+  tasksCompleted: number;
+  prsOpened: number;
+  reviewsCompleted: number;
+}
+
+export interface AgentPresence {
+  id: string;
+  handle: string;
+  harness: string;
+  model: string;
+  transport: "ws" | "http";
+  connectedAt: string;
+  lastSeen: string;
+  task: TaskInfo | null;
+  session: SessionCounters;
+  tps: number;
+}
+
+export interface RoughLocation {
+  city?: string;
+  region?: string;
+  country?: string;
+  lat?: number;
+  lon?: number;
+}
+
+export interface WatcherSummary {
+  count: number;
+  locations: Array<RoughLocation & { id: string; connectedAt: string }>;
+}
+
+export interface FleetMetrics {
+  tps: number;
+  tpsByModel: Record<string, number>;
+  tpsByHarness: Record<string, number>;
+  activeAgents: number;
+  watcherCount: number;
+  totals: SessionCounters;
+  serverTime: string;
+}
+
+export interface EventItem {
+  id: string;
+  at: string;
+  kind:
+    | "agent_online"
+    | "agent_offline"
+    | "task_started"
+    | "pr_opened"
+    | "review_done"
+    | "task_done"
+    | "watcher_joined";
+  text: string;
+  handle?: string;
+  harness?: string;
+  ref?: string;
+}
+
+export interface FleetSnapshot {
+  agents: AgentPresence[];
+  watchers: WatcherSummary;
+  fleet: FleetMetrics;
+  events: EventItem[];
+}
+
+type ServerMessage =
+  | { type: "snapshot"; state: FleetSnapshot }
+  | { type: "agents"; agents: AgentPresence[] }
+  | { type: "fleet"; fleet: FleetMetrics }
+  | { type: "watchers"; watchers: WatcherSummary }
+  | { type: "event"; event: EventItem }
+  | { type: "log"; agentId: string; handle: string; lines: string[] }
+  | { type: "pong" };
+
+// ---------------------------------------------------------------------------
+// Server URL resolution
+
+/** Where's the fleet server? Priority: localStorage override (lets anyone
+ *  point the deployed site at a server) -> build-time env -> localhost in dev.
+ *  null = not configured; the page runs GitHub-feed-only. */
+export function liveServerUrl(): string | null {
+  let fromStorage: string | null = null;
+  try {
+    fromStorage = localStorage.getItem("forgood.liveServer");
+  } catch {
+    /* storage blocked */
+  }
+  const fromEnv = import.meta.env.VITE_LIVE_SERVER_URL as string | undefined;
+  const url = fromStorage || fromEnv || (import.meta.env.DEV ? "http://localhost:8787" : null);
+  return url ? url.replace(/\/+$/, "") : null;
+}
+
+function toWsUrl(httpUrl: string): string {
+  return httpUrl.replace(/^http/, "ws") + "/ws/watch";
+}
+
+// ---------------------------------------------------------------------------
+// The hook
+
+export type LiveStatus = "unconfigured" | "connecting" | "online" | "offline";
+
+export interface TpsPoint {
+  t: number;
+  tps: number;
+  byHarness: Record<string, number>;
+}
+
+export interface LiveFleet {
+  status: LiveStatus;
+  agents: AgentPresence[];
+  fleet: FleetMetrics | null;
+  watchers: WatcherSummary;
+  events: EventItem[];
+  /** Fleet TPS over time, one point per server tick (~2s), for the pulse chart. */
+  tpsHistory: TpsPoint[];
+  /** Short per-agent TPS trails for the card sparklines. */
+  agentTrails: Record<string, number[]>;
+}
+
+const MAX_TPS_POINTS = 90; // ~3 minutes of 2s ticks
+const MAX_TRAIL_POINTS = 30;
+const MAX_EVENTS = 100;
+const RECONNECT_BASE_MS = 2000;
+const RECONNECT_MAX_MS = 30_000;
+
+const EMPTY: LiveFleet = {
+  status: "unconfigured",
+  agents: [],
+  fleet: null,
+  watchers: { count: 0, locations: [] },
+  events: [],
+  tpsHistory: [],
+  agentTrails: {},
+};
+
+export function useLiveFleet(): LiveFleet {
+  const [state, setState] = useState<LiveFleet>(EMPTY);
+  const attempts = useRef(0);
+
+  useEffect(() => {
+    const base = liveServerUrl();
+    if (!base) return;
+
+    let ws: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let closed = false;
+
+    const apply = (msg: ServerMessage) => {
+      setState((prev) => {
+        switch (msg.type) {
+          case "snapshot": {
+            const trails: Record<string, number[]> = {};
+            for (const a of msg.state.agents) trails[a.id] = [a.tps];
+            return {
+              ...prev,
+              status: "online",
+              agents: msg.state.agents,
+              fleet: msg.state.fleet,
+              watchers: msg.state.watchers,
+              events: msg.state.events.slice(0, MAX_EVENTS),
+              agentTrails: trails,
+            };
+          }
+          case "agents": {
+            const trails = { ...prev.agentTrails };
+            for (const a of msg.agents) {
+              trails[a.id] = [...(trails[a.id] ?? []), a.tps].slice(-MAX_TRAIL_POINTS);
+            }
+            for (const id of Object.keys(trails)) {
+              if (!msg.agents.some((a) => a.id === id)) delete trails[id];
+            }
+            return { ...prev, agents: msg.agents, agentTrails: trails };
+          }
+          case "fleet": {
+            const point: TpsPoint = {
+              t: new Date(msg.fleet.serverTime).getTime(),
+              tps: msg.fleet.tps,
+              byHarness: msg.fleet.tpsByHarness,
+            };
+            return {
+              ...prev,
+              fleet: msg.fleet,
+              tpsHistory: [...prev.tpsHistory, point].slice(-MAX_TPS_POINTS),
+            };
+          }
+          case "watchers":
+            return { ...prev, watchers: msg.watchers };
+          case "event":
+            return { ...prev, events: [msg.event, ...prev.events].slice(0, MAX_EVENTS) };
+          default:
+            return prev;
+        }
+      });
+    };
+
+    const connect = () => {
+      if (closed) return;
+      setState((prev) => ({ ...prev, status: attempts.current === 0 ? "connecting" : prev.status }));
+      try {
+        ws = new WebSocket(toWsUrl(base));
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+      ws.onopen = () => {
+        attempts.current = 0;
+      };
+      ws.onmessage = (e) => {
+        try {
+          apply(JSON.parse(e.data as string) as ServerMessage);
+        } catch {
+          /* ignore malformed frame */
+        }
+      };
+      ws.onclose = () => {
+        if (closed) return;
+        setState((prev) => ({ ...prev, status: "offline" }));
+        scheduleReconnect();
+      };
+      ws.onerror = () => ws?.close();
+    };
+
+    const scheduleReconnect = () => {
+      attempts.current += 1;
+      const delay = Math.min(RECONNECT_BASE_MS * 2 ** Math.min(attempts.current, 4), RECONNECT_MAX_MS);
+      reconnectTimer = setTimeout(connect, delay);
+    };
+
+    connect();
+    return () => {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      ws?.close();
+    };
+  }, []);
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers for the live views
+
+export function compactNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 10_000) return `${Math.round(n / 1000)}K`;
+  if (n >= 1_000) return `${(n / 1000).toFixed(1)}K`;
+  return `${Math.round(n * 10) / 10}`;
+}

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -1,22 +1,102 @@
 import { useMemo, useState } from "react";
-import { Radio, GitPullRequest, MessageSquare } from "lucide-react";
+import { Bot, GitPullRequest, Globe, MessageSquare, Radio, Wifi, WifiOff, Wrench } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CommentFeed, ActiveStrip } from "@/components/shared/CommentFeed";
+import { StatCard } from "@/components/shared/StatCard";
 import { relativeTime } from "@/lib/format";
+import { compactNumber, liveServerUrl, useLiveFleet, type LiveStatus } from "@/lib/live";
+import { FleetPulse } from "@/components/live/FleetPulse";
+import { AgentGrid } from "@/components/live/AgentGrid";
+import { WatcherStrip } from "@/components/live/WatcherStrip";
+import { LiveEventFeed } from "@/components/live/LiveEventFeed";
 
-// Poll for a fresh snapshot on the live page — comment-triggered rebuilds land
-// within a minute or two, so this keeps the feed close to real time.
+// Poll for a fresh GitHub snapshot — comment-triggered rebuilds land within a
+// minute or two, so this keeps the comment feed close to real time. The fleet
+// section above it is true real-time over the fleet server's WebSocket.
 const POLL_MS = 45_000;
 
 type Filter = "all" | "issues" | "prs";
 
+function ConnectionDot({ status }: { status: LiveStatus }) {
+  if (status === "online") {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+        <span className="relative flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+        </span>
+        <Wifi className="h-3.5 w-3.5" /> fleet server connected
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span className="relative inline-flex h-2 w-2 rounded-full bg-stone-400" />
+      <WifiOff className="h-3.5 w-3.5" />
+      {status === "connecting" ? "connecting to fleet server…" : "fleet server offline — showing GitHub activity only"}
+    </span>
+  );
+}
+
+/** Real-time mission control, rendered when a fleet server is configured. */
+function FleetSection() {
+  const live = useLiveFleet();
+  if (live.status === "unconfigured") return null;
+
+  const totals = live.fleet?.totals;
+  const fetchTotal = (totals?.fetchesOk ?? 0) + (totals?.fetchesError ?? 0);
+
+  return (
+    <section className="mb-10">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <ConnectionDot status={live.status} />
+        <WatcherStrip watchers={live.watchers} />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <FleetPulse fleet={live.fleet} history={live.tpsHistory} />
+        </div>
+        <div className="grid content-start gap-4 sm:grid-cols-2 lg:grid-cols-1 lg:grid-rows-2">
+          <StatCard label="Workers online" value={live.agents.length} icon={Bot} accent="#0284C7"
+            hint={live.agents.length ? `${live.agents.filter((a) => a.task?.kind === "review").length} reviewing` : "waiting for the fleet"} />
+          <StatCard label="Tool calls" value={compactNumber(totals?.toolCalls ?? 0)} icon={Wrench} accent="#2E4057"
+            hint={fetchTotal > 0 ? `${Math.round(((totals?.fetchesOk ?? 0) / fetchTotal) * 100)}% of ${compactNumber(fetchTotal)} fetches ok` : "all time"} />
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard label="Tokens burned" value={compactNumber((totals?.tokensIn ?? 0) + (totals?.tokensOut ?? 0))} icon={Radio} accent="#C2410C" hint="all time, in + out" />
+        <StatCard label="PRs opened" value={totals?.prsOpened ?? 0} icon={GitPullRequest} accent="#0284C7" hint="all time" />
+        <StatCard label="Reviews done" value={totals?.reviewsCompleted ?? 0} icon={MessageSquare} accent="#7C3AED" hint="all time" />
+        <StatCard label="Watchers" value={live.watchers.count} icon={Globe} accent="#2E4057" hint="right now, locations approximate" />
+      </div>
+
+      <div className="mt-6">
+        <h2 className="mb-3 font-serif text-lg font-semibold">The fleet</h2>
+        <AgentGrid agents={live.agents} trails={live.agentTrails} />
+      </div>
+
+      <Card className="mt-6">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Fleet events</CardTitle>
+        </CardHeader>
+        <CardContent className="max-h-80 overflow-y-auto">
+          <LiveEventFeed events={live.events} />
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
 export default function Live() {
   const { data, error, loading } = useSnapshot(POLL_MS);
   const [filter, setFilter] = useState<Filter>("all");
+  const fleetConfigured = liveServerUrl() !== null;
 
   const comments = useMemo(() => {
     const all = data?.comments ?? [];
@@ -33,9 +113,11 @@ export default function Live() {
   return (
     <div>
       <PageHeader title="Live activity">
-        The latest comments across every issue and pull request, as people and agents work the queue.
-        Updates automatically.
+        Mission control for the worker fleet: who's connected, what they're working on, and how much
+        intelligence is flowing — plus the latest comments across every issue and pull request.
       </PageHeader>
+
+      {fleetConfigured ? <FleetSection /> : null}
 
       <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
         <ActiveStrip actors={active} />


### PR DESCRIPTION
## What this is

Part of #398

**Stage:** 🔨 Build
**Domain:** other (project infrastructure)

## Summary

Implements Phase 1 of the fleet coordination + telemetry server from #398 in a new `server/` folder, and upgrades the Live dashboard page into real-time mission control on top of it. Workers connect (WebSocket, plain curl, or the included Claude Code / Codex harness hooks) and stream presence + heartbeats — counts and rates only, never content — giving the dashboard live worker presence, a fleet **tokens/sec gauge** with per-model/per-harness split, per-agent activity cards, and a rolling fleet event feed. Dashboard viewers are presence too: watchers get a rough city-level location derived from their IP via an **offline** GeoLite2 lookup — the IP is used once in-process, never stored, never logged, and never sent to any client or third party.

### Key decisions

- **TypeScript** for the server — same language as `web/`, so the watcher protocol types are shared by mirror (`server/src/protocol.ts` ↔ `web/src/lib/live.ts`).
- **No database / no Redis** (considered, rejected): every piece of state is ephemeral by design — presence with 90s TTLs, a 60s sliding token window, a capped event feed — and #398 mandates *"keep it small and stateless where possible (GitHub holds state)"*. State is in-memory; the only thing worth keeping across restarts (lifetime totals + event feed) snapshots to an optional `STATE_FILE` on a compose volume. `FleetStore` is the seam if we ever need a shared store for multiple replicas.
- **GitHub stays the source of truth** — the server is an optional accelerator. Every client path degrades gracefully: telemetry posts no-op on failure, the hook clients no-op instantly unless `FLEET_SERVER` is set, and the Live page falls back to the existing GitHub snapshot feed when no server is configured/reachable.
- **Auth is parked** per the maintainer decision on #398 (assumed trust); the `hello` handshake leaves room for the SSH-key/device-flow challenge designed in the issue.
- **Log streaming default-OFF at both ends** per #398: worker must opt in (`STREAM_LOGS=1`, with a loud one-time consent warning) AND server must allow (`ALLOW_LOG_STREAM=1`), redacted twice (client + server), and only reaches watchers if `BROADCAST_LOGS=1` is *also* set.

### What's included

- `server/` — Fastify 5 + WebSocket + zod; `/ws/agent` (workers), `/ws/watch` (dashboard), REST fallbacks (`POST /api/v1/telemetry` for curl workers, `POST /api/v1/logs` for one-shot hook processes, `GET /api/v1/state|metrics`, `/healthz`); rate limiting + payload caps; Dockerfile + `docker-compose.yml` (single self-contained container); `scripts/simulate.mjs` fake-fleet simulator; `examples/agent-heartbeat.sh` showing the autopilot integration shape.
- `server/clients/` — **harness hooks**: `claude-code-hook.mjs` (Claude Code hooks: SessionStart/PostToolUse/Stop/SessionEnd → presence, per-tool call counts, WebFetch ok/error, token deltas from the session transcript with cache reads excluded, opt-in redacted session excerpts) and `codex-notify.mjs` (Codex `notify` bridge: per-turn heartbeat + opt-in redacted last-message excerpt), plus `claude-settings.example.json` for the settings wiring. Self-contained Node stdlib, fail-open, never block the session.
- `web/` — Live page becomes mission control when a server is configured (`VITE_LIVE_SERVER_URL` or `localStorage.forgood.liveServer`): TPS pulse chart, harness-split legend, agent grid with per-agent tok/s trails, watcher strip ("N watching · Auckland, NZ ×3 · locations approximate"), fleet event feed. Chart palette validated for CVD/contrast in both themes (fixed slot order claude → codex → hermes).

## Method checklist

- [x] Every factual claim has a source (inline — design constraints cite #398 and its decision comments)
- [ ] Surprising / load-bearing claims have **two** independent sources — n/a (build stage, no research claims)
- [ ] Confidence marked — n/a (not a finding)
- [x] I stated what would change the conclusion and what I couldn't verify (see below)
- [x] No personal or identifying data; watcher IPs are never stored or exposed by design
- [x] Files are in the right place and follow the relevant template

## For the reviewer

- **Verified:** server `tsc` build + live smoke test (simulator agents over WS, curl telemetry, watcher socket snapshot/deltas, TPS aggregation, offline events); hook clients exercised end-to-end against a running server with a synthetic Claude Code transcript — token deltas correct, per-tool counts recorded, and streamed excerpts arrive at a watcher with GitHub tokens and AWS secrets `[redacted]`; web `tsc + vite` build, oxlint clean on new files; rendered and eyeballed the page in light + dark with 6 simulated agents.
- **Couldn't verify here:** the Docker image build — this sandbox's network policy blocks Docker Hub/ECR image pulls. The Dockerfile runs exactly the commands verified on the host (`npm ci`, `tsc` build, `node dist/index.js`), but please run `docker compose up` once before deploying anywhere. Also: the Claude Code transcript JSONL format is internal and can change between versions — the parser fails soft to zero token deltas if it does; and the Codex `notify` payload shape was implemented defensively from docs, not against a live Codex run.
- **Push hardest on:** the privacy surfaces — `server/src/geo.ts` (IP handling), `server/src/redact.ts` + `clients/fleet-common.mjs` (secret patterns, applied client-side AND server-side), `watcherSummary()` (what actually leaves the server about watchers), and the `STREAM_LOGS`/`ALLOW_LOG_STREAM`/`BROADCAST_LOGS` triple gate. Also sanity-check the TPS window math in `state.ts` (`recordThroughput`/`fleetMetrics`).
- **Deliberately out of scope:** wiring `autopilot.sh` itself (follow-up; the hook clients already cover Claude Code/Codex sessions once configured), dispatch Phases 2–3, auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168QhLpdDoTJ6NXNeHBK174