### PR TITLE
feat: live worker telemetry round 2 — re-land stranded #552 commits + honest TPS + chart tooltip

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,13 @@
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [ { "type": "command", "command": "node server/clients/codex-hook.mjs", "statusMessage": "fleet hello" } ] }
+    ],
+    "PostToolUse": [
+      { "hooks": [ { "type": "command", "command": "node server/clients/codex-hook.mjs", "statusMessage": "fleet heartbeat" } ] }
+    ],
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "node server/clients/codex-hook.mjs", "statusMessage": "fleet tokens" } ] }
+    ]
+  }
+}

--- a/scripts/claude-json-telemetry.py
+++ b/scripts/claude-json-telemetry.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Bridge `claude -p --output-format stream-json` into human logs + live fleet
+telemetry.
+
+Plain `claude -p` buffers everything and prints only the final result — a
+worker looks hung for the whole run ("Handing #NNN to claude…" then silence)
+and reports nothing. The stream-json feed emits every assistant message and
+tool use as it happens, WITH per-message token usage — so this filter renders
+readable progress lines and posts live tool/token telemetry to the fleet
+server (issue #398), no transcript tailing needed.
+
+Symmetric with scripts/codex-json-telemetry.py; wired by run_agent in
+scripts/fg-common.sh whenever FLEET_SERVER is set.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import time
+from pathlib import Path
+from typing import Any
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+FLEET_SERVER = env("FLEET_SERVER").rstrip("/")
+AGENT_ID_FILE = env("FLEET_AGENT_ID_FILE")
+HANDLE = env("FLEET_HANDLE") or env("HANDLE") or env("USER") or "unknown"
+HARNESS = env("AGENT") or "claude"
+MODEL = env("FLEET_MODEL") or env("MODEL") or "claude"
+TASK_KIND = env("FLEET_TASK_KIND") or "work"
+TASK_REF = env("TASK_REF")
+TASK_TITLE = env("TASK_TITLE") or "claude turn"
+STREAM_LOGS = env("STREAM_LOGS") == "1"
+# Cloudflare's bot protection 403s default client user-agents on the
+# tunnelled fleet server — an honest custom UA passes.
+USER_AGENT = "forgood-fleet-telemetry/1.0 (+https://github.com/thecolab-ai/the-for-good-project)"
+
+_last_post_mono = time.monotonic()
+
+
+def read_agent_id() -> str:
+    if not AGENT_ID_FILE:
+        return ""
+    try:
+        return Path(AGENT_ID_FILE).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def write_agent_id(agent_id: str) -> None:
+    if not AGENT_ID_FILE or not agent_id:
+        return
+    try:
+        Path(AGENT_ID_FILE).write_text(agent_id, encoding="utf-8")
+    except OSError:
+        pass
+
+
+def post_telemetry(heartbeat: dict[str, Any]) -> None:
+    if not FLEET_SERVER:
+        return
+    numeric_total = sum(int(v or 0) for v in heartbeat.values() if isinstance(v, int))
+    if numeric_total == 0 and not heartbeat.get("tools"):
+        return
+    body: dict[str, Any] = {
+        "handle": HANDLE,
+        "harness": HARNESS,
+        "model": MODEL,
+        "version": "claude-json-telemetry",
+        "task": {"kind": TASK_KIND},
+        "heartbeat": heartbeat,
+    }
+    if TASK_REF:
+        body["task"]["ref"] = TASK_REF[:32]
+    if TASK_TITLE:
+        body["task"]["title"] = TASK_TITLE[:300]
+    agent_id = read_agent_id()
+    if agent_id:
+        body["agentId"] = agent_id
+    data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    req = urllib.request.Request(
+        f"{FLEET_SERVER}/api/v1/telemetry",
+        data=data,
+        headers={"content-type": "application/json", "user-agent": USER_AGENT},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+            if isinstance(payload, dict) and isinstance(payload.get("agentId"), str):
+                write_agent_id(payload["agentId"])
+    except (OSError, urllib.error.URLError, json.JSONDecodeError):
+        return  # telemetry must never break a worker
+
+
+def post_logs(lines: list[str]) -> None:
+    if not FLEET_SERVER or not STREAM_LOGS or not lines:
+        return
+    agent_id = read_agent_id()
+    if not agent_id:
+        return
+    data = json.dumps(
+        {"agentId": agent_id, "lines": [line[:2000] for line in lines[-20:]]},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{FLEET_SERVER}/api/v1/logs",
+        data=data,
+        headers={"content-type": "application/json", "user-agent": USER_AGENT},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=3).close()
+    except (OSError, urllib.error.URLError):
+        return
+
+
+def post_tokens(tokens_in: int, tokens_out: int) -> None:
+    """Per-message usage deltas with real elapsed wall time, so the TPS gauge
+    reflects an actual rate. Cache reads are excluded by the caller."""
+    global _last_post_mono
+    if tokens_in <= 0 and tokens_out <= 0:
+        return
+    now = time.monotonic()
+    elapsed_ms = max(1, int((now - _last_post_mono) * 1000))
+    _last_post_mono = now
+    post_telemetry({"tokensIn": tokens_in, "tokensOut": tokens_out, "elapsedMs": elapsed_ms})
+
+
+def handle_assistant(message: dict[str, Any]) -> None:
+    lines: list[str] = []
+    for block in message.get("content") or []:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text" and str(block.get("text") or "").strip():
+            text = str(block["text"])
+            print(text, flush=True)
+            lines.extend(line for line in text.splitlines() if line.strip())
+        elif block.get("type") == "tool_use":
+            name = str(block.get("name") or "unknown")[:64]
+            detail = ""
+            tool_input = block.get("input")
+            if isinstance(tool_input, dict):
+                detail = str(tool_input.get("command") or tool_input.get("url") or tool_input.get("query") or "")[:120]
+            line = f"[claude tool] {name}{': ' + detail if detail else ''}"
+            print(line, flush=True)
+            lines.append(line)
+            post_telemetry({"toolCalls": 1, "tools": {name: 1}})
+    usage = message.get("usage")
+    if isinstance(usage, dict):
+        # Cache reads excluded — fresh input + cache writes + output only,
+        # matching the claude-code hook client and the dashboard's meaning of
+        # "intelligence at work".
+        tokens_in = int(usage.get("input_tokens") or 0) + int(usage.get("cache_creation_input_tokens") or 0)
+        tokens_out = int(usage.get("output_tokens") or 0)
+        post_tokens(tokens_in, tokens_out)
+    post_logs(lines)
+
+
+def main() -> int:
+    global MODEL
+    for raw in sys.stdin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            print(raw, flush=True)
+            continue
+        typ = event.get("type")
+        if typ == "system" and event.get("subtype") == "init":
+            if event.get("model"):
+                MODEL = str(event["model"])
+            print(f"[claude session] model={MODEL} session={event.get('session_id', '')[:8]}", flush=True)
+        elif typ == "assistant" and isinstance(event.get("message"), dict):
+            handle_assistant(event["message"])
+        elif typ == "result":
+            cost = event.get("total_cost_usd")
+            print(
+                f"[claude result] {event.get('subtype', '')} turns={event.get('num_turns', '?')}"
+                f"{f' cost=${cost:.4f}' if isinstance(cost, (int, float)) else ''}",
+                flush=True,
+            )
+            text = str(event.get("result") or "")
+            if text.strip() and event.get("is_error"):
+                print(text, flush=True)
+        elif typ == "error":
+            print(f"[claude error] {event.get('message') or event}", file=sys.stderr, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex-json-telemetry.py
+++ b/scripts/codex-json-telemetry.py
@@ -7,9 +7,11 @@ runner output readable while sending those usage deltas to the fleet server.
 """
 from __future__ import annotations
 
+import glob
 import json
 import os
 import sys
+import threading
 import urllib.error
 import urllib.request
 import time
@@ -34,9 +36,128 @@ STREAM_LOGS = env("STREAM_LOGS") == "1"
 # passes), silently eating every token post to the tunnelled fleet server —
 # any honest custom UA gets through.
 USER_AGENT = "forgood-fleet-telemetry/1.0 (+https://github.com/thecolab-ai/the-for-good-project)"
+
+
+def hooks_own_telemetry() -> bool:
+    """True when the codex fleet hook (server/clients/codex-hook.mjs) is wired
+    into the Codex config — it then owns token/tool telemetry (with live
+    mid-run deltas from the transcript), and this bridge must not double-post.
+    The bridge keeps printing human-readable output and streaming logs.
+    Override with FG_CODEX_BRIDGE_TELEMETRY=1 to force bridge posts anyway."""
+    if env("FG_CODEX_BRIDGE_TELEMETRY") == "1":
+        return False
+    codex_home = Path(env("CODEX_HOME") or Path.home() / ".codex")
+    for cfg in (
+        codex_home / "hooks.json",
+        codex_home / "config.toml",
+        Path.cwd() / ".codex" / "hooks.json",
+        Path.cwd() / ".codex" / "config.toml",
+    ):
+        try:
+            if "codex-hook.mjs" in cfg.read_text(encoding="utf-8"):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+HOOKS_OWN_TELEMETRY = hooks_own_telemetry()
 START_MONO = time.monotonic()
-last_usage_total = 0
-last_usage_mono = START_MONO
+
+# ---------------------------------------------------------------------------
+# Live token streaming. The exec --json stream only reports usage at
+# turn.completed — for a 30-minute run that is one burst every 30 minutes and
+# the dashboard reads "no tokens flowing". But Codex continuously appends
+# cumulative `token_count` events to its rollout transcript, so a background
+# poller tails the transcript (located from `thread.started`'s thread id) and
+# posts token DELTAS every few seconds — a real live feed.
+
+TRANSCRIPT_POLL_S = float(env("FG_TOKEN_POLL_SECONDS") or 5)
+_cum_lock = threading.Lock()
+_cum_in = 0  # fresh input (input - cached) already posted
+_cum_out = 0
+_last_post_mono = START_MONO
+_transcript_path: str | None = None
+_transcript_offset = 0
+_thread_id = ""
+
+
+def _find_transcript() -> str | None:
+    global _transcript_path
+    if _transcript_path or not _thread_id:
+        return _transcript_path
+    home = env("CODEX_HOME") or str(Path.home() / ".codex")
+    hits = glob.glob(f"{home}/sessions/*/*/*/rollout-*-{_thread_id}.jsonl")
+    if hits:
+        _transcript_path = max(hits)
+    return _transcript_path
+
+
+def _post_cumulative(fresh_in: int, out_tok: int) -> None:
+    """Post only the movement since the last post, with real elapsed wall
+    time so the fleet TPS gauge reflects an actual rate."""
+    global _cum_in, _cum_out, _last_post_mono
+    with _cum_lock:
+        d_in = max(0, fresh_in - _cum_in)
+        d_out = max(0, out_tok - _cum_out)
+        if d_in == 0 and d_out == 0:
+            return
+        _cum_in = max(_cum_in, fresh_in)
+        _cum_out = max(_cum_out, out_tok)
+        now = time.monotonic()
+        elapsed_ms = max(1, int((now - _last_post_mono) * 1000))
+        _last_post_mono = now
+    post_telemetry({"tokensIn": d_in, "tokensOut": d_out, "elapsedMs": elapsed_ms})
+
+
+def _read_transcript_once() -> None:
+    global _transcript_offset
+    path = _find_transcript()
+    if not path:
+        return
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            f.seek(_transcript_offset)
+            chunk = f.read()
+            end = f.tell()
+    except OSError:
+        return
+    # Never consume a partial trailing line — the writer may be mid-append.
+    nl = chunk.rfind("\n")
+    if nl < 0:
+        return
+    _transcript_offset = end - (len(chunk) - nl - 1)
+    latest = None
+    for line in chunk[: nl + 1].splitlines():
+        if '"token_count"' not in line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        usage = ((obj.get("payload") or {}).get("info") or {}).get("total_token_usage")
+        if isinstance(usage, dict):
+            latest = usage
+    if latest:
+        fresh = max(0, int(latest.get("input_tokens") or 0) - int(latest.get("cached_input_tokens") or 0))
+        _post_cumulative(fresh, int(latest.get("output_tokens") or 0))
+
+
+def _transcript_poller() -> None:
+    while True:
+        time.sleep(TRANSCRIPT_POLL_S)
+        try:
+            _read_transcript_once()
+        except Exception:  # noqa: BLE001 — telemetry must never kill the pipe
+            pass
+
+
+def start_token_stream(thread_id: str) -> None:
+    global _thread_id
+    if not thread_id or _thread_id:
+        return
+    _thread_id = thread_id
+    threading.Thread(target=_transcript_poller, daemon=True, name="fg-token-poll").start()
 
 
 def read_agent_id() -> str:
@@ -58,7 +179,7 @@ def write_agent_id(agent_id: str) -> None:
 
 
 def post_telemetry(heartbeat: dict[str, Any]) -> None:
-    if not FLEET_SERVER:
+    if not FLEET_SERVER or HOOKS_OWN_TELEMETRY:
         return
     # Only send a heartbeat when there is real movement. This prevents no-op
     # malformed events from refreshing presence as fake activity.
@@ -168,34 +289,22 @@ def main() -> int:
             continue
 
         typ = event.get("type")
-        if typ == "item.completed" and isinstance(event.get("item"), dict):
+        if typ == "thread.started":
+            start_token_stream(str(event.get("thread_id") or ""))
+        elif typ == "item.completed" and isinstance(event.get("item"), dict):
             post_logs(print_item(event["item"]))
         elif typ == "turn.completed" and isinstance(event.get("usage"), dict):
-            global last_usage_total, last_usage_mono
+            # Same cumulative ledger as the transcript poller, so the two
+            # sources can never double-count — this just settles any tail the
+            # last poll hadn't seen yet.
             usage = event["usage"]
             ti = int(usage.get("input_tokens") or 0)
             to = int(usage.get("output_tokens") or 0)
             cached = int(usage.get("cached_input_tokens") or 0)
             reasoning = int(usage.get("reasoning_output_tokens") or 0)
-            total = ti + to
-            now = time.monotonic()
-            elapsed_ms = max(1, int((now - last_usage_mono) * 1000))
-            delta_total = max(0, total - last_usage_total)
-            if delta_total > 0:
-                # Codex reports cumulative turn/session usage. Send only the
-                # new token delta and the elapsed wall time since the previous
-                # usage sample, otherwise the fleet dashboard treats the whole
-                # run as a one-minute burst and prints silly TPS.
-                if total > 0:
-                    delta_in = max(0, round(delta_total * (ti / total)))
-                else:
-                    delta_in = 0
-                delta_out = max(0, delta_total - delta_in)
-                post_telemetry({"tokensIn": delta_in, "tokensOut": delta_out, "elapsedMs": elapsed_ms})
-            last_usage_total = max(last_usage_total, total)
-            last_usage_mono = now
+            _post_cumulative(max(0, ti - cached), to)
             print(
-                f"[codex usage] total_input={ti} cached={cached} total_output={to} reasoning={reasoning} delta={delta_total} elapsed_ms={elapsed_ms}",
+                f"[codex usage] total_input={ti} cached={cached} total_output={to} reasoning={reasoning}",
                 flush=True,
             )
         elif typ == "error":

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -453,21 +453,46 @@ run_agent() {
   fi
   case "$AGENT" in
     codex)
+      # The repo ships its own Codex hooks (.codex/config.toml -> the fleet
+      # telemetry client, ADR-0016). Codex skips non-trusted hooks silently in
+      # exec mode, and trust can only be persisted interactively — so pass the
+      # automation bypass, exactly its documented purpose ("automation that
+      # already vets hook sources": these hooks are versioned in this repo and
+      # the runner already uses --dangerously-bypass-approvals-and-sandbox).
+      # Only passed when the checkout actually carries the repo hook config.
+      local hook_trust=""
+      [ -f "$dir/.codex/hooks.json" ] && hook_trust="--dangerously-bypass-hook-trust"
       if [ -n "${FLEET_SERVER:-}" ] && [ "${CODEX_JSON_TELEMETRY:-1}" = 1 ]; then
-        $tmo codex exec --json --cd "$dir" --skip-git-repo-check \
+        $tmo codex exec --json --cd "$dir" --skip-git-repo-check $hook_trust \
           ${CODEX_FLAGS:---dangerously-bypass-approvals-and-sandbox} \
           ${MODEL:+-m "$MODEL"} "$prompt" \
           | python3 "$REPO_DIR/scripts/codex-json-telemetry.py"
       else
-        $tmo codex exec --cd "$dir" --skip-git-repo-check \
+        $tmo codex exec --cd "$dir" --skip-git-repo-check $hook_trust \
           ${CODEX_FLAGS:---dangerously-bypass-approvals-and-sandbox} \
           ${MODEL:+-m "$MODEL"} "$prompt"
       fi
       ;;
     claude)
-      ( cd "$dir" && $tmo claude -p "$prompt" \
-        --permission-mode "${CLAUDE_PERMISSION_MODE:-bypassPermissions}" \
-        ${MODEL:+--model "$MODEL"} )
+      # Default the fleet's claude runs to sonnet (maintainer call,
+      # 2026-07-05: sonnet for testing) — override with --model / MODEL.
+      local claude_model="${MODEL:-sonnet}"
+      if [ -n "${FLEET_SERVER:-}" ] && [ "${CLAUDE_JSON_TELEMETRY:-1}" = 1 ]; then
+        # stream-json (requires --verbose) emits every assistant message and
+        # tool use as it happens WITH per-message token usage — the bridge
+        # renders readable progress and posts live tool/token telemetry.
+        # Plain -p prints nothing until the very end, so a worker looked hung
+        # for the whole run and reported nothing.
+        ( cd "$dir" && $tmo claude -p "$prompt" \
+          --permission-mode "${CLAUDE_PERMISSION_MODE:-bypassPermissions}" \
+          --model "$claude_model" \
+          --output-format stream-json --verbose ) \
+          | python3 "$REPO_DIR/scripts/claude-json-telemetry.py"
+      else
+        ( cd "$dir" && $tmo claude -p "$prompt" \
+          --permission-mode "${CLAUDE_PERMISSION_MODE:-bypassPermissions}" \
+          --model "$claude_model" )
+      fi
       ;;
     hermes)
       ( cd "$dir" && $tmo hermes ${HERMES_PROFILE:+--profile "$HERMES_PROFILE"} chat -Q \

--- a/server/README.md
+++ b/server/README.md
@@ -103,13 +103,9 @@ FLEET_SERVER=http://host:8787 FLEET_HANDLE=<you> claude
 
 Hook events → telemetry: `SessionStart` → hello/presence (model id from the payload); `PostToolUse` → tool-call counts by tool + WebFetch/WebSearch ok/error; `Stop` → token deltas parsed from the session transcript (cache reads excluded so the TPS gauge reflects fresh work) and, when opted in, a redacted excerpt of the assistant's latest message; `SessionEnd` → goodbye. Note the transcript format is internal to Claude Code and can change between versions — the parser fails soft to zero deltas if it does.
 
-**Codex** — point Codex's notify hook at the bridge in `~/.codex/config.toml`:
+**Codex** (codex-cli ≥ 0.142) — the repo ships hook wiring in [`.codex/hooks.json`](../.codex/hooks.json) → [`clients/codex-hook.mjs`](clients/codex-hook.mjs), which applies to any Codex session working in a checkout/worktree of this repo. Hook payloads carry no token usage, so the client parses Codex's rollout transcript incrementally: `SessionStart` → hello/presence; `PostToolUse` → tool counts **plus live token deltas mid-run** (cache reads excluded); `Stop` → remaining deltas and, only with `STREAM_LOGS=1`, a redacted excerpt of the last agent message. Codex gates non-managed hooks behind an interactive trust review, so the runners pass `--dangerously-bypass-hook-trust` (its documented automation use; the hooks are versioned in this repo). The hook activates only for For Good work — an explicit `FLEET_SERVER`, or a cwd that is a For Good checkout — never for unrelated projects on the same machine.
 
-```toml
-notify = ["node", "/path/to/the-for-good-project/server/clients/codex-notify.mjs"]
-```
-
-Codex only fires notify per completed turn, so its telemetry is coarser (presence + heartbeat + opt-in excerpt of the last assistant message; no per-tool or token counts). Set `FLEET_SERVER`, `FLEET_HANDLE`, `FLEET_MODEL` in the environment Codex runs in.
+Older setups: `notify = ["node", ".../clients/codex-notify.mjs"]` in `~/.codex/config.toml` still works but is turn-level only (no per-tool or token telemetry). The `codex exec --json` bridge (`scripts/codex-json-telemetry.py`) remains for runner log streaming/readable output and yields telemetry posting to the hook client automatically when the hook wiring is present.
 
 **Log ingestion endpoint:** hook processes are one-shot, so they POST `{agentId, lines}` to `/api/v1/logs` instead of holding a WebSocket; it 403s unless the server runs with `ALLOW_LOG_STREAM=1`.
 

--- a/server/clients/codex-hook.mjs
+++ b/server/clients/codex-hook.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Codex -> fleet server bridge, wired via Codex's hooks system
+ * (https://developers.openai.com/codex/hooks; needs codex-cli >= 0.142).
+ * One script handles every event; the repo ships the wiring in
+ * .codex/hooks.json (SessionStart, PostToolUse, Stop), which applies to any
+ * Codex session working in a checkout/worktree of this repo. Codex gates
+ * non-managed hooks behind an interactive trust review, so the runners pass
+ * --dangerously-bypass-hook-trust (see run_agent in scripts/fg-common.sh).
+ *
+ * Hook payloads deliberately carry NO token usage — but they do carry
+ * `transcript_path`, and Codex's rollout transcript records cumulative
+ * `token_count` events. So this client parses the transcript incrementally
+ * (like claude-code-hook.mjs does) and posts token DELTAS — which, on
+ * PostToolUse, means live tokens/TPS DURING a long run, something the
+ * `codex exec --json` stream can't provide (usage arrives only at turn end).
+ *
+ * What it sends (issue #398 Phase 1 telemetry):
+ *  - SessionStart -> hello (presence: handle, harness, model)
+ *  - PostToolUse  -> heartbeat: +1 tool call (per-tool breakdown) + any new
+ *                    token deltas from the transcript
+ *  - Stop         -> heartbeat: remaining token deltas; plus — ONLY when
+ *                    STREAM_LOGS=1 — a small redacted excerpt of the last
+ *                    agent message
+ *
+ * Installing this hook IS the telemetry opt-in, so FLEET_SERVER defaults to
+ * the project's mission-control server; set FLEET_SERVER="" to disable, or
+ * point it elsewhere. Never blocks the session: short timeouts, every
+ * failure swallowed, always exits 0. Log streaming stays a SEPARATE opt-in
+ * (STREAM_LOGS=1), redacted client-side and again server-side.
+ */
+const { readFileSync, existsSync } = await import("node:fs");
+
+let payload = {};
+try {
+  payload = JSON.parse(readFileSync(0, "utf8"));
+} catch {
+  process.exit(0);
+}
+
+// Scope the default-on behaviour to For Good work: honour an explicit
+// FLEET_SERVER (autopilot exports it to its codex children; ""=off), and
+// otherwise default to mission control ONLY when the session's cwd is a
+// For Good checkout/worktree (identified by this very client being present).
+// A globally-wired hook therefore never reports unrelated projects.
+if (process.env.FLEET_SERVER === undefined) {
+  const cwd = typeof payload.cwd === "string" ? payload.cwd : process.cwd();
+  if (existsSync(`${cwd}/server/clients/codex-hook.mjs`)) {
+    process.env.FLEET_SERVER = "https://forgood.thecolab.ai";
+  }
+}
+const { enabled, loadState, post, saveState, STREAM_LOGS, toLogLines, warnStreamingOnce, HANDLE } =
+  await import("./fleet-common.mjs");
+
+if (!enabled()) process.exit(0);
+
+const event = payload.hook_event_name ?? "";
+const sessionKey = `codex-${payload.session_id ?? "default"}`.slice(0, 80);
+let state = loadState(sessionKey);
+if (event === "SessionStart") state = warnStreamingOnce(state);
+if (payload.model) state.model = payload.model;
+
+const hello = {
+  handle: HANDLE || "unknown",
+  harness: "codex",
+  model: payload.model || state.model || process.env.FLEET_MODEL || process.env.MODEL || "codex",
+  ...(process.env.TASK_REF || process.env.TASK_TITLE
+    ? { task: { kind: process.env.FLEET_TASK_KIND || "work", ref: process.env.TASK_REF, title: process.env.TASK_TITLE } }
+    : {}),
+};
+
+/** Every telemetry POST is an upsert (hello + heartbeat), so presence works
+ *  even if hooks were installed mid-session and SessionStart never fired. */
+async function send(heartbeat) {
+  const resp = await post("/api/v1/telemetry", {
+    ...(state.agentId ? { agentId: state.agentId } : {}),
+    ...hello,
+    ...(heartbeat ? { heartbeat } : {}),
+  });
+  if (resp?.agentId) state.agentId = resp.agentId;
+}
+
+/** Parse new rollout lines since the last read. Codex `token_count` events
+ *  are CUMULATIVE, so deltas come from comparing the latest cumulative
+ *  figures against what this session last posted. Cache reads are excluded —
+ *  they'd inflate "intelligence at work" by orders of magnitude. */
+function readTranscriptDelta() {
+  const out = { tokensIn: 0, tokensOut: 0, lastText: "" };
+  const path = payload.transcript_path;
+  if (!path) return out;
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return out;
+  }
+  if (Number.isFinite(state.offset) && state.offset > raw.length) {
+    // Transcript shrank (rotated) — resume from the new end, never re-count.
+    state.offset = raw.length;
+    return out;
+  }
+  const offset = Number.isFinite(state.offset) ? state.offset : 0;
+  state.offset = raw.length;
+  let latest = null;
+  for (const line of raw.slice(offset).split("\n")) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const p = entry?.payload;
+    if (!p || typeof p !== "object") continue;
+    if (p.type === "token_count" && p.info?.total_token_usage) latest = p.info.total_token_usage;
+    if (p.type === "agent_message" && typeof p.message === "string" && p.message.trim()) {
+      out.lastText = p.message;
+    }
+  }
+  if (latest) {
+    const cumIn = Math.max(0, (latest.input_tokens ?? 0) - (latest.cached_input_tokens ?? 0));
+    const cumOut = latest.output_tokens ?? 0;
+    out.tokensIn = Math.max(0, cumIn - (state.cumIn ?? 0));
+    out.tokensOut = Math.max(0, cumOut - (state.cumOut ?? 0));
+    state.cumIn = Math.max(cumIn, state.cumIn ?? 0);
+    state.cumOut = Math.max(cumOut, state.cumOut ?? 0);
+  }
+  return out;
+}
+
+/** Token heartbeat with real elapsed wall time, so the fleet TPS gauge
+ *  reflects the actual rate rather than a per-post burst. */
+async function sendTokens(delta) {
+  if (delta.tokensIn <= 0 && delta.tokensOut <= 0) return false;
+  const now = Date.now();
+  const elapsedMs = Math.min(86_400_000, Math.max(1, now - (state.lastTokensAt ?? now - 1000)));
+  state.lastTokensAt = now;
+  await send({ tokensIn: delta.tokensIn, tokensOut: delta.tokensOut, elapsedMs });
+  return true;
+}
+
+switch (event) {
+  case "SessionStart": {
+    state.lastTokensAt = Date.now();
+    await send();
+    break;
+  }
+  case "PostToolUse": {
+    const tool = String(payload.tool_name ?? "unknown").slice(0, 64);
+    const delta = readTranscriptDelta();
+    const heartbeat = { toolCalls: 1, tools: { [tool]: 1 } };
+    if (delta.tokensIn > 0 || delta.tokensOut > 0) {
+      const now = Date.now();
+      heartbeat.tokensIn = delta.tokensIn;
+      heartbeat.tokensOut = delta.tokensOut;
+      heartbeat.elapsedMs = Math.min(86_400_000, Math.max(1, now - (state.lastTokensAt ?? now - 1000)));
+      state.lastTokensAt = now;
+    }
+    await send(heartbeat);
+    break;
+  }
+  case "Stop": {
+    const delta = readTranscriptDelta();
+    await sendTokens(delta);
+    if (STREAM_LOGS && state.agentId && delta.lastText) {
+      await post("/api/v1/logs", { agentId: state.agentId, lines: toLogLines(delta.lastText) });
+    }
+    break;
+  }
+  default:
+    break;
+}
+
+saveState(sessionKey, state);
+process.exit(0);

--- a/server/clients/fleet-common.mjs
+++ b/server/clients/fleet-common.mjs
@@ -27,7 +27,12 @@ export async function post(path, body) {
   try {
     const res = await fetch(`${FLEET_SERVER}${path}`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      // Cloudflare's bot protection 403s default/absent client user-agents on
+      // the tunnelled production server; an honest custom UA passes.
+      headers: {
+        "content-type": "application/json",
+        "user-agent": "forgood-fleet-telemetry/1.0 (+https://github.com/thecolab-ai/the-for-good-project)",
+      },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(POST_TIMEOUT_MS),
     });

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -192,7 +192,11 @@ export class FleetStore extends EventEmitter {
     for (const [tool, n] of Object.entries(hb.tools ?? {})) s.tools[tool] = (s.tools[tool] ?? 0) + n;
     for (const [skill, n] of Object.entries(hb.skills ?? {})) s.skills[skill] = (s.skills[skill] ?? 0) + n;
 
-    const tokens = (hb.tokensIn ?? 0) + (hb.tokensOut ?? 0);
+    // The TPS gauge measures GENERATION speed — output tokens only. Counting
+    // input too made the gauge read thousands of tok/s whenever a worker
+    // ingested big files/tool output, which nobody reads as "speed". Totals
+    // still track both directions.
+    const tokens = hb.tokensOut ?? 0;
     const elapsedMs = Math.max(1, hb.elapsedMs ?? config.tpsWindowSeconds * 1000);
     const windowMs = config.tpsWindowSeconds * 1000;
     rec.recent = rec.recent.filter((p) => now - p.t <= windowMs);

--- a/web/src/components/live/FleetPulse.tsx
+++ b/web/src/components/live/FleetPulse.tsx
@@ -24,7 +24,7 @@ export function FleetPulse({ fleet, history }: { fleet: FleetMetrics | null; his
         <div className="text-sm font-medium text-muted-foreground">Fleet throughput</div>
         <div className="mt-1 flex items-baseline gap-2">
           <span className="font-sans text-5xl font-semibold tabular-nums leading-none">{compactNumber(displayTps)}</span>
-          <span className="text-sm text-muted-foreground">{showingLast ? "last tok/s" : "tokens/sec"}</span>
+          <span className="text-sm text-muted-foreground">{showingLast ? "last out tok/s" : "output tokens/sec"}</span>
           {currentTps > 0 ? (
             <span className="relative ml-1 flex h-2 w-2 self-center">
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" style={{ backgroundColor: accent }} />
@@ -52,10 +52,25 @@ export function FleetPulse({ fleet, history }: { fleet: FleetMetrics | null; his
                   content={({ active, payload }) => {
                     if (!active || !payload?.length) return null;
                     const p = payload[0].payload as TpsPoint;
+                    const when = new Date(p.t);
+                    const split = Object.entries(p.byHarness ?? {}).filter(([, v]) => v > 0);
                     return (
                       <div className="rounded-md border border-border bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-md">
-                        <div className="font-medium tabular-nums">{compactNumber(p.tps)} tok/s</div>
-                        <div className="text-muted-foreground">{new Date(p.t).toLocaleTimeString()}</div>
+                        <div className="font-medium tabular-nums">{compactNumber(p.tps)} out tok/s</div>
+                        <div className="text-muted-foreground">
+                          {when.toLocaleDateString(undefined, { day: "numeric", month: "short" })}{" "}
+                          {when.toLocaleTimeString()}
+                        </div>
+                        {split.length > 0 ? (
+                          <div className="mt-1 space-y-0.5">
+                            {split.map(([h, v]) => (
+                              <div key={h} className="flex items-center gap-1.5 text-muted-foreground">
+                                <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: harnessColor(h, dark) }} />
+                                {h} <span className="tabular-nums text-popover-foreground">{compactNumber(v)}</span>
+                              </div>
+                            ))}
+                          </div>
+                        ) : null}
                       </div>
                     );
                   }}


### PR DESCRIPTION
Part of #398. Round 2 of the live-telemetry work: #552 was squash-merged while three further commits were still landing on its branch, so this PR re-lands them from a fresh branch off main, plus two new fixes the maintainer asked for.

**Re-landed (stranded on the old branch):**
- **codex hooks fleet client** (`server/clients/codex-hook.mjs`, wired by the repo-scoped `.codex/hooks.json`; needs codex-cli ≥ 0.142 — 0.139 never loads hook configs in exec mode, verified by trace). Hook payloads carry no usage, so the client parses the rollout transcript incrementally and posts live token deltas on every PostToolUse. Refuses to activate outside For Good checkouts, so a globally-wired hook can't report unrelated projects. `run_agent` passes `--dangerously-bypass-hook-trust` (its documented automation purpose) only when the repo hook config is present.
- **codex bridge live streaming**: locates the session transcript from `thread.started` and a background poller posts fresh-input/output deltas every 5s — the dashboard's 'no tokens flowing — last burst Nm ago' state is gone (verified live: sustained increments observed on the production server). `turn.completed` settles via the same cumulative ledger, so the two sources can never double-count.
- **claude runner visibility + telemetry**: plain `claude -p` buffers everything until the end — a worker looked hung ('Handing #NNN to claude…' then silence) and never registered. Now `--output-format stream-json` pipes through `scripts/claude-json-telemetry.py`: readable progress (session/model line, `[claude tool] Bash: …`, text, result + cost) and live per-message token/tool telemetry (verified end-to-end on a sonnet run). Fleet claude runs default to `--model sonnet` (maintainer call, 2026-07-05).

**New:**
- **TPS = output tokens only.** Counting input inflated the gauge past 1k tok/s whenever a worker ingested files — nobody reads that as speed. Totals still track both directions.
- **FleetPulse tooltip** on the throughput chart: hover shows the point's out tok/s, date + time, and the per-harness split; hero label now says 'output tokens/sec'.

Verified: server tests + typecheck green, web builds, `bash -n` + `ast.parse` on all runners/bridges, offline ledger test sums exactly, and the production container was rebuilt from this branch (TPS + tooltip live at https://forgood.thecolab.ai).

🤖 Generated with [Claude Code](https://claude.com/claude-code)