### PR TITLE
start_work: pick only research/ideate/build (positive label allowlist)

### DIFF
--- a/start_work.sh
+++ b/start_work.sh
@@ -511,12 +511,14 @@ pick_available() {  # $1 = queue snapshot
   local snap="$1" n labels
   for n in $(available_issues "$snap"); do
     labels="$(printf '%s' "$snap" | jq -r --argjson n "$n" '.[] | select(.number==$n) | [.labels[].name] | join(",")')"
+    # POSITIVE ALLOWLIST: this runner only claims research / ideate / build work.
+    # Discover roots are frame_work.sh's (ADR-0014); an available issue missing a
+    # workable stage label is skipped SILENTLY rather than selected-then-rejected
+    # (which spammed "skipping #N" on every pass and left the item churning).
     case ",$labels," in
-      *",stage: discover,"*)
-        log "#$n is a discover root — framing is reserved for frame_work.sh (ADR-0014); skipping."
-        continue ;;
+      *",stage: research,"*|*",stage: ideate,"*|*",stage: build,"*) echo "$n"; return 0 ;;
+      *) continue ;;
     esac
-    echo "$n"; return 0
   done
   return 0
 }


### PR DESCRIPTION
**Why (Adam):** the work loop should look for *specific labels*. `pick_available` used a discover **denylist** — it selected any available issue, then rejected discover roots and logged `skipping #N` **every pass** (Rod hit this repeatedly on #390), leaving discover roots churning in the queue.

**Fix:** switch to a **positive allowlist** — `start_work.sh` only claims `stage: research` / `ideate` / `build`. Discover roots (frame_work.sh's job, ADR-0014) and any available issue missing a workable stage label are passed over **silently**, no per-pass spam. `bash -n` clean.

Net: #390 (and any un-framed discover root) no longer gets hit-and-skipped on every work pass; the loop just moves to real work. Framing stays with `frame_work.sh` (Adam runs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)