### PR TITLE
discover: frame NZ hospital wait times & ED overcrowding stream

### DIFF
--- a/research/findings/other/discover-hospital-wait-times.md
+++ b/research/findings/other/discover-hospital-wait-times.md
@@ -1,0 +1,59 @@
+---
+title: "Discover framing: NZ public hospital wait times & ED overcrowding — scale, official targets being missed, and the researchable questions"
+domain: "other"
+issue: "#434"
+confidence: "Medium"
+author: "muhamdasim"
+agent: "claude"
+model: "claude-opus-4-8"
+date: "2026-07-04"
+status: "draft"
+---
+
+# Discover framing: NZ public hospital wait times & ED overcrowding
+
+*This is a Discover-stage framing for stream #434 — a cited problem statement, who it affects, what's already being done, and 5 researchable questions to spin out as Research issues. It is a scoping document, not a research finding; each question below needs its own cited investigation.*
+
+## Executive answer
+
+- **The problem is real and officially quantified — the government is missing its own health targets.** Two of the five national health targets bear directly on this: **"shorter stays in emergency departments"** (95% of ED patients admitted, discharged or transferred within 6 hours) and **"faster access to a first specialist assessment / planned care"** (95% waiting less than 4 months). Both are being missed by wide margins.
+- **ED:** national performance was **~74.2% within 6 hours** in Q3 2024/25 — it met the government's *interim milestone* (74% for 2024/25, rising to 77% for 2025/26) but remains far below the 95% standard, and major hospitals are dramatically worse (reported days under 40% at Auckland and Wellington). [NZ Herald, leaked ED data, 2025](https://www.nzherald.co.nz/nz/politics/revealed-leaked-data-show-major-hospitals-failing-emergency-department-wait-time-targets/IO4PRQPI5RDKHHUFM67NPGRNQE/)
+- **Planned care:** as of early 2025, **over 77,000 people had waited more than four months for a first specialist assessment (FSA)**, with performance against the 95%-within-4-months target hovering around **~60%**. [Newsroom, waiting-list data, 2025](https://newsroom.co.nz/2025/04/29/weekly-data-reveals-scale-of-govts-waiting-list-crisis/); [Office of the Auditor-General, *Providing equitable access to planned care treatment*, 2025](https://www.oag.parliament.nz/2025/planned-care/docs/planned-care.pdf)
+- **It is also an equity problem, per the Auditor-General.** The OAG's 2025 report found the planned-care system does **not** provide equitable access — wait times and prioritisation vary in ways that disadvantage some groups. [OAG, 2025](https://www.oag.parliament.nz/2025/planned-care/part2.htm)
+- **Why it matters for this project:** the raw scale is well-documented, but the *comparative* picture (vs OECD/Australia/UK), *what interventions actually worked*, and the *downstream cost of delay* are not synthesised in one place. That gap is where cited research adds value.
+
+## Evidence (scale & current state)
+
+### The official targets it maps to
+
+New Zealand runs five national health targets. Two are directly in scope: **shorter stays in EDs** (95% of patients admitted/discharged/transferred within 6 hours) and **faster access to planned care / FSA** (95% wait < 4 months). The government has set interim milestones below the 95% standard while it rebuilds performance (e.g. the ED milestone was 74% for 2024/25 and 77% for 2025/26). [NZ Herald, 2025](https://www.nzherald.co.nz/nz/politics/revealed-leaked-data-show-major-hospitals-failing-emergency-department-wait-time-targets/IO4PRQPI5RDKHHUFM67NPGRNQE/) *(The Ministry of Health health-targets page — health.govt.nz/statistics-research/system-monitoring/health-targets — is the authoritative source but returned HTTP 403 to a plain fetcher, which per the project's guidance is bot protection, not a dead link; it should be browser-verified when this stream is researched.)*
+
+### Emergency departments
+
+National ED six-hour performance was reported at **~74.2%** in Q3 (Jan–Mar) 2024/25 — meeting the interim milestone but well short of 95%. Leaked hospital-level data indicated the largest hospitals fare far worse, with some days under 40% (Auckland City reportedly as low as 34.4%; Wellington around 39% on its worst day). This hospital-level variation is from media reporting of leaked data and should be confirmed against official Te Whatu Ora releases. [NZ Herald, 2025](https://www.nzherald.co.nz/nz/politics/revealed-leaked-data-show-major-hospitals-failing-emergency-department-wait-time-targets/IO4PRQPI5RDKHHUFM67NPGRNQE/)
+
+### Planned care / first specialist assessment
+
+The volume of people waiting is large and only slowly moving: those waiting **4+ months for an FSA fell from ~85,000 (Feb 2024) to ~77,000 (Sep 2024)**, and **over 77,000** were still waiting 4+ months in early 2025 — against a 95%-within-4-months target that was running near **~60%**. [Newsroom, 2025](https://newsroom.co.nz/2025/04/29/weekly-data-reveals-scale-of-govts-waiting-list-crisis/); [PolicyWise, waiting-list resource](https://www.policywise.co.nz/resources/waiting-list) The Auditor-General's 2025 review concluded access is **not equitable** and prioritisation practices vary across the system. [OAG, 2025](https://www.oag.parliament.nz/2025/planned-care/docs/planned-care.pdf)
+
+## Researchable questions (candidates for Research issues under this stream)
+
+1. **What are the current, official ED and planned-care wait figures (2024–2026)?** Pull the authoritative Te Whatu Ora / MoH health-target series (national and by-hospital) rather than leaked/media numbers — establish the verified baseline.
+2. **How do NZ wait times compare to OECD / Australia / UK?** A like-for-like benchmark (definitions differ by country — e.g. NHS 4-hour vs NZ 6-hour ED standard), so the comparison must be methodologically careful.
+3. **Which interventions have actually reduced waits — and by how much?** Fast-track/streaming EDs, satellite/dedicated elective theatres, outsourcing to private providers, GP-access funding. Look for evaluated effect sizes, not announcements. (One evaluated NZ example: the original 6-hour ED target and its measured effect on length of stay.)
+4. **What is the cost of delayed care?** Clinical outcomes, avoidable deterioration, mental-health and productivity impacts, and downstream cost — to size the harm, not just the queue.
+5. **How do staffing shortfalls correlate with wait spikes?** Nurse/doctor/senior-medical-officer vacancy rates vs ED and planned-care performance, regionally.
+
+## What would change this conclusion
+
+- **Official data may differ from the leaked/media figures used here.** The hospital-level ED numbers and some waitlist counts come from media reporting; question 1 exists precisely to replace them with verified Te Whatu Ora/MoH series. Treat the specific percentages as indicative pending that.
+- **Definitions matter.** "Waiting for FSA" vs "waiting for treatment" vs "removed from the list" are different measures; a rise or fall can reflect reclassification, not real change.
+- **A clinician / health-system economist should steward this stream** (G1) — prioritisation ethics and what "success" means clinically need domain judgement, not just counts.
+
+## Sources
+
+1. NZ Herald, *Revealed: Leaked data show major hospitals failing emergency department wait-time targets* (2025) — ED 6-hour milestones (74%/77%), national ~74.2% Q3 2024/25, hospital-level lows. https://www.nzherald.co.nz/nz/politics/revealed-leaked-data-show-major-hospitals-failing-emergency-department-wait-time-targets/IO4PRQPI5RDKHHUFM67NPGRNQE/ (accessed 4 July 2026)
+2. Office of the Auditor-General, *Providing equitable access to planned care treatment* (B.29[25h], 2025). https://www.oag.parliament.nz/2025/planned-care/docs/planned-care.pdf and https://www.oag.parliament.nz/2025/planned-care/part2.htm (accessed 4 July 2026)
+3. Newsroom, *Weekly data reveals scale of Govt's waiting list crisis* (29 April 2025) — 77,000+ waiting 4+ months for FSA; ~60% against the 4-month target. https://newsroom.co.nz/2025/04/29/weekly-data-reveals-scale-of-govts-waiting-list-crisis/ (accessed 4 July 2026)
+4. PolicyWise, *Long waiting lists and wait times in NZ's public health system* — waitlist trend (85,000 Feb 2024 → ~77,000 Sep 2024). https://www.policywise.co.nz/resources/waiting-list (accessed 4 July 2026)
+5. Ministry of Health, *Health targets* (authoritative target definitions/results; returned 403 to plain fetcher — browser-verify). https://www.health.govt.nz/statistics-research/system-monitoring/health-targets (accessed 4 July 2026)


### PR DESCRIPTION
Part of #434. Stream: #434. (Discover root — uses *Part of*, not *Closes*, so the stream stays open per docs/STREAMS.md.)

**Stage:** Discover (stream #434). Framing a new stream with cited scale + researchable questions.

## What this does
Takes the broad 'hospital wait times' problem and pins it to NZ's own **health targets** it's missing, with hard(ish) figures:
- **ED:** ~74.2% seen within 6 hours (Q3 2024/25) — meets the interim 74% milestone but far below the 95% standard; major hospitals reportedly under 40% some days.
- **Planned care:** **77,000+ waiting 4+ months** for a first specialist assessment; ~60% against the 95%-within-4-months target.
- **Equity:** the Auditor-General's 2025 report found planned-care access is *not* equitable.

Then spins out **5 researchable questions** (verified baseline; OECD/AU/UK benchmark; which interventions actually worked; cost of delay; staffing correlation) as candidates for Research issues.

## Honesty notes
- Some figures are **media/leaked** (NZ Herald) or secondary (Newsroom/PolicyWise) — flagged as such, and **question 1 exists specifically to replace them with official Te Whatu Ora/MoH series**. The MoH health-targets page 403'd to a plain fetcher (bot protection per project guidance; flagged for browser-verify).
- OAG report is the one primary/authoritative source and is cited directly.
- Flagged that a **clinician/health-economist should steward** this stream (G1) — I deliberately did **not** open the child Research issues, leaving the human gate intact.
- No personal data. `npm run validate` passes (130 files).