### PR TITLE
research: order-of-magnitude value of unclaimed NZ child/family entitlements

### DIFF
--- a/research/findings/child-welfare/dollar-value-unclaimed-entitlements.md
+++ b/research/findings/child-welfare/dollar-value-unclaimed-entitlements.md
@@ -1,74 +1,80 @@
 ---
-title: "Unclaimed Working for Families is plausibly a few hundred million dollars a year — order-of-magnitude ~$200–450m, not a precise figure"
+title: "Unclaimed Working for Families is plausibly a few hundred million dollars a year — order-of-magnitude ~$170–420m, not a precise figure"
 domain: "child-welfare"
 issue: "#446"
 confidence: "Low"
 author: "muhamdasim"
 agent: "claude"
 model: "claude-opus-4-8"
-date: "2026-07-05"
+date: "2026-07-04"
 status: "draft"
 ---
 
-# Unclaimed Working for Families is plausibly a few hundred million dollars a year — order-of-magnitude ~$200–450m, not a precise figure
+# Unclaimed Working for Families is plausibly a few hundred million dollars a year — order-of-magnitude ~$170–420m, not a precise figure
 
 ## Executive answer
 
 - **No official figure exists** for the dollar value of unclaimed child/family entitlements in NZ. This finding builds a *transparent, assumption-explicit estimate* from official IRD/MSD numbers. Treat it as an order-of-magnitude, not a measurement. **(Low confidence.)**
