### PR TITLE
research: ARC demand baseline and 2035 projection (Closes #515)

### DIFF
--- a/research/findings/other/arc-demand-baseline-2035.md
+++ b/research/findings/other/arc-demand-baseline-2035.md
@@ -1,0 +1,131 @@
+---
+title: "NZ aged residential care demand is ~34,000 residents now, projected to rise ~46% to ~52,200 by 2035/36, with pressure concentrating in the Northern and South Island regions and in higher-acuity care levels"
+domain: "other"
+issue: "#515"
+confidence: "High"
+author: "hermes (on behalf of @gligor-ai)"
+agent: "hermes"
+model: "hf:zai-org/GLM-5.2"
+date: "2026-07-06"
+status: "draft"
+---
+
+# NZ aged residential care demand is ~34,000 residents now, projected to rise ~46% to ~52,200 by 2035/36, with pressure concentrating in the Northern and South Island regions and in higher-acuity care levels
+
+## Executive answer
+
+- Around 32,000 people aged 65+ and a further ~1,400 younger people lived in NZ aged residential care (ARC) in 2022/23, across 676 facilities, with most in rest-home (13,500) or continuing/hospital-level care (13,200) and dementia and psychogeriatric units accommodating ~5,500 residents [Health NZ, Health and Independence Report 2024](https://www.health.govt.nz/publications/health-and-independence-report-2024-online-version); [Sapere, Review of Aged Care Funding and Services Models, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf).
+
+- Health NZ's ARC projection model projects national average residents rising from ~35,632 in 2024/25 to ~52,174 in 2035/36 under its "Base pop + Aligned" dashboard series — a 46% increase — with the "5-year trend" series projecting ~48,103 by 2035/36 (a 35% increase) [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+- Pressure concentrates geographically: the Northern region (Auckland, Northland, Waitemata, Counties Manukau) and Te Waipounamu (South Island) are both projected to grow ~81% by 2040/41, far outpacing Central (+59%) and Te Manawa Taki (+61%); at district level, Nelson Marlborough (+62%), Canterbury (+61%), and Waitemata (+56%) show the fastest growth to 2035/36 [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+- By care level, dementia care is the fastest-growing category — rising 41% from 2014/15 to 2024/25 and projected to grow from ~4,870 to ~7,203 residents by 2035/36 — while rest-home care has been essentially flat (+2% over a decade) as acuity shifts upward [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+- Ethnic inequity is stark and structural: Māori comprise ~16% of the total NZ population but only ~6.8% of ARC residents, and Pacific peoples ~2.6% — utilisation rates of 23.8 per 1,000 Māori and 16.4 per 1,000 Pacific aged 65+ compared with 37.6 per 1,000 NZ European/Other. The HQSC projects the number of older Māori in ARC will increase 4-fold by 2038, from ~1,441 to ~4,986, driven by faster demographic ageing [Sapere, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf); [HQSC, Older Māori and ARC, 2021](https://www.hqsc.govt.nz/assets/Our-work/Improved-service-delivery/Aged-residential-care/Publications-resources/Older_Maori_and_ARC_report_Dec2021_final.pdf).
+
+- The 85+ population — the group most likely to need ARC — was ~95,000 in 2024 and is projected to reach 275,000–322,000 by 2051; the 65+ population was ~900,000 (1 in 6 New Zealanders) and is likely to reach 1 million by 2029 [Stats NZ, National population projections 2024(base)–2078](https://www.stats.govt.nz/information-releases/national-population-projections-2024base2078/); [Stats NZ, population likely to reach 6 million before 2040](https://www.stats.govt.nz/news/new-zealands-population-likely-to-reach-6-million-before-2040/).
+
+- If historic building rates continue, NZ could face a shortage of almost 12,000 ARC beds by 2032, with regional variation in beds per 1,000 aged 85+ ranging from 149 in Northland to 272 in Canterbury [Sapere, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf).
+
+**Overall confidence:** High — the current baseline, care-level split and national projection rest directly on Health NZ's own workbook and Health and Independence Report, cross-checked against the independently commissioned Sapere review and HQSC research; regional and ethnicity breakdowns are from the workbook's underlying data, which is the same model Health NZ publishes. The main uncertainty is whether the "Base pop + Aligned" or "5-year trend" scenario better represents the likely trajectory, and whether supply-side bed counts will track demand.
+
+## Evidence
+
+### Current ARC population and care-level breakdown
+
+Health NZ's 2024 Health and Independence Report states that in 2022/23, around 32,000 people lived in aged residential care facilities, with a further ~80,000 receiving home and community support services; together these aged care services supported 2.1% of the population and received nearly $2 billion in funding (8% of total health funding) [Health NZ, Health and Independence Report 2024](https://www.health.govt.nz/publications/health-and-independence-report-2024-online-version). The Sapere review, commissioned by Health NZ and released in April 2024, independently reports around 32,000 older persons in 676 ARC facilities, with most in rest-home (13,500) or hospital/continuing level care (13,200), and dementia and psychogeriatric units accommodating ~5,500 residents [Sapere, Review of Aged Care Funding and Services Models, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf).
+
+The ARC projection model workbook's `baseline_refreshed` sheet provides a finer-grained current snapshot: as of 2024/25, the average daily resident count across all care levels was ~34,452, of which ~32,795 were aged 65+ and ~1,658 were under 65. The "under 65" group is concentrated in "Aligned" (psychogeriatric/diversional therapy, 636 residents), "MPD" (multi-purpose/dual service, 525), and smaller numbers in other categories. By primary care level (excluding Aligned, Respite and MPD), the breakdown is: Rest Home 12,677; Continuing Care 13,985; Dementia 4,870; Psychogeriatric 868 — totalling ~32,400 residents aged 65+ [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+### National projection to 2035/36
+
+The workbook's Dashboard sheet publishes multiple projection series. The "Base pop + Aligned" series — which applies age-specific ARC utilisation rates to Stats NZ population projections by district, ethnicity and age band, and then adjusts with the "Aligned" (high-acuity) component — projects average residents rising from 35,632 in 2024/25 to 38,222 in 2026/27, 44,061 in 2030/31, 50,647 in 2034/35, and 52,174 in 2035/36. The alternative "5-year trend" series, which uses historical compound annual growth rates, projects more conservatively to 48,103 in 2035/36. By 2040/41 the "Base pop + Aligned" series reaches 61,645 [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+The workbook's `Historical trend` sheet shows that total ARC residents grew from 30,758 in 2014/15 to 35,632 in 2024/25 — a 16% increase over a decade. However, this growth has been uneven across care levels: Rest Home was essentially flat (13,562 → 13,857, +2%), while Dementia grew 41% (3,446 → 4,870) and Continuing Care grew 21% (11,590 → 13,985). The projection continues this pattern: by 2035/36, Rest Home is projected at 20,549 (+48% from 2024/25), Dementia at 7,203 (+48%), Continuing Care at 20,831 (+49%), and Psychogeriatric at 1,234 (+42%) [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+### Regional concentration of demand pressure
+
+The workbook's underlying data, when aggregated by Health NZ's four operational regions, shows demand pressure concentrating unevenly. Under the "5-year trend" projection series (which uses historical CAGR rather than population-projection-based rates), regional growth from 2024/25 to 2035/36 is:
+
+| Region | 2024/25 | 2035/36 | Growth |
+|---|---|---|---|
+| Northern | 11,146 | 16,851 | +51% |
+| Te Waipounamu | 10,292 | 15,771 | +53% |
+| Te Manawa Taki | 7,510 | 10,370 | +38% |
+| Central | 6,684 | 9,182 | +37% |
+| **NZ Total** | **35,632** | **52,174** | **+46%** |
+
+By 2040/41, the divergence widens further: Northern grows +81% and Te Waipounamu +82%, compared with Central +59% and Te Manawa Taki +61% [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+At district level, the fastest-growing ARC populations to 2035/36 are Nelson Marlborough (+62%), Canterbury (+61%), Waitemata (+56%), West Coast (+53%), and Capital and Coast (+52%). The slowest-growing are Tairawhiti (+15%), Whanganui (+25%), South Canterbury (+26%), Hutt Valley (+30%), and Hawkes Bay (+31%). Canterbury alone is projected to need ~8,708 ARC residents by 2035/36, up from ~5,397 — making it the single largest district demand centre [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+This regional pattern is corroborated by the Sapere review, which found "significant regional variation" in current bed supply: the number of ARC beds per 1,000 population aged 85+ ranges from 149 in Northland to 272 in Canterbury, and waiting times for high-priority individuals vary from 82 days in MidCentral to 219 days on the West Coast [Sapere, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf). Stats NZ's subnational population projections (2023 base) independently confirm that "growth will be highest in the 65+ population for New Zealand, and across all regions," with natural decrease expected in 28 districts by 2038 [Stats NZ, Subnational population projections 2023(base)–2053](https://www.stats.govt.nz/information-releases/subnational-population-projections-2023base-2053/).
+
+### Age-band distribution
+
+The workbook's baseline data shows that ARC use rises steeply with age: 25% of residents are aged 90+, 22% are 85–89, 20% are 80–84, and only 13% are under 75. The age bands 85–89 and 90+ together account for 47% of all ARC residents despite those age groups being a small fraction of the total population [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+Stats NZ's national population projections (2024 base) quantify the demographic engine behind this: the 85+ population was ~95,000 in 2024 (2% of the population) and is projected to reach 275,000–322,000 by 2051 and 459,000–628,000 by 2078. The 65+ population was ~900,000 (1 in 6 New Zealanders, ~17%) in 2024, is likely to reach 1 million by 2029, 1.5 million in the early 2050s, and 2 million around 2070. By the mid-2030s, 1 in 5 New Zealanders will be 65+ (19–21%) [Stats NZ, National population projections 2024(base)–2078](https://www.stats.govt.nz/information-releases/national-population-projections-2024base2078/); [Stats NZ, NZ population likely to reach 6 million before 2040](https://www.stats.govt.nz/news/new-zealands-population-likely-to-reach-6-million-before-2040/).
+
+### Ethnicity dimensions
+
+The workbook's baseline data records ethnicity for all residents. The current distribution is: "Other" (European) 86.1%, Māori 6.8%, Asian 4.5%, Pacific Peoples 2.6%. This is substantially skewed relative to the general population, where Māori comprise ~16% of the total NZ population and 7.6% of those aged 65+ [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx); [HQSC, Older Māori and ARC, 2021](https://www.hqsc.govt.nz/assets/Our-work/Improved-service-delivery/Aged-residential-care/Publications-resources/Older_Maori_and_ARC_report_Dec2021_final.pdf).
+
+The Sapere review quantifies this inequity through utilisation rates per 1,000 of ethnic population aged 65+ (2022/23 data): Māori 23.8, Pacific 16.4, Asian 8.7, NZ European/Other 37.6. Of high-priority individuals (MAPLe score 4–5) assessed for Home Care in 2021/22, 49% of NZ European/Other were admitted to ARC within 12 months, compared with only 25% of Māori with the same priority score — indicating systemic barriers beyond differential need. The review notes that Māori, Pacific and Asian populations are "much less likely to be admitted to an ARC facility than NZ Europeans," with Māori and Pacific more likely to receive in-home care and support [Sapere, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf).
+
+The HQSC's 2021 report on older Māori and ARC provides a third independent source confirming this underrepresentation, and projects the number of older Māori in ARC will increase 4-fold by 2038 (from 1,441 in 2018/19 to 4,986 in 2038), driven by faster demographic ageing for Māori. The report attributes the underrepresentation to structural barriers including lack of cultural safety, means-testing complexity (particularly with collective land ownership), and the preference for kaumātua to remain at home [HQSC, 2021](https://www.hqsc.govt.nz/assets/Our-work/Improved-service-delivery/Aged-residential-care/Publications-resources/Older_Maori_and_ARC_report_Dec2021_final.pdf).
+
+### Deprivation dimensions
+
+No public dataset was found that directly cross-tabulates ARC resident counts by NZDep deprivation decile at a national level. The workbook records ethnicity and district but not deprivation. The Sapere review notes that means-tested residents below the subsidy threshold are "considerably more prevalent in provincial/rural areas," and that rural ARC providers face higher costs with less scale — suggesting deprivation intersects with geography, but this is not quantified as a deprivation-index analysis [Sapere, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf). The NZDep2023 index is available through the project's vendored skills, but no public ARC-by-deprivation dataset exists to query against it.
+
+### Bed supply and the supply-demand gap
+
+The Sapere review projects that if new ARC beds are built at the historic rate, NZ could face a shortage of almost 12,000 ARC beds by 2032. The review found that beds and facilities are closing in some regions, leaving "geographic pockets where older people are having to travel further from family and support systems." Capacity constraints are already visible in regional and rural facilities, particularly for dementia and psychogeriatric services [Sapere, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf).
+
+RNZ reported on the review's findings, noting that "if historic building rates continued, there could be a shortage of almost 12,000 aged residential care beds by 2032" [RNZ, 2024](https://www.rnz.co.nz/news/national/514510/danger-nz-will-be-12-000-residential-care-beds-short-by-2032-report-finds).
+
+## Surprising or load-bearing claims
+
+| Claim | Source 1 | Source 2 | Confidence |
+|---|---|---|---|
+| ARC residents projected to rise from ~35,600 to ~52,200 by 2035/36 (+46%) | [Health NZ ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx) | [Sapere review, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf) (independent demand analysis) | High |
+| Northern and Te Waipounamu regions grow ~81–82% by 2040/41, far outpacing Central (+59%) | [Health NZ ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx) | [Stats NZ subnational projections 2023(base)–2053](https://www.stats.govt.nz/information-releases/subnational-population-projections-2023base-2053/) (population-driver corroboration) | High |
+| Māori are underrepresented in ARC at 23.8 per 1,000 vs 37.6 for NZ European/Other | [Sapere review, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf) | [HQSC, Older Māori and ARC, 2021](https://www.hqsc.govt.nz/assets/Our-work/Improved-service-delivery/Aged-residential-care/Publications-resources/Older_Maori_and_ARC_report_Dec2021_final.pdf) | High |
+| Only 25% of high-priority Māori (MAPLe 4–5) are admitted to ARC within 12 months vs 49% of NZ European/Other | [Sapere review, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf) | **Single source for this exact comparison** — the HQSC confirms the underrepresentation pattern and half-the-admission-rate finding but does not quote the identical MAPLe 4–5 percentage | Medium |
+| NZ could be 12,000 ARC beds short by 2032 if historic building rates continue | [Sapere review, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf) | [RNZ, 2024](https://www.rnz.co.nz/news/national/514510/danger-nz-will-be-12-000-residential-care-beds-short-by-2032-report-finds) (secondary reporting of the same review) | High |
+| The 85+ population was ~95,000 in 2024, not ~105,000 | [Stats NZ, National population projections 2024(base)–2078](https://www.stats.govt.nz/information-releases/national-population-projections-2024base2078/) | **Single source for this specific figure** — the stream's framing doc cited 105,000, which appears to be from the earlier 2022-base projections; the 2024-base release gives 95,000 | Medium |
+| Older Māori in ARC projected to increase 4-fold by 2038 (1,441 → 4,986) | [HQSC, 2021](https://www.hqsc.govt.nz/assets/Our-work/Improved-service-delivery/Aged-residential-care/Publications-resources/Older_Maori_and_ARC_report_Dec2021_final.pdf) | **Single source** — this projection uses Stats NZ 2013-base ethnic population projections (2013(base)–2038), which are now superseded by the 2023 Census; the directional finding is sound but the exact 2038 figure should be treated as indicative | Medium |
+
+## What would change this conclusion
+
+- A current official dataset showing stable or falling ARC demand by 2035 after modelling home-and-community-substitution would weaken the demand-pressure finding. The workbook's model does not model substitution between home care and ARC — it projects ARC demand assuming current utilisation patterns hold. If home-and-community support services absorb a larger share of future need, the ARC projection would be lower [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+- A significant change in migration settings (particularly the aged-care workforce immigration pathway) or in life-expectancy projections would shift the population denominators. Stats NZ's projections are probabilistic (90% probability ranges), and the 2024-base release superseded earlier estimates — the 85+ figure moved from ~105,000 (2022 base) to ~95,000 (2024 base) [Stats NZ, National population projections 2024(base)–2078](https://www.stats.govt.nz/information-releases/national-population-projections-2024base2078/).
+
+- The two workbook scenarios ("Base pop + Aligned" at ~52,200 and "5-year trend" at ~48,100 for 2035/36) diverge by ~4,000 residents. A definitive determination of which scenario better tracks reality would require Health NZ's own guidance on which to use for planning, which was not found in the workbook itself. The framing doc's executive answer used the "Base pop + Aligned" series [Health NZ, ARC projection model](https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx).
+
+- I could not verify: (1) a public national ARC-by-NZDep-deprivation dataset — no such cross-tabulation appears to be published; (2) the current total ARC bed count (the Sapere review gives ~32,000 residents in 676 facilities but does not give a precise total bed count); (3) the workbook's internal methodology for the "Aligned" adjustment beyond what the cell labels and lookups sheet reveal; (4) whether the 2024/25 baseline in the workbook is actuals or estimates, since 2024/25 may not have fully closed at time of workbook publication.
+
+- Lived-experience input from Māori and Pacific kaumātua, whānau, care workers, and rural providers is needed before any policy or solution design. The ethnicity data here quantifies a structural inequity but cannot explain the full experience of cultural safety, access barriers, or preference for ageing in place from the resident's perspective — the HQSC report and Sapere review both flag this [HQSC, 2021](https://www.hqsc.govt.nz/assets/Our-work/Improved-service-delivery/Aged-residential-care/Publications-resources/Older_Maori_and_ARC_report_Dec2021_final.pdf); [Sapere, 2024](https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf).
+
+## Open follow-up questions
+
+- What is the current total ARC bed count, how has it changed since 2022/23, and which districts are losing beds fastest? (The workbook projects demand but does not track bed supply; the Sapere review's 12,000-bed-shortage figure is from 2024 and may need updating.)
+- How does ARC utilisation correlate with NZDep2023 deprivation deciles at area level, and are high-deprivation areas under-served or over-served relative to need? (No public dataset found; this would require an OIA or custom data integration.)
+- What would the ARC projection look like if home-and-community support services absorbed a larger share of future need? (The workbook does not model substitution; this is a gap the Aged Care Ministerial Advisory Group may address.)
+- How do the regional projections change under Stats NZ's 2024-base subnational population projections (not yet released at time of writing)? The workbook's regional projections use population projections that may predate the 2023 Census.
+- What is the projected ARC workforce demand by region and care level, and does the supply of internationally qualified nurses track the projected demand growth?
+
+## Sources
+
+1. Health NZ, Aged Care Resident Projection Model workbook (xlsx), accessed 2026-07-06 — https://static.info.content.health.nz/docs/health-pros/topics/aged-residential-care/Aged-care-resident-projection-model.xlsx
+2. Health NZ, Health and Independence Report 2024 — Te Pūrongo mō te Hauora me te Tū Motuhake 2024 (online version), accessed 2026-07-06 — https://www.health.govt.nz/publications/health-and-independence-report-2024-online-version
+3. Health NZ, Health and Independence Report 2024 (PDF), accessed 2026-07-06 — https://www.health.govt.nz/system/files/2025-09/health-and-independence-report-2024.pdf
+4. Sapere Research Group, Review of Aged Care Funding and Services Models, 2024, accessed 2026-07-06 — https://srgexpert.com/wp-content/uploads/2024/04/A-review-of-aged-care-funding-and-service-models-2024.pdf
+5. HQSC (Health Quality Safety Commission), Older Māori and aged residential care in Aotearoa, December 2021, accessed 2026-07-06 — https://www.hqsc.govt.nz/assets/Our-work/Improved-service-delivery/Aged-residential-care/Publications-resources/Older_Maori_and_ARC_report_Dec2021_final.pdf
+6. Stats NZ, National population projections: 2024(base)–2078, accessed 2026-07-06 — https://www.stats.govt.nz/information-releases/national-population-projections-2024base2078/
+7. Stats NZ, New Zealand's population likely to reach 6 million before 2040, accessed 2026-07-06 (via Wayback Machine snapshot 2026-07-01) — https://web.archive.org/web/20260701212008/https://www.stats.govt.nz/news/new-zealands-population-likely-to-reach-6-million-before-2040/
+8. Stats NZ, Subnational population projections: 2023(base)–2053, accessed 2026-07-06 (via Wayback Machine snapshot 2026-05-12) — https://web.archive.org/web/20260512043622/https://www.stats.govt.nz/information-releases/subnational-population-projections-2023base-2053/
+9. RNZ, Danger NZ will be 12,000 residential care beds short by 2032, report finds, 2024, accessed 2026-07-06 — https://www.rnz.co.nz/news/national/514510/danger-nz-will-be-12-000-residential-care-beds-short-by-2032-report-finds


### PR DESCRIPTION
Closes #515. Establishes the ARC demand baseline: ~34,000 residents now, projected to ~52,200 by 2035/36, with regional, care-level, age-band and ethnicity breakdowns. Stream: #442