### PR TITLE
fix: codex TPS — charge tokens their generation window, not the tool gap

### DIFF
--- a/scripts/codex-json-telemetry.py
+++ b/scripts/codex-json-telemetry.py
@@ -15,6 +15,7 @@ import threading
 import urllib.error
 import urllib.request
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -93,9 +94,11 @@ def _find_transcript() -> str | None:
     return _transcript_path
 
 
-def _post_cumulative(fresh_in: int, out_tok: int) -> None:
-    """Post only the movement since the last post, with real elapsed wall
-    time so the fleet TPS gauge reflects an actual rate."""
+def _post_cumulative(fresh_in: int, out_tok: int, window_ms: int | None = None) -> None:
+    """Post only the movement since the last post. `window_ms` is the
+    GENERATION window (from the rollout's own timestamps) — charging
+    wall-clock-since-last-post instead lets tool-execution gaps dilute the
+    rate the same way the claude bridge used to read 0.3 tok/s."""
     global _cum_in, _cum_out, _last_post_mono
     with _cum_lock:
         d_in = max(0, fresh_in - _cum_in)
@@ -105,13 +108,40 @@ def _post_cumulative(fresh_in: int, out_tok: int) -> None:
         _cum_in = max(_cum_in, fresh_in)
         _cum_out = max(_cum_out, out_tok)
         now = time.monotonic()
-        elapsed_ms = max(1, int((now - _last_post_mono) * 1000))
+        elapsed_ms = window_ms if window_ms and window_ms > 0 else int((now - _last_post_mono) * 1000)
         _last_post_mono = now
-    post_telemetry({"tokensIn": d_in, "tokensOut": d_out, "elapsedMs": elapsed_ms})
+    post_telemetry({"tokensIn": d_in, "tokensOut": d_out, "elapsedMs": min(600_000, max(1, elapsed_ms))})
+
+
+# Rollout entries that mark "generation starts after this": a tool's output
+# going back in, the user prompt, or the task starting. The window charged to
+# a token_count is (its timestamp - the latest boundary before it).
+_BOUNDARY_TYPES = frozenset(
+    {"function_call_output", "custom_tool_call_output", "local_shell_call_output", "mcp_tool_call_output", "user_message", "task_started"}
+)
+_SCAN_MARKERS = tuple(f'"{t}"' for t in _BOUNDARY_TYPES) + ('"token_count"',)
+_last_boundary_ms: int | None = None
+
+
+def _ts_ms(value: Any) -> int | None:
+    try:
+        return int(datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp() * 1000)
+    except (ValueError, TypeError):
+        return None
+
+
+_read_lock = threading.Lock()
 
 
 def _read_transcript_once() -> None:
-    global _transcript_offset
+    # Called from the poller thread AND from turn.completed on the main
+    # thread — serialize so offset/boundary state stays coherent.
+    with _read_lock:
+        _read_transcript_locked()
+
+
+def _read_transcript_locked() -> None:
+    global _transcript_offset, _last_boundary_ms
     path = _find_transcript()
     if not path:
         return
@@ -127,20 +157,32 @@ def _read_transcript_once() -> None:
     if nl < 0:
         return
     _transcript_offset = end - (len(chunk) - nl - 1)
-    latest = None
     for line in chunk[: nl + 1].splitlines():
-        if '"token_count"' not in line:
+        if not any(marker in line for marker in _SCAN_MARKERS):
             continue
         try:
             obj = json.loads(line)
         except json.JSONDecodeError:
             continue
-        usage = ((obj.get("payload") or {}).get("info") or {}).get("total_token_usage")
-        if isinstance(usage, dict):
-            latest = usage
-    if latest:
-        fresh = max(0, int(latest.get("input_tokens") or 0) - int(latest.get("cached_input_tokens") or 0))
-        _post_cumulative(fresh, int(latest.get("output_tokens") or 0))
+        payload = obj.get("payload") or {}
+        ptype = payload.get("type")
+        ts = _ts_ms(obj.get("timestamp"))
+        if ptype in _BOUNDARY_TYPES:
+            if ts is not None:
+                _last_boundary_ms = ts
+            continue
+        if ptype != "token_count":
+            continue
+        usage = (payload.get("info") or {}).get("total_token_usage")
+        if not isinstance(usage, dict):
+            continue
+        window = None
+        if ts is not None and _last_boundary_ms is not None and ts > _last_boundary_ms:
+            window = ts - _last_boundary_ms
+        if ts is not None:
+            _last_boundary_ms = ts
+        fresh = max(0, int(usage.get("input_tokens") or 0) - int(usage.get("cached_input_tokens") or 0))
+        _post_cumulative(fresh, int(usage.get("output_tokens") or 0), window)
 
 
 def _transcript_poller() -> None:
@@ -302,7 +344,11 @@ def main() -> int:
             to = int(usage.get("output_tokens") or 0)
             cached = int(usage.get("cached_input_tokens") or 0)
             reasoning = int(usage.get("reasoning_output_tokens") or 0)
