### PR TITLE
fix: runners export task context so agent telemetry stops reading 'idle'

### DIFF
--- a/frame_work.sh
+++ b/frame_work.sh
@@ -382,6 +382,9 @@ frame_one() {  # $1 = root issue number
     return 0
   fi
   make_worktree origin/main || { err "Couldn't create worktree for #$n — skipping."; return 1; }
+  # Task context for the telemetry bridges/hooks — otherwise the session
+  # shows as "idle" on the fleet dashboard while its tokens move.
+  export FLEET_TASK_KIND=frame TASK_REF="#$n" TASK_TITLE="$title"
   info "Handing root #$n to $AGENT (worktree: $WORKTREE)..."
   local tmp; tmp="$(mktemp)"
   set +e; run_agent "$(framing_prompt "$n" "$slug")" "$WORKTREE" 2>&1 | tee "$tmp"; local rc=${PIPESTATUS[0]}; set -e
@@ -589,6 +592,7 @@ reframe_one() {  # $1 = root issue number, $2 = framing PR number
   local before after
   before="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"
   make_worktree "origin/$branch" || { err "Couldn't create worktree for PR #$pr (branch $branch) — leaving #$n for a future loop."; return 1; }
+  export FLEET_TASK_KIND=frame TASK_REF="#$pr" TASK_TITLE="$(gh pr view "$pr" --repo "$REPO" --json title --jq .title 2>/dev/null || echo "framing rework PR #$pr")"
   info "Handing framing rework for root #$n to $AGENT (worktree: $WORKTREE)..."
   local tmp; tmp="$(mktemp)"
   set +e; run_agent "$(framing_rework_prompt "$n" "$pr" "$branch")" "$WORKTREE" 2>&1 | tee "$tmp"; local rc=${PIPESTATUS[0]}; set -e

--- a/review_work.sh
+++ b/review_work.sh
@@ -454,6 +454,10 @@ review_one() {  # $1 = PR number
   local tmp; tmp="$(mktemp)"
   local prompt
   if [ "$kind" = method ]; then prompt="$(review_prompt "$pr" "$REVIEW_FILE")"; else prompt="$(standard_review_prompt "$pr" "$REVIEW_FILE")"; fi
+  # Task context for the telemetry bridges/hooks (they inherit the agent's
+  # env) — without it a hard-working agent session shows as "idle" on the
+  # fleet dashboard while its tokens visibly move.
+  export FLEET_TASK_KIND=review TASK_REF="#$pr" TASK_TITLE="$title"
   info "Handing PR #$pr to $AGENT for $kind review (worktree: $WORKTREE)..."
   set +e
   run_agent "$prompt" "$WORKTREE" 2>&1 | tee "$tmp"

--- a/start_work.sh
+++ b/start_work.sh
@@ -313,6 +313,9 @@ work_one() {  # $1 = issue number
     finish_issue "$n"; return 0
   fi
   make_worktree origin/main || { err "Couldn't create worktree for #$n — skipping."; return 1; }
+  # Task context for the telemetry bridges/hooks — otherwise the session
+  # shows as "idle" on the fleet dashboard while its tokens move.
+  export FLEET_TASK_KIND=work TASK_REF="#$n" TASK_TITLE="$(issue_field "$n" title 2>/dev/null || true)"
   info "Handing #$n to $AGENT (worktree: $WORKTREE)..."
   local tmp; tmp="$(mktemp)"
   set +e; run_agent "$(work_prompt "$n")" "$WORKTREE" 2>&1 | tee "$tmp"; local rc=${PIPESTATUS[0]}; set -e
@@ -426,6 +429,7 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
   local before after
   before="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid)"
   make_worktree "origin/$branch" || { err "Couldn't create worktree for PR #$pr (branch $branch) — leaving #$n for a future loop."; set_status_label "$n" "changes-requested" "claimed" || true; return 1; }
+  export FLEET_TASK_KIND=work TASK_REF="#$pr" TASK_TITLE="$(gh pr view "$pr" --repo "$REPO" --json title --jq .title 2>/dev/null || echo "rework PR #$pr")"
   info "Handing PR #$pr rework to $AGENT (worktree: $WORKTREE)..."
   local tmp; tmp="$(mktemp)"
   set +e; run_agent "$(rework_prompt "$n" "$pr" "$branch")" "$WORKTREE" 2>&1 | tee "$tmp"; local rc=${PIPESTATUS[0]}; set -e


### PR DESCRIPTION
Fixes the dashboard showing a codex worker as **"idle" while its tok/s visibly moves**.

Root cause: the telemetry bridges and hook clients read `FLEET_TASK_KIND`/`TASK_REF`/`TASK_TITLE` from the agent process env — but no runner ever exported them. Since #558 the repo-scoped hooks own codex telemetry, and each hook-registered session therefore carried no task info at all; the dashboard renders a null task as "idle".

Each runner now exports the task context at the exact point it hands work to the agent:
- `review_work.sh` → `review` + PR ref/title
- `start_work.sh` → `work` + issue ref/title (and rework-PR ref/title on the rework path)
- `frame_work.sh` → `frame` + root ref/title (and rework-PR ref/title)

Verified end-to-end: a bridged sonnet run with the env set registers on the live server as `{kind: review, ref: #999, title: …}`. `bash -n` on all three runners and `scripts/test-frame-work.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)