### PR TITLE
docs: CONTRIBUTING.md — validator now covers analysis/ too

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Some documents ship in two formats: a Markdown original for LLMs and contributor
 
 This keeps the project's one-source-of-truth principle intact: the Markdown is the database, everything else is a view of it. See [`analysis/README.md`](analysis/README.md) for a worked example.
 
-The `analysis/` artifact type and rendered-companion convention are recorded in [`ADR-0004`](docs/adr/0004-analysis-documents-and-rendered-companions.md). Analysis files follow the cited-and-honest method, and `npm run validate` checks them too — provenance frontmatter (`type: analysis`, author/agent/model, status, date), a "Confidence & limits" section, and at least one inline citation — alongside findings and solutions.
+The `analysis/` artifact type and rendered-companion convention are recorded in [`ADR-0004`](docs/adr/0004-analysis-documents-and-rendered-companions.md). Analysis files follow the cited-and-honest method, and `npm run validate` checks them too — provenance frontmatter (`title`, `type: analysis`, author/agent/model, status, date), a "Confidence & limits" section, and at least one inline citation — alongside findings and solutions.
 
 ## Pull request checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Some documents ship in two formats: a Markdown original for LLMs and contributor
 
 This keeps the project's one-source-of-truth principle intact: the Markdown is the database, everything else is a view of it. See [`analysis/README.md`](analysis/README.md) for a worked example.
 
-The `analysis/` artifact type and rendered-companion convention are recorded in [`ADR-0004`](docs/adr/0004-analysis-documents-and-rendered-companions.md). Analysis files follow the cited-and-honest method, but the current validator still checks only findings and solutions; reviewers enforce the analysis standard until the ADR tripwire is hit.
+The `analysis/` artifact type and rendered-companion convention are recorded in [`ADR-0004`](docs/adr/0004-analysis-documents-and-rendered-companions.md). Analysis files follow the cited-and-honest method, and `npm run validate` checks them too — provenance frontmatter (`type: analysis`, author/agent/model, status, date), a "Confidence & limits" section, and at least one inline citation — alongside findings and solutions.
 
 ## Pull request checklist
 


### PR DESCRIPTION
## What this is

Closes #406

**Stage:** n/a — repo docs maintenance
**Domain:** other

## Summary

CONTRIBUTING.md said *"the current validator still checks only findings and solutions; reviewers enforce the analysis standard until the ADR tripwire is hit."* That tripwire has been hit: `scripts/validate-findings.mjs` walks `analysis/` (line 147) and applies `validateAnalysis()` (lines 125–143). Updated the sentence to describe what the validator actually enforces on analysis docs.

## Method checklist

- [x] Every factual claim has a source (the claim is the code: validate-findings.mjs:125-147)
- [x] No personal or identifying data; no overstated or fabricated claims
- [x] Files are in the right place and follow the relevant template
- [ ] Confidence / two-source / change-my-mind items — n/a, doc-only sync with code

## For the reviewer

Push on whether my one-line description of `validateAnalysis()` matches the code exactly — I list provenance frontmatter, the Confidence & limits section, and ≥1 citation. Also check whether ADR-0004 itself needs a status note; I deliberately left the ADR untouched since ADRs record decisions, not implementation status.


---

*Klaus Brave + Claude Fable 5 (ultracode)*
