### PR TITLE
fix(autopilot): don't let a skipped issue burn the MAX slot; gate framing behind FRAMING=true

### DIFF
--- a/.github/trusted-reviewers.json
+++ b/.github/trusted-reviewers.json
@@ -4,8 +4,7 @@
     "adam91holt"
   ],
   "framers": [
-    "adam91holt",
-    "thecolab-clawd"
+    "adam91holt"
   ],
   "whitelist": [
     "adam91holt",

--- a/autopilot.sh
+++ b/autopilot.sh
@@ -41,6 +41,8 @@ export AGENT MODEL
 
 REVIEW_PER_WORK="${REVIEW_PER_WORK:-2}"   # review passes per work pass — bias to review; it's the bottleneck
 FRAME_PER_WORK="${FRAME_PER_WORK:-1}"       # framing/discover rework passes per cycle; frame_work owns discover roots
+FRAMING="${FRAMING:-false}"                  # OFF by default — set FRAMING=true to enable discover-root framing at all
+export FRAMING
 POLL_SECONDS="${POLL_SECONDS:-120}"       # idle wait between cycles when the whole queue is empty
 MAX_CYCLES="${MAX_CYCLES:-0}"             # 0 = run forever
 PULL="${PULL:-1}"                         # git-pull latest main each cycle (0 to disable)
@@ -233,7 +235,7 @@ while :; do
   # Framing side: discover roots and sent-back discover/framing PRs are not
   # claimable by start_work.sh (ADR-0014). Without this pass autopilot can look
   # idle while discover rework such as PRs marked "Part of #<root>" is waiting.
-  if [ "${FRAME_PER_WORK:-0}" -gt 0 ]; then
+  if [ "$FRAMING" = "true" ] && [ "${FRAME_PER_WORK:-0}" -gt 0 ]; then
     for _ in $(seq 1 "$FRAME_PER_WORK"); do
       info "frame pass…"
       run_pass frame env MAX=1 POLL_SECONDS=0 ./frame_work.sh "$@" && did_something=1

--- a/frame_work.sh
+++ b/frame_work.sh
@@ -645,6 +645,14 @@ pick_frameable() {  # $1 = queue snapshot
 
 main() {
   preflight
+  # Global framing kill-switch: framing is OFF unless explicitly enabled with
+  # FRAMING=true. This is deliberately a graceful skip (not an error) with the
+  # "nothing available" idle sentinel, so autopilot's run_pass reads it as idle
+  # rather than a failed pass. DRY_RUN still previews so you can inspect intent.
+  if [ "${FRAMING:-false}" != "true" ] && [ "$DRY_RUN" = 0 ]; then
+    info "Framing gated off — set FRAMING=true to enable discover-root framing. (nothing available to frame)"
+    return
+  fi
   # The capability floor (#379 / ADR-0014): framing is reserved for a trusted
   # identity running a powerful model. FAIL CLOSED — but let DRY_RUN through
   # with a warning so anyone can inspect what the runner would do.

--- a/start_work.sh
+++ b/start_work.sh
@@ -255,7 +255,11 @@ claim_issue() {  # $1 = issue number; returns 0 if we hold the claim
   local n="$1"
   # Re-check it's still available (best-effort lock via the label + assignee).
   local labels; labels="$(issue_labels "$n")"
-  case ",$labels," in *",status: available,"*) : ;; *) warn "#$n no longer available — skipping."; return 1 ;; esac
+  # rc 2 = "unworkable, advance to the NEXT candidate" (vs rc 1 = a genuine
+  # failed attempt): the caller must not let this consume a MAX slot, and must
+  # not re-pick this same issue on the next loop (#502 churned forever because a
+  # skip both counted toward MAX=1 and left the issue first in the queue).
+  case ",$labels," in *",status: available,"*) : ;; *) warn "#$n no longer available — skipping."; return 2 ;; esac
   # Never start FRESH work on an issue that already has an open PR: a claim
   # race that slips past the tie-break can otherwise produce two PRs for one
   # issue (#305 + #307 both closed #234), and the loser's stale PR wedges the
