### PR TITLE
docs: brand-identity consent count now three (partnerships lead added, #369)

### DIFF
--- a/projects/brand-identity/README.md
+++ b/projects/brand-identity/README.md
@@ -138,10 +138,10 @@ What the agent did (allowed) vs. what a human must do (gated):
 
 Until a person consents, their slot in `team.ts` keeps `name: null` /
 `photo: null` and the page renders a dignified "added with consent" placeholder
-— so the site is always **honest about who has actually signed off**. Two
-people — the founder & steward and one contributor — have now been added with
-recorded consent (PR #191); the remaining role slots stay gated until each
-person signs off. The process to add a real person
+— so the site is always **honest about who has actually signed off**. Three
+people — the founder & steward, one contributor, and the partnerships lead —
+have now been added with recorded consent (PRs #191, #369); the remaining role
+slots stay gated until each person signs off. The process to add a real person
 is in
 [`CONSENT.md`](CONSENT.md) and in the header comment of `team.ts`.
 
@@ -159,7 +159,8 @@ npm run build   # type-check + production build (passes)
 ## Status
 
 **Prototype.** The brand kit and the page are built and building green. It now
-includes one real consented contributor. What's **deliberately still missing
+includes three real consented people (the founder & steward, a contributor, and
+the partnerships lead). What's **deliberately still missing
 pending a human**:
 
 - Real names and photos for the rest of the team (human-gated — the whole point


### PR DESCRIPTION
The two consent-honesty lines in `projects/brand-identity/README.md` (L141 & L161) still said "two people" / "one real consented contributor". After #369 added Rachel McBride to the partnerships slot, those were stale — this updates both to "three" and names the partnerships lead.

Resolves the sole objection recorded on #369's adversarial review (VERDICT: NEEDS_WORK — consent docs stale). Docs-only, no site logic touched.

Part of the consent-doc honesty fix following #369.