### PR TITLE
web: complete the leaderboard legend — PRs opened ×1, commit cap 50

### DIFF
--- a/web/src/pages/Leaderboard.tsx
+++ b/web/src/pages/Leaderboard.tsx
@@ -104,7 +104,7 @@ export default function Leaderboard() {
       )}
 
       <p className="mt-4 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-        <Trophy className="h-3.5 w-3.5" /> Points: findings <BookOpen className="h-3.5 w-3.5" />×5 · PRs merged <GitPullRequest className="h-3.5 w-3.5" />×3 · issues claimed <CircleDot className="h-3.5 w-3.5" />×2 · reviews given <ScanEye className="h-3.5 w-3.5" />×4 · commits <GitCommit className="h-3.5 w-3.5" />
+        <Trophy className="h-3.5 w-3.5" /> Points: findings <BookOpen className="h-3.5 w-3.5" />×5 · PRs merged <GitPullRequest className="h-3.5 w-3.5" />×3 · issues claimed <CircleDot className="h-3.5 w-3.5" />×2 · PRs opened <GitPullRequest className="h-3.5 w-3.5" />×1 · reviews given <ScanEye className="h-3.5 w-3.5" />×4 · commits <GitCommit className="h-3.5 w-3.5" />×1 (max 50)
         <span className="inline-flex items-center gap-1"><FlaskConical className="h-3.5 w-3.5" /> research + review combined.</span>
       </p>
     </div>


### PR DESCRIPTION
## What this is

Closes #407

**Stage:** n/a — dashboard maintenance
**Domain:** other

## Summary

The leaderboard page's legend is the only user-facing statement of the scoring formula, and it was incomplete relative to `web/scripts/build-data.mjs` (lines 399–401): it omitted that an opened PR earns **×1** and that commit points cap at **50**. Added both to the legend. Text-only change — no scoring logic touched. `npm run lint` and `npm run build` pass (only pre-existing warnings in unrelated files).

## Method checklist

- [x] Every factual claim has a source (the formula: build-data.mjs:399-401)
- [x] No personal or identifying data; no overstated or fabricated claims
- [x] Files are in the right place and follow the relevant template
- [ ] Confidence / two-source / change-my-mind items — n/a, UI text sync with code

## For the reviewer

Check the legend now matches the code exactly: `findings×5 + PRs merged×3 + issues claimed×2 + PRs opened×1 + min(commits,50)` research side, `reviews×4` review side. I reused the GitPullRequest icon for 'PRs opened' — flag if you'd rather a distinct icon (e.g. GitPullRequestArrow) to visually separate it from 'PRs merged'.


---

*Klaus Brave + Claude Fable 5 (ultracode)*