@@ -264,7 +268,7 @@ claim_issue() {  # $1 = issue number; returns 0 if we hold the claim
   local existing; existing="$(pr_for_issue "$n" || true)"
   if [ -n "$existing" ]; then
     warn "#$n already has open PR #$existing — skipping instead of opening a duplicate."
-    return 1
+    return 2
   fi
   if [ "$DRY_RUN" = 1 ]; then info "[dry-run] would claim #$n (assign @$ME, status: available → claimed)"; return 0; fi
   gh issue edit "$n" --repo "$REPO" --add-assignee "@me" \
@@ -307,7 +311,7 @@ finish_issue() {  # $1 = issue number
 work_one() {  # $1 = issue number
   local n="$1"
   rule; info "${c_bold}Issue #$n${c_reset} — $(issue_field "$n" title)"
-  claim_issue "$n" || return 1
+  claim_issue "$n"; local crc=$?; [ "$crc" -ne 0 ] && return "$crc"   # rc 2 = unworkable/skip → caller advances without spending a MAX slot
   if [ "$DRY_RUN" = 1 ]; then
     info "[dry-run] would run: AGENT=$AGENT in a fresh origin/main worktree on the following prompt:"; log "$(work_prompt "$n" | sed 's/^/    /')"
     finish_issue "$n"; return 0
@@ -595,6 +599,12 @@ main() {
     done=$((done+1))
     if [ "$MAX" -gt 0 ] && [ "$done" -ge "$MAX" ]; then rule; ok "Reached MAX=$MAX issue(s). Stopping."; return; fi
   fi
+  # Issues skipped as unworkable THIS run (already has a PR, no longer
+  # available). We drop them from the snapshot below so selection advances to
+  # the next candidate instead of re-picking the same stuck issue every loop
+  # (#502 was available-with-a-PR, sorted first, and churned forever). Cleared
+  # on the poll/sleep path so a long-running poller re-evaluates fresh.
+  local skip_ids=""
   while :; do
     reconcile_rework   # pull in any PRs a reviewer sent back that the hand-off missed
     # ONE GraphQL query snapshots the whole open-issue queue; every check below
@@ -604,6 +614,9 @@ main() {
     # we sleep and retry — exactly what the old per-call `|| true` reads did,
     # rather than letting set -e kill the whole runner.
     local snap; snap="$(fetch_open_issues)" || snap='[]'
+    if [ -n "$skip_ids" ]; then
+      snap="$(printf '%s' "$snap" | jq --argjson skip "[$skip_ids]" '[.[] | select((.number as $n | $skip | index($n)) | not)]')" || snap='[]'
+    fi
     # Priority: my own rework → a TTL-freed rework I can push → a fresh issue.
     local next kind=new
     next="$(rework_issues "$snap" | head -1 || true)"
@@ -619,11 +632,19 @@ main() {
         # same issue every cycle (the claim tie-break stays correct regardless;
         # this just cuts down how often two of them collide in the first place).
         local nap=$(( POLL_SECONDS + (RANDOM % (POLL_SECONDS / 4 + 1)) ))
-        log "No rework for @$ME and no available issues. Sleeping ${nap}s... (Ctrl-C to stop)"; sleep "$nap"; continue
+        log "No rework for @$ME and no available issues. Sleeping ${nap}s... (Ctrl-C to stop)"; skip_ids=""; sleep "$nap"; continue
       fi
       rule; ok "Queue empty — no rework for @$ME and nothing available.${STAGE:+ (stage=$STAGE)}"; break
     fi
-    if [ "$kind" = rework ]; then rework_one "$next" || true; else work_one "$next" || true; fi
+    local wrc=0
+    if [ "$kind" = rework ]; then rework_one "$next" || wrc=$?; else work_one "$next" || wrc=$?; fi
+    # rc 2 = the issue was unworkable (already has a PR / no longer available).
+    # A skip must NOT spend a MAX slot; remember it so we don't re-pick it, and
+    # loop straight to the next candidate.
+    if [ "$wrc" -eq 2 ]; then
+      skip_ids="${skip_ids:+$skip_ids,}$next"
+      continue
+    fi
     done=$((done+1))
     if [ "$MAX" -gt 0 ] && [ "$done" -ge "$MAX" ]; then rule; ok "Reached MAX=$MAX issue(s). Stopping."; break; fi
   done


### PR DESCRIPTION
## Problem

The autopilot work pass was **spinning without doing work** despite 30+ `status: available` research issues in the queue.

Two compounding bugs in `start_work.sh`:

1. **A skip counted as a completed issue.** `claim_issue` returns non-zero when an issue is unworkable (already has an open PR, or no longer `available`). The loop did `work_one … || true` then unconditionally `done=$((done+1))`. With autopilot's `MAX=1`, skipping the first stuck issue (#502, `available`-with-PR-#565) *spent the single slot* → "Reached MAX=1. Stopping." — before reaching any real work.
2. **The same dead issue was re-picked every pass.** `pick_available` returns the oldest available issue; #502 sorts first and nothing excluded it, so every cycle re-picked and re-skipped it forever.

## Fix

- `claim_issue` returns **rc 2** ("unworkable — advance") for the two skip cases, distinct from rc 1 (a genuine failed attempt). `work_one` propagates it.
- The main loop treats rc 2 as: **don't spend a `MAX` slot**, remember the id, prune it from the queue snapshot, and advance to the next candidate. `skip_ids` is cleared on the poll/sleep path so a long-running poller re-evaluates fresh.

Verified with a dry run against the live queue: `#502` skips → advances to `#504` → claims real work → *then* counts the slot. Previously it stopped dead on #502.

## Framing lockdown (temporary, maintainer-only)

Framing now requires **both**:

- **`FRAMING=true`** — new global kill-switch, **OFF by default**. `autopilot.sh` skips the frame pass entirely unless set; `frame_work.sh main()` enforces it directly too (graceful idle skip, not an error), so a bare `./frame_work.sh` no-ops. `DRY_RUN=1` still previews.
- **Identity = `adam91holt` only** — removed `thecolab-clawd` from `framers` in `.github/trusted-reviewers.json` (existing capability-floor gate, ADR-0014).

## Files
- `start_work.sh` — skip-accounting fix
- `autopilot.sh` — `FRAMING` gate on the frame pass
- `frame_work.sh` — `FRAMING` enforcement in `main()`
- `.github/trusted-reviewers.json` — `framers` = `adam91holt` only

All pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)