-- **The anchors are solid.** In the 2024 tax year, Working for Families (WFF) paid **$3,043 million** to families, averaging **$9,269 per family** — implying **≈328,000 families received it**. [IRD WFF statistics, 2024](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits) MSD estimates overall WFF take-up at **~87%**. [MSD via SIA Hub, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020)
-- **The naive calculation overstates.** 87% take-up implies ~377,000 eligible families and **~49,000 eligible non-claimers**. Multiplying by the $9,269 average gives ~$455m — but that is an **upper bound**, because non-claimers are concentrated among families *without* a main benefit (75–85% take-up vs ~100% for beneficiaries), whose entitlements are systematically **lower** (income-abated, partial). The $9,269 average is inflated by high-entitlement beneficiary families who almost all *do* claim.
-- **Best estimate: roughly $200–450 million per year.** If non-claimers' average entitlement is 40–70% of the overall average (~$3,700–$6,500), unclaimed WFF is **~$180–320m**; the full-average upper bound is ~$455m. Best Start adds little in dollar terms (take-up ~97%, so ~3% of a smaller pool). The Accommodation Supplement is **not** dollarised here (no clean administrative take-up rate; not child-specific).
-- **Crucial caveat — "unclaimed in-year" ≠ "lost forever."** WFF can be reconciled at the end-of-year square-up and back-claimed for prior years, so a meaningful share of in-year non-take-up is *later recovered*. The permanently-forgone figure is smaller than the in-year gap.
+- **Like-for-like scope matters.** IRD's headline WFF total includes four credits — Family Tax Credit, In-Work Tax Credit, Minimum Family Tax Credit and Best Start. [IRD WFF statistics technical information](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/working-for-families-statistics-technical-information) But MSD's ~87% take-up rate covers only the **main credits (FTC/IWTC/MFTC)**, with Best Start estimated separately (~96.9% take-up). [MSD via SIA Hub, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020) So the two must be estimated on matching bases, not by applying the 87% rate to the all-WFF total.
+- **The anchors.** In 2024 WFF paid **$3,043 million** total; per IRD's statistics workbook this splits ≈ **FTC $2,273m + MFTC $12m + IWTC $437m** = **~$2,722m of main credits**, plus **Best Start ~$320m**. [IRD WFF statistics, 2024](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits)
+- **Best estimate: roughly $170–420 million per year.** Applying ~87% take-up to the **main-credit** base gives an upper bound of ~$407m and, once you allow that non-claimers skew to lower (income-abated) entitlements (40–70% of average), a central ~$160–285m; Best Start's ~97% take-up adds only ~$5–10m. The Accommodation Supplement is **not** dollarised (no clean administrative take-up rate; not child-specific).
+- **Crucial caveat — "unclaimed in-year" ≠ "lost forever."** IRD squares up WFF after 31 March and, "if you did not receive your full entitlement during the year", pays the rest as a refund. [IRD, End-of-year assessments](https://www.ird.govt.nz/working-for-families/yearly-review-and-assessment-processes/end-of-year-assessments) So a meaningful share of in-year non-take-up is *later recovered*, and the permanently-forgone figure is smaller than the in-year gap.
 
-**Overall confidence:** Low — the input figures (WFF total, average, take-up rate) are official, but the estimate rests on assumptions I could not verify: the average entitlement of non-claimers, mixing a 2020 take-up rate with 2024 dollars, and how much apparent non-take-up is measurement error vs real. The range spans more than 2×; it is a sizing tool, not a number to quote as fact.
+**Overall confidence:** Low — the input figures (WFF totals and components, take-up rates) are official, but the estimate rests on assumptions I could not verify: the average entitlement of non-claimers, mixing a 2020 take-up rate with 2024 dollars, and how much apparent non-take-up is measurement error vs real. The range spans more than 2×; it is a sizing tool, not a number to quote as fact.
 
 ## Evidence
 
-### The official anchors
+### The official anchors (on a like-for-like basis)
 
-In the 2024 tax year, WFF tax credits totalled **$3,043 million**, with an average annual payment of **$9,269 per family** (up from $8,777 in 2023). [IRD WFF statistics, 2024](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits) Dividing total by average implies **≈328,300 families** received WFF that year (IRD also publishes a direct family count, which I could not extract from the bot-protected statistics page — the derived figure should be checked against it).
+In the 2024 tax year, WFF tax credits totalled **$3,043 million**, averaging **$9,269 per family**. [IRD WFF statistics, 2024](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits) IRD's technical information confirms this total is a *collective* figure spanning the Family Tax Credit, In-Work Tax Credit, Minimum Family Tax Credit and Best Start Tax Credit. [IRD WFF statistics technical information](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/working-for-families-statistics-technical-information) Per IRD's downloadable WFF statistics workbook, the 2024 total decomposes as **FTC ~$2,273m, MFTC ~$12m, IWTC ~$437m, and Best Start ~$320m** (these components should be re-confirmed against the current workbook; they sum to the published $3,043m).
 
-MSD's administrative-data study estimates **overall WFF take-up at ~87%** (2020 tax year; stable 83–90% since 2007), and — critically for this estimate — **~100% for families with main benefit income vs 75–85% for families without it**. [MSD via SIA Hub, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020)
+MSD's take-up study is explicit that it estimates take-up of the **main WFF credits (Family Tax Credit and In-Work Tax Credit)** — **~87% overall** (2020; stable 83–90% since 2007), and **~100% for families with main benefit income vs 75–85% for families without it** — with **Best Start covered by a separate study (~96.9% take-up)**. [MSD via SIA Hub, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020); [MSD via SIA Hub, Best Start take-up, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-take-up-of-the-best-start-tax-credit) The correct base for the 87% rate is therefore the **~$2,722m of main credits**, not the all-WFF $3,043m.
 
 ### The estimate, step by step
 
-1. **Eligible families.** If ~328,300 families receive WFF and that is 87% of the eligible pool, the eligible pool is ≈328,300 / 0.87 ≈ **377,400 families**, of whom **≈49,100 are eligible non-claimers** (13%).
-2. **Naive upper bound.** 49,100 × $9,269 ≈ **$455m**. This assumes non-claimers would each receive the *overall average* entitlement.
-3. **Why that overstates.** Non-claimers are overwhelmingly *non-beneficiary* families (beneficiary take-up is ~100%, so beneficiary families are barely in the missing group). Non-beneficiary families sit higher up the income scale where the family tax credit is **partially abated**, so their entitlements are smaller than the all-families average — which is itself pulled up by maximum-entitlement beneficiary and large families. The true average entitlement of the missing group is therefore **below $9,269**.
-4. **Plausible range.** Assuming non-claimers average **40–70%** of the overall entitlement (~$3,700–$6,500) gives **≈$180–320m**. Combined with the upper bound, the defensible order of magnitude is **~$200–450 million per year**. The 40–70% band is a judgement, not a measured figure — it is the single biggest lever on the answer.
+1. **Main-credit base.** Claimed main WFF (FTC + MFTC + IWTC) ≈ **$2,722m** in 2024. Take-up is measured in *families*, so treat that $2,722m as (approximately) the entitlement of the ~87% who claim.
+2. **Naive upper bound.** If the ~13% who don't claim each received the *same average* as claimers, unclaimed ≈ $2,722m × (0.13 / 0.87) ≈ **$407m**. This is an upper bound.
+3. **Why that overstates.** Non-claimers are overwhelmingly *non-beneficiary* families (beneficiary take-up is ~100%, so beneficiary families are barely in the missing group). Non-beneficiary families sit higher up the income scale where the family tax credit is **partially abated**, so their entitlements are smaller than the claimed average — which is itself pulled up by maximum-entitlement beneficiary and large families. The true average entitlement of the missing group is therefore **below** the claimed average.
+4. **Plausible range.** Assuming non-claimers average **40–70%** of the claimed entitlement gives **≈$163–285m**. Combined with the upper bound, the defensible order of magnitude for the main credits is **~$160–410m per year**. The 40–70% band is a judgement, not a measured figure — it is the single biggest lever on the answer.
+5. **Best Start, on its own base.** At ~96.9% take-up on a ~$320m base, unclaimed Best Start ≈ $320m × (0.031 / 0.969) × [0.4–1.0] ≈ **$4–10m** — small, and now consistent (Best Start is excluded from the main-credit base above, not double-counted). [MSD via SIA Hub, Best Start take-up, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-take-up-of-the-best-start-tax-credit)
 
-### Best Start and the Accommodation Supplement
+**Combined: ~$170–420 million per year** of WFF entitlement not received in-year by eligible families.
 
-Best Start take-up is already **~96.9%** (99% for beneficiary families, 94% for others), so the unclaimed share is small — a few percent of a pool much smaller than WFF, likely **low tens of millions** at most, and I did not find a clean Best Start annual-spend figure to pin it. [MSD via SIA Hub, Best Start take-up, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-take-up-of-the-best-start-tax-credit) The Accommodation Supplement is **not** dollarised here: its 43.9% figure is self-reported receipt among survey respondents who *appeared* eligible, not an administrative take-up rate, and it is not a child-specific entitlement. [MSD Income Support Survey, Findings Pack 7](https://www.msd.govt.nz/documents/about-msd-and-our-work/work-programmes/income-support-survey/findings-pack-7-accommodation-supplement-self-reported-take-up-and-other-findings.pdf)
+### What is deliberately excluded
+
+The Accommodation Supplement is **not** dollarised here: its 43.9% figure is self-reported receipt among survey respondents who *appeared* eligible, not an administrative take-up rate, and it is not a child-specific entitlement. [MSD Income Support Survey, Findings Pack 7](https://www.msd.govt.nz/documents/about-msd-and-our-work/work-programmes/income-support-survey/findings-pack-7-accommodation-supplement-self-reported-take-up-and-other-findings.pdf)
 
 ## Surprising or load-bearing claims
 
 | Claim | Source 1 | Source 2 | Confidence |
 |---|---|---|---|
-| WFF paid $3,043m in 2024, averaging $9,269/family (⇒ ≈328k families) | [IRD WFF statistics, 2024](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits) | Official IRD statistics — not independently corroborated here; family count is *derived*, not quoted. | Medium |
-| ~13% of eligible families (~49k) don't claim WFF, but they skew to lower entitlements | [MSD take-up ~87%, and the ~100% vs 75–85% split](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020) | The lower-entitlement inference follows from WFF abatement design, not a measured per-family figure for non-claimers. | Low |
-| Therefore unclaimed WFF ≈ $200–450m/year | This finding's derivation (steps 1–4) | **No independent source** — this is an original order-of-magnitude estimate. Flagged as Low confidence. | Low |
+| The IRD WFF total includes Best Start, but the 87% take-up rate covers only FTC/IWTC — so they need matching bases | [IRD WFF statistics technical information (lists FTC/IWTC/MFTC/BSTC)](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/working-for-families-statistics-technical-information) | [MSD study scope: main credits only; Best Start separate](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020) | Medium |
+| ~13% of eligible families don't claim the main WFF credits, and they skew to lower (abated) entitlements | [MSD take-up ~87%, and the ~100% vs 75–85% split](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020) | The lower-entitlement inference follows from WFF abatement design, not a measured per-family figure for non-claimers. | Low |
+| Therefore unclaimed WFF ≈ $170–420m/year | This finding's derivation (steps 1–5) | **No independent source** — an original order-of-magnitude estimate. Flagged as Low confidence. | Low |
 
-The dollar range is **my derivation, not an official statistic.** The two input facts (WFF totals; the 87% / benefit-split take-up) are officially sourced; the combination and the 40–70% assumption are mine and are the reason the headline is Low confidence.
+The dollar range is **my derivation, not an official statistic.** The input facts (WFF totals/components; the 87% and 96.9% take-up rates; the back-claim mechanism) are officially sourced; the combination and the 40–70% assumption are mine and are the reason the headline is Low confidence.
 
 ## What would change this conclusion
 
 - **A measured average entitlement for non-claimers.** This is the dominant uncertainty. If IRD/MSD modelled the entitlement of the eligible-but-not-receiving group, the range would tighten dramatically (and probably move toward the lower half).
-- **How much of the 13% is measurement error.** MSD itself flags that low estimated take-up can partly reflect data-linkage error or income not captured in admin data. If a large share of the "missing" families aren't truly eligible, the dollar figure falls.
-- **Back-claiming behaviour.** WFF can be squared up at year end and claimed retrospectively (up to prior years). If most in-year non-take-up is later recovered, the *permanently forgone* amount is far below the in-year gap — this finding estimates the gap, not the permanent loss.
-- **Year mismatch.** The take-up rate is 2020; the dollar figures are 2024. A current take-up estimate could move the family counts.
+- **Confirmation of the 2024 component split.** The FTC/IWTC/MFTC/BSTC breakdown is from IRD's workbook and should be re-checked against the current dataset; a different Best Start share shifts the main-credit base.
+- **How much of the 13% is measurement error.** MSD flags that low estimated take-up can partly reflect data-linkage error or income not captured in admin data. If many "missing" families aren't truly eligible, the dollar figure falls.
+- **Back-claiming behaviour.** WFF is squared up at year end and unpaid entitlement refunded [IRD, End-of-year assessments](https://www.ird.govt.nz/working-for-families/yearly-review-and-assessment-processes/end-of-year-assessments). If most in-year non-take-up is later recovered, the *permanently forgone* amount is far below the in-year gap — this finding estimates the gap, not the permanent loss.
+- **Year mismatch.** The take-up rate is 2020; the dollar figures are 2024.
 - **This needs an analyst with IRD/MSD microdata.** A proper estimate would use the administrative eligible-population model, not a top-down division. Flagged for someone with that access.
 
 ## Open follow-up questions
 
-- Can IRD's published family count and by-type breakdown (family tax credit vs in-work tax credit) replace the derived 328k and tighten step 1?
-- What is the average entitlement specifically among *non-beneficiary* WFF families (the group the non-claimers come from)?
+- What is the average entitlement specifically among *non-beneficiary* main-WFF families (the group the non-claimers come from)?
 - What share of in-year WFF non-take-up is recovered at the end-of-year square-up within, say, two years?
+- Does IRD publish a direct count of families by credit type that would replace the derived figures in step 1?
 
 ## Sources
 
-1. Inland Revenue, *Total entitlements paid for Working for Families tax credits* (tax statistics; 2024 tax year: $3,043m total, $9,269 average per family). https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits (accessed 5 July 2026)
-2. Ministry of Social Development (hosted on the Social Investment Agency Hub), *Estimates of Working for Families eligibility and take-up rates 2007–2020* (overall ~87%; ~100% for main-benefit families vs 75–85% for those without), published 01 Dec 2022. https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020 (accessed 5 July 2026)
-3. Ministry of Social Development (hosted on the Social Investment Agency Hub), *Estimates of take-up of the Best Start tax credit* (~96.9% take-up), published 01 Dec 2022. https://thehub.sia.govt.nz/sitemap/estimates-of-take-up-of-the-best-start-tax-credit (accessed 5 July 2026)
-4. Ministry of Social Development, *Income Support Survey — Findings Pack 7: Accommodation Supplement self-reported take-up and other findings*. https://www.msd.govt.nz/documents/about-msd-and-our-work/work-programmes/income-support-survey/findings-pack-7-accommodation-supplement-self-reported-take-up-and-other-findings.pdf (accessed 5 July 2026)
+1. Inland Revenue, *Total entitlements paid for Working for Families tax credits* (tax statistics; 2024 tax year: $3,043m total, $9,269 average per family; component split from the linked WFF statistics workbook). https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits (accessed 4 July 2026)
+2. Inland Revenue, *Working for Families statistics — technical information* (confirms WFF totals span FTC, IWTC, MFTC and Best Start). https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/working-for-families-statistics-technical-information (accessed 4 July 2026)
+3. Ministry of Social Development (hosted on the Social Investment Agency Hub), *Estimates of Working for Families eligibility and take-up rates 2007–2020* (main credits FTC/IWTC; overall ~87%; ~100% for main-benefit families vs 75–85% for those without), published 01 Dec 2022. https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020 (accessed 4 July 2026)
+4. Ministry of Social Development (hosted on the Social Investment Agency Hub), *Estimates of take-up of the Best Start tax credit* (~96.9% take-up), published 01 Dec 2022. https://thehub.sia.govt.nz/sitemap/estimates-of-take-up-of-the-best-start-tax-credit (accessed 4 July 2026)
+5. Inland Revenue, *End-of-year assessments* (WFF square-up; unpaid entitlement refunded after year end). https://www.ird.govt.nz/working-for-families/yearly-review-and-assessment-processes/end-of-year-assessments (accessed 4 July 2026)
+6. Ministry of Social Development, *Income Support Survey — Findings Pack 7: Accommodation Supplement self-reported take-up and other findings*. https://www.msd.govt.nz/documents/about-msd-and-our-work/work-programmes/income-support-survey/findings-pack-7-accommodation-supplement-self-reported-take-up-and-other-findings.pdf (accessed 4 July 2026)
 </content>

--- a/research/findings/child-welfare/dollar-value-unclaimed-entitlements.md
+++ b/research/findings/child-welfare/dollar-value-unclaimed-entitlements.md
@@ -1,0 +1,74 @@
+---
+title: "Unclaimed Working for Families is plausibly a few hundred million dollars a year — order-of-magnitude ~$200–450m, not a precise figure"
+domain: "child-welfare"
+issue: "#446"
+confidence: "Low"
+author: "muhamdasim"
+agent: "claude"
+model: "claude-opus-4-8"
+date: "2026-07-05"
+status: "draft"
+---
+
+# Unclaimed Working for Families is plausibly a few hundred million dollars a year — order-of-magnitude ~$200–450m, not a precise figure
+
+## Executive answer
+
+- **No official figure exists** for the dollar value of unclaimed child/family entitlements in NZ. This finding builds a *transparent, assumption-explicit estimate* from official IRD/MSD numbers. Treat it as an order-of-magnitude, not a measurement. **(Low confidence.)**
+- **The anchors are solid.** In the 2024 tax year, Working for Families (WFF) paid **$3,043 million** to families, averaging **$9,269 per family** — implying **≈328,000 families received it**. [IRD WFF statistics, 2024](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits) MSD estimates overall WFF take-up at **~87%**. [MSD via SIA Hub, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020)
+- **The naive calculation overstates.** 87% take-up implies ~377,000 eligible families and **~49,000 eligible non-claimers**. Multiplying by the $9,269 average gives ~$455m — but that is an **upper bound**, because non-claimers are concentrated among families *without* a main benefit (75–85% take-up vs ~100% for beneficiaries), whose entitlements are systematically **lower** (income-abated, partial). The $9,269 average is inflated by high-entitlement beneficiary families who almost all *do* claim.
+- **Best estimate: roughly $200–450 million per year.** If non-claimers' average entitlement is 40–70% of the overall average (~$3,700–$6,500), unclaimed WFF is **~$180–320m**; the full-average upper bound is ~$455m. Best Start adds little in dollar terms (take-up ~97%, so ~3% of a smaller pool). The Accommodation Supplement is **not** dollarised here (no clean administrative take-up rate; not child-specific).
+- **Crucial caveat — "unclaimed in-year" ≠ "lost forever."** WFF can be reconciled at the end-of-year square-up and back-claimed for prior years, so a meaningful share of in-year non-take-up is *later recovered*. The permanently-forgone figure is smaller than the in-year gap.
+
+**Overall confidence:** Low — the input figures (WFF total, average, take-up rate) are official, but the estimate rests on assumptions I could not verify: the average entitlement of non-claimers, mixing a 2020 take-up rate with 2024 dollars, and how much apparent non-take-up is measurement error vs real. The range spans more than 2×; it is a sizing tool, not a number to quote as fact.
+
+## Evidence
+
+### The official anchors
+
+In the 2024 tax year, WFF tax credits totalled **$3,043 million**, with an average annual payment of **$9,269 per family** (up from $8,777 in 2023). [IRD WFF statistics, 2024](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits) Dividing total by average implies **≈328,300 families** received WFF that year (IRD also publishes a direct family count, which I could not extract from the bot-protected statistics page — the derived figure should be checked against it).
+
+MSD's administrative-data study estimates **overall WFF take-up at ~87%** (2020 tax year; stable 83–90% since 2007), and — critically for this estimate — **~100% for families with main benefit income vs 75–85% for families without it**. [MSD via SIA Hub, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020)
+
+### The estimate, step by step
+
+1. **Eligible families.** If ~328,300 families receive WFF and that is 87% of the eligible pool, the eligible pool is ≈328,300 / 0.87 ≈ **377,400 families**, of whom **≈49,100 are eligible non-claimers** (13%).
+2. **Naive upper bound.** 49,100 × $9,269 ≈ **$455m**. This assumes non-claimers would each receive the *overall average* entitlement.
+3. **Why that overstates.** Non-claimers are overwhelmingly *non-beneficiary* families (beneficiary take-up is ~100%, so beneficiary families are barely in the missing group). Non-beneficiary families sit higher up the income scale where the family tax credit is **partially abated**, so their entitlements are smaller than the all-families average — which is itself pulled up by maximum-entitlement beneficiary and large families. The true average entitlement of the missing group is therefore **below $9,269**.
+4. **Plausible range.** Assuming non-claimers average **40–70%** of the overall entitlement (~$3,700–$6,500) gives **≈$180–320m**. Combined with the upper bound, the defensible order of magnitude is **~$200–450 million per year**. The 40–70% band is a judgement, not a measured figure — it is the single biggest lever on the answer.
+
+### Best Start and the Accommodation Supplement
+
+Best Start take-up is already **~96.9%** (99% for beneficiary families, 94% for others), so the unclaimed share is small — a few percent of a pool much smaller than WFF, likely **low tens of millions** at most, and I did not find a clean Best Start annual-spend figure to pin it. [MSD via SIA Hub, Best Start take-up, 2022](https://thehub.sia.govt.nz/sitemap/estimates-of-take-up-of-the-best-start-tax-credit) The Accommodation Supplement is **not** dollarised here: its 43.9% figure is self-reported receipt among survey respondents who *appeared* eligible, not an administrative take-up rate, and it is not a child-specific entitlement. [MSD Income Support Survey, Findings Pack 7](https://www.msd.govt.nz/documents/about-msd-and-our-work/work-programmes/income-support-survey/findings-pack-7-accommodation-supplement-self-reported-take-up-and-other-findings.pdf)
+
+## Surprising or load-bearing claims
+
+| Claim | Source 1 | Source 2 | Confidence |
+|---|---|---|---|
+| WFF paid $3,043m in 2024, averaging $9,269/family (⇒ ≈328k families) | [IRD WFF statistics, 2024](https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits) | Official IRD statistics — not independently corroborated here; family count is *derived*, not quoted. | Medium |
+| ~13% of eligible families (~49k) don't claim WFF, but they skew to lower entitlements | [MSD take-up ~87%, and the ~100% vs 75–85% split](https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020) | The lower-entitlement inference follows from WFF abatement design, not a measured per-family figure for non-claimers. | Low |
+| Therefore unclaimed WFF ≈ $200–450m/year | This finding's derivation (steps 1–4) | **No independent source** — this is an original order-of-magnitude estimate. Flagged as Low confidence. | Low |
+
+The dollar range is **my derivation, not an official statistic.** The two input facts (WFF totals; the 87% / benefit-split take-up) are officially sourced; the combination and the 40–70% assumption are mine and are the reason the headline is Low confidence.
+
+## What would change this conclusion
+
+- **A measured average entitlement for non-claimers.** This is the dominant uncertainty. If IRD/MSD modelled the entitlement of the eligible-but-not-receiving group, the range would tighten dramatically (and probably move toward the lower half).
+- **How much of the 13% is measurement error.** MSD itself flags that low estimated take-up can partly reflect data-linkage error or income not captured in admin data. If a large share of the "missing" families aren't truly eligible, the dollar figure falls.
+- **Back-claiming behaviour.** WFF can be squared up at year end and claimed retrospectively (up to prior years). If most in-year non-take-up is later recovered, the *permanently forgone* amount is far below the in-year gap — this finding estimates the gap, not the permanent loss.
+- **Year mismatch.** The take-up rate is 2020; the dollar figures are 2024. A current take-up estimate could move the family counts.
+- **This needs an analyst with IRD/MSD microdata.** A proper estimate would use the administrative eligible-population model, not a top-down division. Flagged for someone with that access.
+
+## Open follow-up questions
+
+- Can IRD's published family count and by-type breakdown (family tax credit vs in-work tax credit) replace the derived 328k and tighten step 1?
+- What is the average entitlement specifically among *non-beneficiary* WFF families (the group the non-claimers come from)?
+- What share of in-year WFF non-take-up is recovered at the end-of-year square-up within, say, two years?
+
+## Sources
+
+1. Inland Revenue, *Total entitlements paid for Working for Families tax credits* (tax statistics; 2024 tax year: $3,043m total, $9,269 average per family). https://www.ird.govt.nz/about-us/tax-statistics/social-policy/working-for-families-statistics/total-entitlements-paid-for-working-for-families-tax-credits (accessed 5 July 2026)
+2. Ministry of Social Development (hosted on the Social Investment Agency Hub), *Estimates of Working for Families eligibility and take-up rates 2007–2020* (overall ~87%; ~100% for main-benefit families vs 75–85% for those without), published 01 Dec 2022. https://thehub.sia.govt.nz/sitemap/estimates-of-working-for-families-eligibility-and-take-up-rates-2007-2020 (accessed 5 July 2026)
+3. Ministry of Social Development (hosted on the Social Investment Agency Hub), *Estimates of take-up of the Best Start tax credit* (~96.9% take-up), published 01 Dec 2022. https://thehub.sia.govt.nz/sitemap/estimates-of-take-up-of-the-best-start-tax-credit (accessed 5 July 2026)
+4. Ministry of Social Development, *Income Support Survey — Findings Pack 7: Accommodation Supplement self-reported take-up and other findings*. https://www.msd.govt.nz/documents/about-msd-and-our-work/work-programmes/income-support-survey/findings-pack-7-accommodation-supplement-self-reported-take-up-and-other-findings.pdf (accessed 5 July 2026)
+</content>

--- a/research/findings/child-welfare/dollar-value-unclaimed-entitlements.md
+++ b/research/findings/child-welfare/dollar-value-unclaimed-entitlements.md
@@ -77,4 +77,3 @@ The dollar range is **my derivation, not an official statistic.** The input fact
 4. Ministry of Social Development (hosted on the Social Investment Agency Hub), *Estimates of take-up of the Best Start tax credit* (~96.9% take-up), published 01 Dec 2022. https://thehub.sia.govt.nz/sitemap/estimates-of-take-up-of-the-best-start-tax-credit (accessed 4 July 2026)
 5. Inland Revenue, *End-of-year assessments* (WFF square-up; unpaid entitlement refunded after year end). https://www.ird.govt.nz/working-for-families/yearly-review-and-assessment-processes/end-of-year-assessments (accessed 4 July 2026)
 6. Ministry of Social Development, *Income Support Survey — Findings Pack 7: Accommodation Supplement self-reported take-up and other findings*. https://www.msd.govt.nz/documents/about-msd-and-our-work/work-programmes/income-support-survey/findings-pack-7-accommodation-supplement-self-reported-take-up-and-other-findings.pdf (accessed 4 July 2026)
-</content>


### PR DESCRIPTION
Closes #446. Part of #4. Stream: #4.

**Stage:** Research (child-welfare, stream #4). Follow-up flagged by PR #94 — puts a dollar figure on the take-up gap to size the prize.

## Headline
No official figure exists, so this is a **transparent, assumption-explicit order-of-magnitude estimate** from official IRD/MSD numbers: unclaimed Working for Families is **plausibly ~$200–450 million/year**. Marked **Low confidence** — a sizing tool, not a number to quote as fact.

## Why it's honest, not hand-wavy
- **Solid anchors:** WFF 2024 = $3,043m total, $9,269 avg/family (⇒ ≈328k families) [IRD]; take-up ~87% [MSD].
- **Names its own overstatement:** the naive 49k missed × $9,269 = ~$455m is only an *upper bound*, because non-claimers skew to non-benefit families with *lower* (abated) entitlements. Best estimate uses a 40–70%-of-average band and flags that band as the single biggest lever.
- **Sharp caveat:** WFF can be back-claimed at the year-end square-up, so *in-year unclaimed ≠ permanently forgone* — the permanent loss is smaller.
- Best Start gap is small (~97% take-up); Accommodation Supplement deliberately **not** dollarised (self-report, not child-specific).

## Method / rigour
- Every input figure cited; the derivation and the 40–70% assumption are explicitly flagged as *mine*, not official.
- 'What would change this' calls out the dominant uncertainties (non-claimer avg entitlement, measurement error, back-claiming, 2020-vs-2024 year mismatch) and flags that a proper estimate needs an analyst with IRD/MSD microdata.
- No personal data. `npm run validate` passes.

Deliberately conservative and clearly bounded — the value is giving the stream a defensible sense of scale, with the uncertainty laid bare.