-            _post_cumulative(max(0, ti - cached), to)
+            # Drain the transcript first so the final response's tokens get
+            # their REAL generation window; any residue settles over a floored
+            # window rather than registering as a burst.
+            _read_transcript_once()
+            _post_cumulative(max(0, ti - cached), to, 3000)
             print(
                 f"[codex usage] total_input={ti} cached={cached} total_output={to} reasoning={reasoning}",
                 flush=True,

--- a/server/clients/codex-hook.mjs
+++ b/server/clients/codex-hook.mjs
@@ -85,7 +85,7 @@ async function send(heartbeat) {
  *  figures against what this session last posted. Cache reads are excluded —
  *  they'd inflate "intelligence at work" by orders of magnitude. */
 function readTranscriptDelta() {
-  const out = { tokensIn: 0, tokensOut: 0, lastText: "" };
+  const out = { tokensIn: 0, tokensOut: 0, lastText: "", windowMs: 0 };
   const path = payload.transcript_path;
   if (!path) return out;
   let raw;
@@ -101,7 +101,20 @@ function readTranscriptDelta() {
   }
   const offset = Number.isFinite(state.offset) ? state.offset : 0;
   state.offset = raw.length;
+  // Generation windows come from the rollout's own timestamps: a window runs
+  // from the latest boundary (tool output returning, user prompt, task start)
+  // to the token_count it produced. Charging wall-clock between hook firings
+  // would dilute the rate with tool-execution time.
+  const BOUNDARIES = new Set([
+    "function_call_output",
+    "custom_tool_call_output",
+    "local_shell_call_output",
+    "mcp_tool_call_output",
+    "user_message",
+    "task_started",
+  ]);
   let latest = null;
+  let lastBoundary = Number.isFinite(state.lastBoundaryTs) ? state.lastBoundaryTs : null;
   for (const line of raw.slice(offset).split("\n")) {
     if (!line.trim()) continue;
     let entry;
@@ -112,11 +125,21 @@ function readTranscriptDelta() {
     }
     const p = entry?.payload;
     if (!p || typeof p !== "object") continue;
-    if (p.type === "token_count" && p.info?.total_token_usage) latest = p.info.total_token_usage;
+    const ts = Date.parse(entry.timestamp ?? "") || null;
+    if (BOUNDARIES.has(p.type)) {
+      if (ts) lastBoundary = ts;
+      continue;
+    }
+    if (p.type === "token_count" && p.info?.total_token_usage) {
+      latest = p.info.total_token_usage;
+      if (ts && lastBoundary && ts > lastBoundary) out.windowMs += ts - lastBoundary;
+      if (ts) lastBoundary = ts;
+    }
     if (p.type === "agent_message" && typeof p.message === "string" && p.message.trim()) {
       out.lastText = p.message;
     }
   }
+  state.lastBoundaryTs = lastBoundary;
   if (latest) {
     const cumIn = Math.max(0, (latest.input_tokens ?? 0) - (latest.cached_input_tokens ?? 0));
     const cumOut = latest.output_tokens ?? 0;
@@ -128,14 +151,19 @@ function readTranscriptDelta() {
   return out;
 }
 
-/** Token heartbeat with real elapsed wall time, so the fleet TPS gauge
- *  reflects the actual rate rather than a per-post burst. */
+/** Token heartbeat over the tokens' own generation window (from rollout
+ *  timestamps), falling back to wall time since the last token post. */
+function tokenWindowMs(delta) {
+  const now = Date.now();
+  const fallback = now - (state.lastTokensAt ?? now - 1000);
+  state.lastTokensAt = now;
+  const windowMs = delta.windowMs > 0 ? delta.windowMs : fallback;
+  return Math.min(600_000, Math.max(1, windowMs));
+}
+
 async function sendTokens(delta) {
   if (delta.tokensIn <= 0 && delta.tokensOut <= 0) return false;
-  const now = Date.now();
-  const elapsedMs = Math.min(86_400_000, Math.max(1, now - (state.lastTokensAt ?? now - 1000)));
-  state.lastTokensAt = now;
-  await send({ tokensIn: delta.tokensIn, tokensOut: delta.tokensOut, elapsedMs });
+  await send({ tokensIn: delta.tokensIn, tokensOut: delta.tokensOut, elapsedMs: tokenWindowMs(delta) });
   return true;
 }
 
@@ -150,11 +178,9 @@ switch (event) {
     const delta = readTranscriptDelta();
     const heartbeat = { toolCalls: 1, tools: { [tool]: 1 } };
     if (delta.tokensIn > 0 || delta.tokensOut > 0) {
-      const now = Date.now();
       heartbeat.tokensIn = delta.tokensIn;
       heartbeat.tokensOut = delta.tokensOut;
-      heartbeat.elapsedMs = Math.min(86_400_000, Math.max(1, now - (state.lastTokensAt ?? now - 1000)));
-      state.lastTokensAt = now;
+      heartbeat.elapsedMs = tokenWindowMs(delta);
     }
     await send(heartbeat);
     break;


### PR DESCRIPTION
Companion to #560/#561 (claude) — codex had the same TPS dilution: token deltas were charged wall-clock since the previous post, so a response after a long shell command read absurdly slow and turn-end settles could burst absurdly fast.

The codex rollout timestamps every entry, so both codex telemetry paths now charge tokens their **generation window** — `token_count.timestamp − latest preceding boundary` (tool output returning / user prompt / task start):

- **`scripts/codex-json-telemetry.py`** — the poller processes every new `token_count` individually over its own window; `turn.completed` drains the transcript first, then settles residue over a floored 3s window; reads are lock-serialized across the poller and main threads.
- **`server/clients/codex-hook.mjs`** — same boundary/window accounting, with the boundary timestamp persisted in the session state file across one-shot hook invocations. This is the path that owns codex telemetry wherever the repo hook config is present (i.e. all worktree runs since #558), so it matters as much as the bridge.

Offline verification: a synthetic rollout with a 30s tool gap between two 2s generations posts samples of 50 and 60 tok/s (aggregate 55) with the gap charged nothing and session totals exact (500 fresh-in / 220 out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)