### PR TITLE
feat(live): worldwide globe + throughput = sum of workers

### DIFF
--- a/server/scripts/simulate.mjs
+++ b/server/scripts/simulate.mjs
@@ -38,17 +38,38 @@ const TASKS = [
 const TOOLS = ["bash", "edit", "read", "webfetch", "gh", "grep"];
 const SKILLS = ["child-poverty-nz", "deprivation-nz", "data-govt-nz", "geonet-nz", "lawa-nz"];
 
+// Rough worldwide worker locations so the globe is populated in local/dev
+// (localhost has no IP geo). The server prefers real IP geo and only uses this
+// self-reported fallback when the lookup fails.
+const CITIES = [
+  { city: "Auckland", country: "NZ", lat: -36.8, lon: 174.8 },
+  { city: "Wellington", country: "NZ", lat: -41.3, lon: 174.8 },
+  { city: "Christchurch", country: "NZ", lat: -43.5, lon: 172.6 },
+  { city: "Sydney", country: "AU", lat: -33.9, lon: 151.2 },
+  { city: "Melbourne", country: "AU", lat: -37.8, lon: 145.0 },
+  { city: "Singapore", country: "SG", lat: 1.35, lon: 103.8 },
+  { city: "London", country: "GB", lat: 51.5, lon: -0.1 },
+  { city: "Berlin", country: "DE", lat: 52.5, lon: 13.4 },
+  { city: "San Francisco", country: "US", lat: 37.8, lon: -122.4 },
+  { city: "New York", country: "US", lat: 40.7, lon: -74.0 },
+  { city: "Toronto", country: "CA", lat: 43.7, lon: -79.4 },
+  { city: "Bengaluru", country: "IN", lat: 13.0, lon: 77.6 },
+  { city: "Tokyo", country: "JP", lat: 35.7, lon: 139.7 },
+  { city: "São Paulo", country: "BR", lat: -23.5, lon: -46.6 },
+];
+
 const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
 
 function startAgent(i) {
   const handle = HANDLES[i % HANDLES.length];
   const harness = pick(HARNESSES);
   const model = pick(MODELS[harness]);
+  const location = CITIES[i % CITIES.length];
   const ws = new WebSocket(`${SERVER}/ws/agent`);
   let timer;
 
   ws.addEventListener("open", () => {
-    ws.send(JSON.stringify({ type: "hello", handle, harness, model, task: pick(TASKS), version: "sim-0.1" }));
+    ws.send(JSON.stringify({ type: "hello", handle, harness, model, task: pick(TASKS), location, version: "sim-0.1" }));
     console.log(`[sim] ${handle} online (${harness} · ${model})`);
     timer = setInterval(() => {
       // A plausible working rhythm: bursts of tokens, occasional milestones.

--- a/server/src/agent-ws.ts
+++ b/server/src/agent-ws.ts
@@ -7,6 +7,7 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { WebSocket } from "ws";
 import { config } from "./config.js";
+import { roughLocate } from "./geo.js";
 import { originAllowed, RateLimiter } from "./guards.js";
 import { agentMessageSchema } from "./protocol.js";
 import { redactLines } from "./redact.js";
@@ -59,7 +60,9 @@ export function registerAgentSocket(app: FastifyInstance, store: FleetStore): vo
 
       switch (msg.type) {
         case "hello": {
-          const id = store.upsertAgent(msg, "ws", agentId ?? undefined);
+          // City-level only; req.ip is read once here and never stored (#398).
+          const location = config.watcherGeo ? roughLocate(req.ip) : null;
+          const id = store.upsertAgent(msg, "ws", agentId ?? undefined, location);
           if (!id) {
             socket.send(JSON.stringify({ type: "error", error: "fleet full" }));
             socket.close(1013, "fleet full");

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -34,6 +34,17 @@ const countMap = z.record(z.string().max(64), count);
 // ---------------------------------------------------------------------------
 // Agent -> server messages
 
+/** A deliberately-imprecise, self-reported location. The server prefers a
+ *  city-level lookup from the connection IP (which it then discards) and only
+ *  falls back to this when IP geo fails — e.g. a worker behind localhost/CGNAT
+ *  or the fleet simulator. Coordinates only; no addresses. */
+export const roughLocationSchema = z.object({
+  city: z.string().max(80).optional(),
+  country: z.string().max(80).optional(),
+  lat: z.number().min(-90).max(90).optional(),
+  lon: z.number().min(-180).max(180).optional(),
+});
+
 export const helloSchema = z.object({
   type: z.literal("hello"),
   /** Public GitHub handle. Identity is assumed-trust for now (auth parked). */
@@ -42,6 +53,8 @@ export const helloSchema = z.object({
   model: z.string().min(1).max(128),
   task: taskInfoSchema.optional(),
   version: z.string().max(64).optional(),
+  /** Optional fallback location (used only if IP geo fails). See schema note. */
+  location: roughLocationSchema.optional(),
 });
 export type Hello = z.infer<typeof helloSchema>;
 
@@ -146,6 +159,8 @@ export interface AgentPresence {
   /** Last non-zero token burst observed for this agent, retained for idle display. */
   lastTps: number;
   lastTpsAt: string | null;
+  /** Rough, city-level location for the worldwide globe (IP discarded, ~11km). */
+  location?: RoughLocation | null;
 }
 
 export interface RoughLocation {

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -62,13 +62,6 @@ interface WatcherRecord {
   expiresAt: number;
 }
 
-interface TpsBucket {
-  total: number;
-  elapsedMs: number;
-  byModel: Record<string, { tokens: number; elapsedMs: number }>;
-  byHarness: Record<string, { tokens: number; elapsedMs: number }>;
-}
-
 interface PersistedState {
   totals: SessionCounters;
   events: EventItem[];
@@ -103,8 +96,6 @@ function toPresence(rec: AgentRecord, now: number): AgentPresence {
 export class FleetStore extends EventEmitter {
   private readonly agents = new Map<string, AgentRecord>();
   private readonly watchers = new Map<string, WatcherRecord>();
-  /** bucket index (unix seconds / bucket size) -> token counts */
-  private readonly tpsBuckets = new Map<number, TpsBucket>();
   private readonly logs = new Map<string, LogLine[]>();
   private totals: SessionCounters = emptyCounters();
   private events: EventItem[] = [];
@@ -294,29 +285,11 @@ export class FleetStore extends EventEmitter {
 
   private recordThroughput(rec: AgentRecord, hb: Omit<Heartbeat, "type">, tokens: number): void {
     if (tokens > 0) {
-      const nowIso = new Date().toISOString();
+      // Per-agent "last burst" rate, shown on a worker card when it goes quiet.
+      // The fleet-level lastTps is derived (as a sum) in fleetMetrics().
       const elapsedMs = Math.max(1, hb.elapsedMs ?? config.tpsWindowSeconds * 1000);
-      const burstTps = sampleTps(tokens, elapsedMs);
-      rec.lastTps = burstTps;
-      rec.lastTpsAt = nowIso;
-      this.lastTps = burstTps;
-      this.lastTpsAt = nowIso;
-      const bucketId = Math.floor(Date.now() / 1000 / config.tpsBucketSeconds);
-      let bucket = this.tpsBuckets.get(bucketId);
-      if (!bucket) {
-        bucket = { total: 0, elapsedMs: 0, byModel: {}, byHarness: {} };
-        this.tpsBuckets.set(bucketId, bucket);
-      }
-      bucket.total += tokens;
-      bucket.elapsedMs += elapsedMs;
-      const model = bucket.byModel[rec.model] ?? { tokens: 0, elapsedMs: 0 };
-      model.tokens += tokens;
-      model.elapsedMs += elapsedMs;
-      bucket.byModel[rec.model] = model;
-      const harness = bucket.byHarness[rec.harness] ?? { tokens: 0, elapsedMs: 0 };
-      harness.tokens += tokens;
-      harness.elapsedMs += elapsedMs;
-      bucket.byHarness[rec.harness] = harness;
+      rec.lastTps = sampleTps(tokens, elapsedMs);
+      rec.lastTpsAt = new Date().toISOString();
     }
     const t = this.totals;
     t.tokensIn += hb.tokensIn ?? 0;
@@ -335,40 +308,40 @@ export class FleetStore extends EventEmitter {
   }
 
   fleetMetrics(): FleetMetrics {
-    const currentBucket = Math.floor(Date.now() / 1000 / config.tpsBucketSeconds);
-    const bucketCount = Math.ceil(config.tpsWindowSeconds / config.tpsBucketSeconds);
-    let total = 0;
-    let elapsedMs = 0;
-    const byModel: Record<string, { tokens: number; elapsedMs: number }> = {};
-    const byHarness: Record<string, { tokens: number; elapsedMs: number }> = {};
-    for (let i = 0; i < bucketCount; i++) {
-      const bucket = this.tpsBuckets.get(currentBucket - i);
-      if (!bucket) continue;
-      total += bucket.total;
-      elapsedMs += bucket.elapsedMs;
-      for (const [k, v] of Object.entries(bucket.byModel)) {
-        const acc = byModel[k] ?? { tokens: 0, elapsedMs: 0 };
-        acc.tokens += v.tokens;
-        acc.elapsedMs += v.elapsedMs;
-        byModel[k] = acc;
-      }
-      for (const [k, v] of Object.entries(bucket.byHarness)) {
-        const acc = byHarness[k] ?? { tokens: 0, elapsedMs: 0 };
-        acc.tokens += v.tokens;
-        acc.elapsedMs += v.elapsedMs;
-        byHarness[k] = acc;
-      }
+    // Fleet throughput is the SUM of every connected worker's honest tok/s
+    // (hash-rate style): concurrent producers add together, so the hero figure
+    // equals the total of the per-worker rates shown in the fleet table and the
+    // per-harness legend. Each agent's rate is the honest generation-window rate
+    // (see agentTps / #560); we just add them up rather than averaging.
+    const now = Date.now();
+    let tps = 0;
+    const byModel: Record<string, number> = {};
+    const byHarness: Record<string, number> = {};
+    for (const rec of this.agents.values()) {
+      const rate = agentTps(rec, now);
+      if (rate <= 0) continue;
+      tps += rate;
+      byModel[rec.model] = (byModel[rec.model] ?? 0) + rate;
+      byHarness[rec.harness] = (byHarness[rec.harness] ?? 0) + rate;
     }
-    // Prune buckets that have slid out of every window.
-    for (const id of this.tpsBuckets.keys()) {
-      if (id < currentBucket - bucketCount * 2) this.tpsBuckets.delete(id);
+    const round1 = (n: number) => Math.round(n * 10) / 10;
+    tps = round1(tps);
+    for (const [k, v] of Object.entries(byModel)) byModel[k] = round1(v);
+    for (const [k, v] of Object.entries(byHarness)) byHarness[k] = round1(v);
+
+    // Remember the last non-zero fleet throughput so the hero can show "last
+    // burst" when every worker goes quiet, instead of snapping to zero.
+    if (tps > 0) {
+      this.lastTps = tps;
+      this.lastTpsAt = new Date(now).toISOString();
     }
+
     return {
-      tps: aggregateTps(total, elapsedMs),
+      tps,
       lastTps: this.lastTps,
       lastTpsAt: this.lastTpsAt,
-      tpsByModel: Object.fromEntries(Object.entries(byModel).map(([k, v]) => [k, aggregateTps(v.tokens, v.elapsedMs)])),
-      tpsByHarness: Object.fromEntries(Object.entries(byHarness).map(([k, v]) => [k, aggregateTps(v.tokens, v.elapsedMs)])),
+      tpsByModel: byModel,
+      tpsByHarness: byHarness,
       activeAgents: this.agents.size,
       watcherCount: this.watchers.size,
       totals: this.totals,

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -120,12 +120,15 @@ export class FleetStore extends EventEmitter {
   /** Returns null when the fleet is at maxAgents and this would be a NEW
    *  agent — presence is unauthenticated until auth lands, so allocation from
    *  a flood of hellos has to be bounded. */
-  upsertAgent(hello: Hello, transport: "ws" | "http", id?: string): string | null {
+  upsertAgent(hello: Hello, transport: "ws" | "http", id?: string, location?: RoughLocation | null): string | null {
     const agentId = id ?? randomUUID();
     const existing = this.agents.get(agentId);
     if (!existing && this.agents.size >= config.maxAgents) return null;
     const now = Date.now();
     const nowIso = new Date(now).toISOString();
+    // Prefer the IP-derived location (already discarded by the caller); fall
+    // back to a self-reported one only when IP geo failed (localhost / sim).
+    const resolvedLocation = location ?? hello.location ?? null;
     const rec: AgentRecord = existing ?? {
       id: agentId,
       handle: hello.handle,
@@ -138,6 +141,7 @@ export class FleetStore extends EventEmitter {
       session: emptyCounters(),
       lastTps: 0,
       lastTpsAt: null,
+      location: resolvedLocation,
       recent: [],
       expiresAt: 0,
     };
@@ -146,6 +150,7 @@ export class FleetStore extends EventEmitter {
     rec.model = hello.model;
     rec.lastSeen = nowIso;
     rec.expiresAt = now + config.agentTtlSeconds * 1000;
+    if (resolvedLocation) rec.location = resolvedLocation;
     if (hello.task) rec.task = hello.task;
     this.agents.set(agentId, rec);
     if (!existing) {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,12 +29,15 @@
         "recharts": "^3.9.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.6.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "topojson-client": "^3.1.0",
+        "world-atlas": "^2.0.2"
       },
       "devDependencies": {
         "@types/node": "^24.13.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/topojson-client": "^3.1.5",
         "@vitejs/plugin-react": "^6.0.3",
         "autoprefixer": "^10.5.2",
         "gray-matter": "^4.0.3",
@@ -1765,6 +1768,13 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -1816,6 +1826,27 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -5134,6 +5165,26 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -5490,6 +5541,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/world-atlas": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz",
+      "integrity": "sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ==",
+      "license": "ISC"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -31,12 +31,15 @@
     "recharts": "^3.9.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "topojson-client": "^3.1.0",
+    "world-atlas": "^2.0.2"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/topojson-client": "^3.1.5",
     "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.5.2",
     "gray-matter": "^4.0.3",

--- a/web/src/components/live/FleetConsole.tsx
+++ b/web/src/components/live/FleetConsole.tsx
@@ -19,9 +19,11 @@ import type { Finding, Snapshot } from "@/lib/types";
 import { FleetPulse } from "./FleetPulse";
 import { AgentTable } from "./AgentTable";
 import { LiveEventFeed } from "./LiveEventFeed";
+import { FleetGlobe, type GlobePoint } from "./FleetGlobe";
+import { harnessColor, useIsDark } from "./harness";
 
 type CommentFilter = "all" | "issues" | "prs";
-type FeedTab = "comments" | "findings";
+type FeedTab = "activity" | "comments" | "findings";
 
 const CONFIDENCE_STYLE: Record<string, string> = {
   High: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
@@ -268,9 +270,10 @@ function WorkerTerminal({ agent, lines, onClose }: { agent: AgentPresence; lines
 
 export function FleetConsole({ snapshot }: { snapshot: Snapshot }) {
   const live = useLiveFleet();
+  const dark = useIsDark();
   const { theme, toggle } = useTheme();
   const [filter, setFilter] = useState<CommentFilter>("all");
-  const [feedTab, setFeedTab] = useState<FeedTab>("comments");
+  const [feedTab, setFeedTab] = useState<FeedTab>("activity");
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [loadedLogs, setLoadedLogs] = useState<Record<string, LogLine[]>>({});
 
@@ -285,6 +288,44 @@ export function FleetConsole({ snapshot }: { snapshot: Snapshot }) {
   );
   const available = stats.byStatus?.available ?? 0;
   const inReview = stats.byStatus?.["in review"] ?? stats.byStatus?.["in-review"] ?? 0;
+
+  // Worldwide globe: plot located workers (by harness colour) and watchers.
+  const watcherColor = dark ? "#34D399" : "#059669";
+  const globePoints: GlobePoint[] = useMemo(() => {
+    const pts: GlobePoint[] = [];
+    for (const a of live.agents) {
+      const l = a.location;
+      if (typeof l?.lat === "number" && typeof l?.lon === "number") {
+        pts.push({ lat: l.lat, lon: l.lon, color: harnessColor(a.harness, dark), kind: "worker" });
+      }
+    }
+    for (const w of live.watchers.locations) {
+      if (typeof w.lat === "number" && typeof w.lon === "number") {
+        pts.push({ lat: w.lat, lon: w.lon, color: watcherColor, kind: "watcher" });
+      }
+    }
+    return pts;
+  }, [live.agents, live.watchers, dark, watcherColor]);
+  const locatedWorkers = live.agents.filter((a) => typeof a.location?.lat === "number").length;
+  const globeCountries = useMemo(() => {
+    const set = new Set<string>();
+    for (const a of live.agents) if (a.location?.country) set.add(a.location.country);
+    for (const w of live.watchers.locations) if (w.country) set.add(w.country);
+    return set.size;
+  }, [live.agents, live.watchers]);
+  const topPlace = useMemo(() => {
+    const counts = new Map<string, number>();
+    const add = (city?: string, country?: string) => {
+      const label = [city, country].filter(Boolean).join(", ");
+      if (label) counts.set(label, (counts.get(label) ?? 0) + 1);
+    };
+    for (const a of live.agents) add(a.location?.city, a.location?.country);
+    for (const w of live.watchers.locations) add(w.city, w.country);
+    let best: string | null = null;
+    let bestN = 0;
+    for (const [label, n] of counts) if (n > bestN) { best = label; bestN = n; }
+    return best;
+  }, [live.agents, live.watchers]);
 
   const selectedAgent = live.agents.find((a) => a.id === selectedAgentId) ?? null;
   useEffect(() => {
@@ -417,22 +458,34 @@ export function FleetConsole({ snapshot }: { snapshot: Snapshot }) {
             )}
           </section>
 
-          {/* Bottom row — activity + comments/findings side by side */}
-          <div className="grid min-h-0 grid-cols-1 gap-3 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-            <section className="hud-panel flex min-h-0 flex-col overflow-hidden">
-              <div className="p-3 pb-2">
-                <PanelHead label="Activity" icon={Radio} accent="#C2410C"
-                  right={generatedAt ? <span>upd {relativeTime(generatedAt)}</span> : null} />
+          {/* Bottom row — worldwide globe + tabbed activity/comments/findings */}
+          <div className="grid min-h-0 grid-cols-1 gap-3 xl:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]">
+            {/* Globe — the fleet, worldwide */}
+            <section className="hud-panel flex min-h-[18rem] flex-col overflow-hidden xl:min-h-0">
+              <div className="flex items-center justify-between gap-2 p-3 pb-1">
+                <PanelHead label="Worldwide" icon={Globe} accent="#0EA5E9"
+                  right={<span className="inline-flex items-center gap-3">
+                    <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-brand-cyan" />workers</span>
+                    <span className="inline-flex items-center gap-1"><span className="h-2 w-2 rounded-full bg-emerald-500" />watchers</span>
+                  </span>} />
               </div>
-              <div className="console-scroll min-h-0 flex-1 overflow-y-auto px-3 pb-3">
-                <LiveEventFeed events={live.events} />
+              <div className="relative min-h-0 flex-1">
+                <FleetGlobe points={globePoints} />
+              </div>
+              <div className="flex items-center gap-x-4 gap-y-1 border-t border-border/60 px-3 py-2 text-[11px] text-muted-foreground">
+                <span><span className="font-mono font-semibold text-foreground">{locatedWorkers}</span> workers mapped</span>
+                <span><span className="font-mono font-semibold text-foreground">{live.watchers.count}</span> watching</span>
+                <span><span className="font-mono font-semibold text-foreground">{globeCountries}</span> countries</span>
+                {topPlace ? <span className="ml-auto truncate">busiest · {topPlace}</span> : null}
               </div>
             </section>
 
-            <section className="hud-panel flex min-h-0 flex-col overflow-hidden">
+            {/* Feeds — activity / comments / findings */}
+            <section className="hud-panel flex min-h-[18rem] flex-col overflow-hidden xl:min-h-0">
               <div className="flex flex-wrap items-center justify-between gap-2 p-3 pb-2">
                 <div className="flex items-center gap-1 rounded-lg bg-secondary/50 p-0.5">
                   {([
+                    { k: "activity", label: "Activity", icon: Radio, count: live.events.length },
                     { k: "comments", label: "Comments", icon: MessageSquare, count: filteredComments.length },
                     { k: "findings", label: "Findings", icon: FileText, count: recentFindings.length },
                   ] as const).map(({ k, label, icon: Icon, count }) => (
@@ -468,10 +521,14 @@ export function FleetConsole({ snapshot }: { snapshot: Snapshot }) {
                       </button>
                     ))}
                   </div>
+                ) : feedTab === "activity" && generatedAt ? (
+                  <span className="text-[11px] text-muted-foreground">upd {relativeTime(generatedAt)}</span>
                 ) : null}
               </div>
               <div className="console-scroll min-h-0 flex-1 overflow-y-auto px-3 pb-3">
-                {feedTab === "comments" ? <CommentFeed comments={filteredComments} /> : <FindingsFeed findings={recentFindings} />}
+                {feedTab === "activity" ? <LiveEventFeed events={live.events} />
+                  : feedTab === "comments" ? <CommentFeed comments={filteredComments} />
+                    : <FindingsFeed findings={recentFindings} />}
               </div>
             </section>
           </div>

--- a/web/src/components/live/FleetConsole.tsx
+++ b/web/src/components/live/FleetConsole.tsx
@@ -117,7 +117,7 @@ function PanelHead({ label, count, accent = "#0EA5E9", right, icon: Icon }:
 function StatTile({ label, value, hint, icon: Icon, accent = "#2E4057" }:
   { label: string; value: React.ReactNode; hint?: string; icon: typeof Bot; accent?: string }) {
   return (
-    <div className="hud-panel flex min-h-0 flex-col justify-between overflow-hidden p-3">
+    <div className="hud-panel flex min-h-[6.25rem] flex-col justify-between overflow-hidden p-3">
       <div className="flex items-start justify-between gap-2">
         <span className="hud-label truncate">{label}</span>
         <span className="rounded-md p-1" style={{ backgroundColor: `${accent}1f` }}>
@@ -374,10 +374,12 @@ export function FleetConsole({ snapshot }: { snapshot: Snapshot }) {
       {/* ── Grid body ── */}
       <main className="flex-1 xl:min-h-0">
         <div className="grid h-full grid-cols-1 gap-3 p-3 xl:grid-cols-[336px_minmax(0,1fr)]">
-          {/* Left rail — throughput + KPIs */}
+          {/* Left rail — throughput (grows) + compact KPI tiles */}
           <div className="flex min-h-0 flex-col gap-3">
-            <FleetPulse fleet={live.fleet} history={live.historicalTps.length ? live.historicalTps : live.tpsHistory} />
-            <div className="grid flex-1 grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-2 xl:grid-rows-3">
+            <div className="min-h-[16rem] xl:flex-1">
+              <FleetPulse fleet={live.fleet} history={live.historicalTps.length ? live.historicalTps : live.tpsHistory} />
+            </div>
+            <div className="grid shrink-0 grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-2">
               <StatTile label="Workers" value={live.agents.length} icon={Cpu} accent="#0EA5E9"
                 hint={live.agents.length ? `${reviewing} reviewing` : "waiting for fleet"} />
               <StatTile label="Watchers" value={live.watchers.count} icon={Globe} accent="#7C3AED" hint="right now" />

--- a/web/src/components/live/FleetGlobe.tsx
+++ b/web/src/components/live/FleetGlobe.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useRef } from "react";
+import { feature } from "topojson-client";
+import type { Topology } from "topojson-specification";
+import type { Feature, GeoJsonProperties, Geometry } from "geojson";
+import countriesTopo from "world-atlas/countries-110m.json";
+import { useIsDark } from "./harness";
+
+export interface GlobePoint {
+  lat: number;
+  lon: number;
+  color: string;
+  /** Workers get a larger, pulsing marker; watchers a smaller steady dot. */
+  kind: "worker" | "watcher";
+}
+
+const TILT = (-18 * Math.PI) / 180; // axial tilt so it reads as a globe, not a disc
+const DEG = Math.PI / 180;
+
+// Low-res country borders (world-atlas 110m), flattened once into rings of
+// [lon, lat] pairs. Drawn as faint outlines on the sphere so continents read.
+const COUNTRY_RINGS: [number, number][][] = (() => {
+  const topo = countriesTopo as unknown as Topology;
+  const fc = feature(topo, topo.objects.countries) as unknown as {
+    features: Feature<Geometry, GeoJsonProperties>[];
+  };
+  const rings: [number, number][][] = [];
+  for (const f of fc.features) {
+    const g = f.geometry;
+    if (!g) continue;
+    const polys =
+      g.type === "Polygon" ? [g.coordinates] : g.type === "MultiPolygon" ? g.coordinates : [];
+    for (const poly of polys) for (const ring of poly) rings.push(ring as [number, number][]);
+  }
+  return rings;
+})();
+
+/** Project a lat/lon (with a spin offset) to screen space + a visibility flag. */
+function project(lat: number, lon: number, spin: number, cx: number, cy: number, r: number) {
+  const phi = lat * DEG;
+  const lambda = (lon + spin) * DEG;
+  const x = Math.cos(phi) * Math.sin(lambda);
+  let y = Math.sin(phi);
+  let z = Math.cos(phi) * Math.cos(lambda);
+  // Tilt around the X axis.
+  const ct = Math.cos(TILT);
+  const st = Math.sin(TILT);
+  const y2 = y * ct - z * st;
+  const z2 = y * st + z * ct;
+  y = y2;
+  z = z2;
+  return { x: cx + x * r, y: cy - y * r, z, front: z > 0 };
+}
+
+/**
+ * A lightweight, dependency-free rotating globe (canvas 2D, orthographic).
+ * Draws a faint graticule sphere with an atmosphere glow and plots glowing
+ * markers for connected workers and watchers — the fleet, worldwide. Drag to
+ * spin; releases back to a slow auto-rotate.
+ */
+export function FleetGlobe({ points }: { points: GlobePoint[] }) {
+  const dark = useIsDark();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const pointsRef = useRef(points);
+  pointsRef.current = points;
+  const darkRef = useRef(dark);
+  darkRef.current = dark;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const wrap = wrapRef.current;
+    if (!canvas || !wrap) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let raf = 0;
+    let spin = 20; // degrees; auto-advances
+    let autoSpin = true;
+    let dragging = false;
+    let lastX = 0;
+    let size = 0;
+    let dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+    const resize = () => {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const w = wrap.clientWidth;
+      const h = wrap.clientHeight;
+      size = Math.max(120, Math.min(w, h));
+      canvas.width = Math.round(w * dpr);
+      canvas.height = Math.round(h * dpr);
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(wrap);
+
+    const draw = (t: number) => {
+      const w = canvas.width;
+      const h = canvas.height;
+      ctx.clearRect(0, 0, w, h);
+      const cx = w / 2;
+      const cy = h / 2;
+      const r = (size * dpr) / 2 - 10 * dpr;
+      const isDark = darkRef.current;
+
+      const sphereFill = isDark ? "rgba(14,165,233,0.06)" : "rgba(2,132,199,0.05)";
+      const grat = isDark ? "rgba(148,163,184,0.10)" : "rgba(71,85,105,0.08)";
+      const land = isDark ? "rgba(148,197,224,0.42)" : "rgba(51,90,120,0.42)";
+      const rim = isDark ? "rgba(14,165,233,0.5)" : "rgba(2,132,199,0.35)";
+
+      // Atmosphere glow.
+      const glow = ctx.createRadialGradient(cx, cy, r * 0.7, cx, cy, r * 1.25);
+      glow.addColorStop(0, isDark ? "rgba(14,165,233,0.18)" : "rgba(2,132,199,0.12)");
+      glow.addColorStop(1, "rgba(0,0,0,0)");
+      ctx.fillStyle = glow;
+      ctx.beginPath();
+      ctx.arc(cx, cy, r * 1.25, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Sphere body + rim.
+      ctx.beginPath();
+      ctx.arc(cx, cy, r, 0, Math.PI * 2);
+      ctx.fillStyle = sphereFill;
+      ctx.fill();
+      ctx.lineWidth = 1 * dpr;
+      ctx.strokeStyle = rim;
+      ctx.stroke();
+
+      if (autoSpin) spin = (spin + 0.12) % 360;
+
+      // Faint graticule for depth (equator + a few meridians), front hemisphere.
+      ctx.strokeStyle = grat;
+      ctx.lineWidth = 1 * dpr;
+      for (let lon = -180; lon < 180; lon += 30) {
+        ctx.beginPath();
+        let started = false;
+        for (let lat = -85; lat <= 85; lat += 6) {
+          const p = project(lat, lon, spin, cx, cy, r);
+          if (!p.front) { started = false; continue; }
+          if (!started) { ctx.moveTo(p.x, p.y); started = true; }
+          else ctx.lineTo(p.x, p.y);
+        }
+        ctx.stroke();
+      }
+      for (let lat = -60; lat <= 60; lat += 30) {
+        ctx.beginPath();
+        let started = false;
+        for (let lon = -180; lon <= 180; lon += 6) {
+          const p = project(lat, lon, spin, cx, cy, r);
+          if (!p.front) { started = false; continue; }
+          if (!started) { ctx.moveTo(p.x, p.y); started = true; }
+          else ctx.lineTo(p.x, p.y);
+        }
+        ctx.stroke();
+      }
+
+      // Country outlines — the continents, front hemisphere only.
+      ctx.strokeStyle = land;
+      ctx.lineWidth = 1 * dpr;
+      ctx.lineJoin = "round";
+      for (const ring of COUNTRY_RINGS) {
+        ctx.beginPath();
+        let started = false;
+        for (let k = 0; k < ring.length; k++) {
+          const p = project(ring[k][1], ring[k][0], spin, cx, cy, r);
+          if (!p.front) { started = false; continue; }
+          if (!started) { ctx.moveTo(p.x, p.y); started = true; }
+          else ctx.lineTo(p.x, p.y);
+        }
+        ctx.stroke();
+      }
+
+      // Markers.
+      const pulse = 0.5 + 0.5 * Math.sin(t / 500);
+      for (const pt of pointsRef.current) {
+        const p = project(pt.lat, pt.lon, spin, cx, cy, r);
+        if (!p.front) continue;
+        const base = (pt.kind === "worker" ? 3.2 : 2.2) * dpr;
+        // Soft halo.
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, base * (pt.kind === "worker" ? 3.2 : 2.4), 0, Math.PI * 2);
+        ctx.fillStyle = pt.color;
+        ctx.globalAlpha = 0.14 * p.z;
+        ctx.fill();
+        // Pulsing ring for workers.
+        if (pt.kind === "worker") {
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, base * (1.6 + pulse * 1.4), 0, Math.PI * 2);
+          ctx.strokeStyle = pt.color;
+          ctx.globalAlpha = (0.5 - pulse * 0.4) * p.z;
+          ctx.lineWidth = 1 * dpr;
+          ctx.stroke();
+        }
+        // Core dot.
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, base, 0, Math.PI * 2);
+        ctx.fillStyle = pt.color;
+        ctx.globalAlpha = Math.min(1, 0.55 + p.z * 0.45);
+        ctx.fill();
+        ctx.globalAlpha = 1;
+      }
+
+      raf = requestAnimationFrame(draw);
+    };
+    raf = requestAnimationFrame(draw);
+
+    const onDown = (e: PointerEvent) => {
+      dragging = true;
+      autoSpin = false;
+      lastX = e.clientX;
+      canvas.setPointerCapture(e.pointerId);
+    };
+    const onMove = (e: PointerEvent) => {
+      if (!dragging) return;
+      spin = (spin + (e.clientX - lastX) * 0.4) % 360;
+      lastX = e.clientX;
+    };
+    const onUp = () => {
+      dragging = false;
+      // Resume auto-spin shortly after release.
+      window.setTimeout(() => { if (!dragging) autoSpin = true; }, 1500);
+    };
+    canvas.addEventListener("pointerdown", onDown);
+    canvas.addEventListener("pointermove", onMove);
+    canvas.addEventListener("pointerup", onUp);
+    canvas.addEventListener("pointercancel", onUp);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      canvas.removeEventListener("pointerdown", onDown);
+      canvas.removeEventListener("pointermove", onMove);
+      canvas.removeEventListener("pointerup", onUp);
+      canvas.removeEventListener("pointercancel", onUp);
+    };
+  }, []);
+
+  return (
+    <div ref={wrapRef} className="relative h-full w-full">
+      <canvas ref={canvasRef} className="h-full w-full cursor-grab touch-none active:cursor-grabbing" />
+    </div>
+  );
+}

--- a/web/src/components/live/FleetPulse.tsx
+++ b/web/src/components/live/FleetPulse.tsx
@@ -19,8 +19,8 @@ export function FleetPulse({ fleet, history }: { fleet: FleetMetrics | null; his
   const harnesses = harnessOrder(Object.keys(fleet?.tpsByHarness ?? {}));
 
   return (
-    <Card className="relative overflow-hidden">
-      <CardContent className="p-5">
+    <Card className="relative flex h-full flex-col overflow-hidden">
+      <CardContent className="flex flex-1 flex-col p-5">
         <div className="text-sm font-medium text-muted-foreground">Fleet throughput</div>
         <div className="mt-1 flex items-baseline gap-2">
           <span className="font-sans text-5xl font-semibold tabular-nums leading-none">{compactNumber(displayTps)}</span>
@@ -36,7 +36,7 @@ export function FleetPulse({ fleet, history }: { fleet: FleetMetrics | null; his
           <div className="mt-1 text-xs text-muted-foreground">No tokens flowing right now — last burst {relativeTime(fleet.lastTpsAt)}</div>
         ) : null}
 
-        <div className="mt-3 h-24">
+        <div className="mt-3 h-24 min-h-[6rem] flex-1">
           {history.length > 1 ? (
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={history} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>

--- a/web/src/lib/live.ts
+++ b/web/src/lib/live.ts
@@ -44,6 +44,7 @@ export interface AgentPresence {
   tps: number;
   lastTps: number;
   lastTpsAt: string | null;
+  location?: RoughLocation | null;
 }
 
 export interface RoughLocation {


### PR DESCRIPTION
Follow-ups to the mission-control console (#562), which merged with only its first commit — these two changes were pushed to that branch afterwards, so this PR gets them onto `main`. Rebased onto current `main` (composes cleanly with the #566/#568 telemetry fixes).

### 1. Fleet throughput now adds every worker together
The hero figure was dividing summed tokens by summed elapsed, which produced a per-worker **average** — so it looked smaller than the per-harness legend. It's now the **sum of each worker's honest tok/s** (hash-rate style), so the hero equals the sum of the per-harness legend and the per-worker tok/s column. Per-harness / per-model splits are summed the same way. Retires the now-unused in-memory TPS bucket aggregation (derives from live agent rates; durable history unaffected). Composes with the honest per-agent rates from #560/#566.

Also: the left rail's KPI tiles no longer balloon on large screens — they're a fixed compact size and the throughput panel grows into the extra height as a larger hero chart.

### 2. Worldwide globe of workers + watchers
A Shopify-style rotating globe with **real country outlines** (world-atlas 110m) drawn on a dependency-free canvas — glowing markers for each located worker (coloured by harness) and watcher, drag-to-spin, ~60fps, theme-aware. A footer reads out workers mapped · watching · countries · busiest location. To place it, the bottom row is now **[globe] + [feeds]**, and the feeds panel gains an **Activity** tab beside Comments / Findings.

**Worker geolocation** (mirrors the watcher contract, #398): agents are geolocated city-level from their connection IP on `hello` (geoip-lite, offline, IP read once and discarded); adds an optional `location` to `AgentPresence`. `hello` also accepts a self-reported `location` used **only** as a fallback when IP geo fails (localhost / simulator), and the simulator now reports a spread of world cities so the globe is populated in local/dev.

### Checks
- Web `tsc` / `oxlint` / `vite build` clean; server `tsc` + tests green; globe holds ~57–60fps.
- No page scroll at 1512 / 1280 / 1920; light + dark verified.
- Two small deps added: `world-atlas` (data) + `topojson-client` (~43KB gzip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)