### PR TITLE
feat(server): TOFU auto-enrollment — server claiming as autopilot's default, no token hand-outs

### DIFF
--- a/autopilot.sh
+++ b/autopilot.sh
@@ -33,9 +33,11 @@
 # Env:  REVIEW_GITHUB_TOKEN  REVIEW_PER_WORK(=2)  POLL_SECONDS(=120)
 #       MAX_CYCLES(=0)  PULL(=1)  MAIN_BRANCH(=main)  + everything the runners read
 #       FLEET_SERVER(=https://forgood.thecolab.ai; ""=off)  STREAM_LOGS(=0, opt-in)
-#       FLEET_TOKEN (server-minted agent token: authed heartbeats + pause/resume/
-#       stop/abort commands)  FLEET_CLAIM(=0; 1 + FLEET_TOKEN = server-orchestrated
-#       claiming in start_work.sh — default off, label-claim flow unchanged)
+#       FLEET_CLAIM(=1: server-orchestrated claiming, AUTO-ENROLLS this gh
+#       identity on first contact and stores the token in ~/.forgood/ — no
+#       hand-outs; every failure falls back to the label-claim path; 0=off)
+#       FLEET_TOKEN (optional pre-minted agent token — overrides auto-enroll;
+#       authed heartbeats carry pause/resume/stop/abort commands either way)
 set -euo pipefail
 cd "$(dirname "$0")"
 source "scripts/fg-common.sh"
@@ -97,6 +99,20 @@ if [ -n "$FLEET_CMDS_FILE" ]; then
   ( umask 077; : > "$FLEET_CMDS_FILE" ) 2>/dev/null || true
 fi
 fleet_cleanup_run_dir() { [ -n "${FLEET_RUN_DIR:-}" ] && rm -rf "$FLEET_RUN_DIR" 2>/dev/null || true; }
+
+# Server-orchestrated claiming (ADR-0017) — ON by default: the runner asks
+# the fleet server for its next issue (atomic Redis lease, no label race)
+# and AUTO-ENROLLS on first contact — the server mints this identity's token
+# straight into ~/.forgood/, so nobody hands tokens out. EVERY failure
+# (server down, enrollment refused, queue empty) falls back to the exact
+# label-claim path, so this is safe to default on. Opt out with
+# FLEET_CLAIM=0. The enrolled token also authenticates heartbeats, which is
+# what makes server-side pause/stop/abort commands reach this runner.
+FLEET_CLAIM="${FLEET_CLAIM-1}"
+export FLEET_CLAIM
+if [ -n "$FLEET_SERVER" ] && [ "$FLEET_CLAIM" = "1" ]; then
+  fleet_ensure_token || true
+fi
 
 fleet_enabled() { [ -n "$FLEET_SERVER" ]; }
 

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -251,13 +251,20 @@ writes the *same* `status: claimed` label + assignee itself
 ([ADR-0017](adr/0017-server-orchestrated-pull-claim.md); server setup and the
 full API live in [`server/README.md`](../server/README.md)).
 
-**Default OFF.** Nothing changes unless *both* are set:
+**Default ON in `autopilot.sh` — with nothing to hand out.** Just run it:
 
 ```bash
-FLEET_TOKEN=fgt_...   # server-minted bearer token (a maintainer mints it — see server/README.md)
-FLEET_CLAIM=1         # opt into server claiming (FLEET_SERVER already defaults to production)
-./autopilot.sh codex
+./autopilot.sh codex   # first contact AUTO-ENROLLS your gh identity: the server
+                       # mints your token into ~/.forgood/ (0600) — no maintainer step
 ```
+
+`FLEET_CLAIM=0` opts out (label path only). A pre-minted `FLEET_TOKEN=fgt_...`
+overrides auto-enrollment (that's how elevated-tier identities run). Standalone
+`start_work.sh` keeps server claiming opt-in (`FLEET_CLAIM=1`). If enrollment
+is refused (handle already enrolled elsewhere, or revoked) the runner warns
+once and uses the label path — recovery is an operator re-mint, never
+self-service (a revocation must stick). One handle can hold at most
+`MAX_ACTIVE_CLAIMS` (default 3) live server claims at a time.
 
 What changes when it's on:
 

--- a/docs/adr/0017-server-orchestrated-pull-claim.md
+++ b/docs/adr/0017-server-orchestrated-pull-claim.md
@@ -48,17 +48,32 @@ and fail-open at every layer:
    durable source of truth.** Every durable fact still lands on GitHub as the same
    labels/assignees humans and non-enrolled contributors rely on; the server's MongoDB
    mirror (fed by HMAC-verified webhooks plus a reconciling interval sync) is a rebuildable
-   cache, never authoritative; enrolment is per-agent opt-in (`FLEET_CLAIM=1` +
-   `FLEET_TOKEN`), and every server failure falls back to today's label path. A fleet with
-   the server unplugged is slower and racier, never stuck.
-3. **Auth is a server-minted token registry with trust tiers.** A maintainer mints a bearer
-   token bound to a GitHub handle and a tier (`framer` / `trusted` / `standard`); only the
-   SHA-256 hash is stored, and revocation is server-side and immediate. GitHub device-flow
-   auth (designed in #398) is deferred: it proves control of a GitHub account, not the
-   maintainer's decision to trust that identity with a claim-writing bot token — minting
-   *is* the trust decision, mirroring the `trusted-reviewers.json` allow-lists — and it
-   would cost an OAuth app plus an interactive step per enrolment. Tiers are recorded now
-   so later capability-floored dispatch doesn't need a schema change.
+   cache, never authoritative; and every server failure falls back to today's label path.
+   Server claiming is the **default** in `autopilot.sh` (`FLEET_CLAIM=1`; opt out with
+   `FLEET_CLAIM=0`) precisely because that fallback is total — a fleet with the server
+   unplugged is slower and racier, never stuck.
+3. **Auth is a server-minted token registry with trust tiers, and standard-tier tokens
+   self-mint on first contact (TOFU auto-enrollment).** Nobody hands tokens out: a
+   runner's first contact calls `POST /api/v1/agents/enroll` with its self-reported GitHub
+   login, the server mints a `standard`-tier token exactly once per handle (a unique index
+   arbitrates racers), and the runner stores it under `~/.forgood/` (0600). Only the
+   SHA-256 hash is stored server-side, and revocation is immediate and *sticky*: a revoked
+   or already-enrolled handle is never re-issued by enrollment — recovery is an operator
+   re-mint (`fleet-admin.mjs` / admin route), otherwise anyone could rotate a rival's
+   token by re-enrolling their handle. The accepted trade-off is **first-contact handle
+   squatting** (identity is assumed-trust, exactly like telemetry's `hello.handle` and the
+   label path's claim comments): squatting is visible in the registry, revocable, bounded
+   by a per-handle active-claim cap (`MAX_ACTIVE_CLAIMS`, default 3) and per-IP rate
+   limits — and the adversarial review gate remains the merge-time defence regardless of
+   who claimed. `AUTO_ENROLL=0` turns self-enrollment off (operator-minted tokens only).
+   Elevated tiers (`framer` / `trusted`) are still operator-minted decisions, mirroring
+   the `trusted-reviewers.json` allow-lists. GitHub device-flow auth (designed in #398)
+   stays deferred — it proves account control, which assumed-trust deliberately doesn't
+   require, at the cost of an OAuth app plus an interactive step per enrolment. One
+   mechanical consequence: GitHub silently drops assignees without repo access, so an
+   auto-enrolled outside contributor's claim proceeds **without** an assignee
+   (`assigneeSet:false` on the assignment; the label + lease still carry the claim) —
+   the same situation the label path has always had for fork contributors.
 4. **Redis and Mongo split by lifetime.** Redis holds hot, expiring, atomicity-critical
    state: leases and command-delivery queues. MongoDB holds durable-but-rebuildable state:
    the issue/PR mirror, webhook deliveries, the agent registry, the assignments audit

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -50,8 +50,51 @@ rule() { printf '%s────────────────────�
 # The telemetry side (fleet_send / fleet_logs) lives in autopilot.sh; these
 # live here so start_work.sh (which has no telemetry helpers) can claim,
 # renew and release too.
+# Where the auto-enrolled token lives (0600, owner-only). One file per
+# server host so pointing FLEET_SERVER elsewhere never replays a token minted
+# for a different server.
+fleet_token_file() {
+  local host; host="$(printf '%s' "${FLEET_SERVER:-}" | sed 's|^[a-z]*://||; s|[/:].*$||')"
+  printf '%s' "${FLEET_TOKEN_FILE:-$HOME/.forgood/fleet-token-${host:-default}}"
+}
+
+# fleet_ensure_token — resolve FLEET_TOKEN: env var > stored file > TOFU
+# auto-enroll against the server (ADR-0017: first contact mints the token,
+# so nobody hands tokens out). Returns 1 when no token can be resolved (the
+# caller falls back to the label-claim path). The stored file is trusted
+# only when it is a regular, non-symlink file we own — same paranoia as the
+# command stash: a foreign-writable path must never feed a bearer token.
+fleet_ensure_token() {
+  [ -n "${FLEET_TOKEN:-}" ] && return 0
+  [ -n "${FLEET_SERVER:-}" ] || return 1
+  local f; f="$(fleet_token_file)"
+  if [ -f "$f" ] && [ ! -L "$f" ] && [ -O "$f" ]; then
+    FLEET_TOKEN="$(head -c 256 "$f" 2>/dev/null | tr -d '[:space:]')"
+    [ -n "$FLEET_TOKEN" ] && { export FLEET_TOKEN; return 0; }
+  fi
+  # First contact: enroll this gh identity. 409 = the handle is already
+  # enrolled somewhere else (or was revoked) — that's an operator
+  # conversation, not something to retry every loop.
+  local resp token
+  resp="$(curl -sS -m 5 -X POST "$FLEET_SERVER/api/v1/agents/enroll" \
+    -H 'content-type: application/json' \
+    -d "$(jq -cn --arg h "${ME:-${FLEET_HANDLE:-}}" --arg a "${AGENT:-}" --arg m "${MODEL:-}" '
+        {handle: $h}
+      + (if $a != "" then {harness: $a[0:32]} else {} end)
+      + (if $m != "" then {model: $m[0:128]} else {} end)')" 2>/dev/null)" || return 1
+  token="$(printf '%s' "$resp" | jq -r 'select(.ok == true) | .token // empty' 2>/dev/null || true)"
+  if [ -z "$token" ]; then
+    warn "fleet enrollment failed for @${ME:-${FLEET_HANDLE:-?}}: $(printf '%s' "$resp" | jq -r '.error // "server unreachable"' 2>/dev/null || echo 'server unreachable') — using the label-claim path."
+    return 1
+  fi
+  ( umask 077; mkdir -p "$(dirname "$f")" && printf '%s' "$token" > "$f" ) || true
+  FLEET_TOKEN="$token"; export FLEET_TOKEN
+  ok "Enrolled @${ME:-${FLEET_HANDLE:-?}} with the fleet server (token stored in $f)"
+  return 0
+}
+
 fleet_claim_enabled() {
-  [ -n "${FLEET_SERVER:-}" ] && [ -n "${FLEET_TOKEN:-}" ] && [ "${FLEET_CLAIM:-0}" = "1" ]
+  [ -n "${FLEET_SERVER:-}" ] && [ "${FLEET_CLAIM:-0}" = "1" ] && fleet_ensure_token
 }
 
 # fleet_claim [stages-csv] — ask the server for the next eligible issue. On

--- a/scripts/test-fg-common-fleet.sh
+++ b/scripts/test-fg-common-fleet.sh
@@ -50,6 +50,19 @@ class Handler(BaseHTTPRequestHandler):
         with open(log_file, "a") as f:
             f.write(json.dumps({"path": self.path, "body": body, "auth": auth}) + "\n")
         mode = open(mode_file).read().strip()
+        if self.path == "/api/v1/agents/enroll":
+            if mode == "enroll409":
+                raw = json.dumps({"ok": False, "error": "handle already enrolled"}).encode()
+                self.send_response(409)
+            else:
+                raw = json.dumps({"ok": True, "token": "fgt_" + "ab" * 16,
+                                  "handle": "testuser", "tier": "standard"}).encode()
+                self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+            return
         if mode == "empty":
             payload = {"ok": True, "issue": None}
         elif mode == "garbage":
@@ -176,5 +189,42 @@ if [ -n "$foreign" ] && [ ! -O "$foreign" ]; then
 else
   pass "fleet_pop_commands: drain-once + refuses non-regular stashes (no foreign file available to test ownership)"
 fi
+
+# --- fleet_ensure_token: TOFU auto-enroll (ADR-0017) ---------------------------
+# No FLEET_TOKEN anywhere → first contact enrolls, stores the token 0600,
+# and later runs reuse the stored file without re-enrolling.
+unset FLEET_TOKEN
+export FLEET_TOKEN_FILE="$TMP/fleet-token"
+ME="testuser"
+enrolls_before="$(grep -c '/api/v1/agents/enroll' "$LOG_FILE" || true)"
+fleet_claim_enabled || fail "auto-enroll must resolve a token with no FLEET_TOKEN set"
+[ "$FLEET_TOKEN" = "fgt_$(printf 'ab%.0s' 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)" ] \
+  || fail "FLEET_TOKEN must hold the enrolled token (got: ${FLEET_TOKEN:-unset})"
+req="$(grep '/api/v1/agents/enroll' "$LOG_FILE" | tail -1)"
+printf '%s' "$req" | jq -e '.body | fromjson | .handle == "testuser"' >/dev/null \
+  || fail "enroll must send the gh identity as the handle (got: $req)"
+[ -f "$FLEET_TOKEN_FILE" ] || fail "enrolled token must be stored"
+[ "$(stat -c %a "$FLEET_TOKEN_FILE")" = "600" ] || fail "stored token must be 0600 (got $(stat -c %a "$FLEET_TOKEN_FILE"))"
+pass "fleet_ensure_token enrolls on first contact and stores the token 0600"
+
+# Stored token is reused — no second enroll request.
+unset FLEET_TOKEN
+fleet_claim_enabled || fail "stored token must be reused"
+[ -n "$FLEET_TOKEN" ] || fail "FLEET_TOKEN must be loaded from the stored file"
+enrolls_after="$(grep -c '/api/v1/agents/enroll' "$LOG_FILE" || true)"
+[ "$enrolls_after" = "$((enrolls_before + 1))" ] \
+  || fail "exactly ONE enroll request expected across both runs (got $enrolls_after)"
+pass "stored token reused without re-enrolling"
+
+# A symlinked token file is REFUSED (never read), and an enroll refusal (409:
+# handle taken/revoked) falls back to the label path rather than looping.
+unset FLEET_TOKEN
+rm -f "$FLEET_TOKEN_FILE"; ln -s /etc/hostname "$FLEET_TOKEN_FILE"
+printf 'enroll409' > "$MODE_FILE"
+fleet_claim_enabled && fail "409 enrollment must disable fleet claiming (label-path fallback)"
+[ -z "${FLEET_TOKEN:-}" ] || fail "a symlinked token file must never be read (got: $FLEET_TOKEN)"
+rm -f "$FLEET_TOKEN_FILE"
+printf 'claim' > "$MODE_FILE"
+pass "symlinked token file refused; enroll 409 falls back to the label path"
 
 echo "ALL FLEET CLIENT TESTS PASSED"

--- a/server/README.md
+++ b/server/README.md
@@ -158,7 +158,30 @@ docker compose up -d --build
 Leave any of the three unset and that surface stays disabled — the image still runs
 telemetry-only with all of them (and the stores) unset.
 
-### Minting agent tokens (admin)
+### Auto-enrollment (default): runners mint their own token
+
+Nobody hands tokens out for the normal case ([ADR-0017](../docs/adr/0017-server-orchestrated-pull-claim.md)):
+a runner's **first contact** calls the unauthenticated enroll route with its own GitHub
+login, gets a `standard`-tier token exactly once, and stores it under `~/.forgood/`
+(0600). `./autopilot.sh` does this automatically — there is no setup step.
+
+```bash
+# What the runner does under the hood, exactly once per handle:
+curl -s -X POST $URL/api/v1/agents/enroll -H "$JSON" \
+  -d '{"handle":"your-gh-login","harness":"codex"}'
+# 200 {ok:true, token:"fgt_…", handle, tier:"standard"} — first contact only
+# 409 ever after (incl. after a revoke: revocations STICK; recovery = operator re-mint)
+# 403 when the server runs AUTO_ENROLL=0 (operator-minted tokens only)
+```
+
+Identity is self-reported assumed trust (same as telemetry's `hello.handle`); squatting a
+handle is possible, visible in the registry listing, revocable, and bounded — one handle
+holds at most `MAX_ACTIVE_CLAIMS` (default 3) live claims, and the adversarial review gate
+still guards every merge. Handles without repo access can't be GitHub assignees (GitHub
+silently drops them), so their claims carry `assigneeSet:false` and identity lives in the
+lease + assignment record — labels still gate the queue for everyone.
+
+### Minting agent tokens (admin — elevated tiers, resets)
 
 All admin calls take `Authorization: Bearer $ADMIN_TOKEN` (constant-time compared, never
 logged; failures are 401):
@@ -190,7 +213,9 @@ curl -s -X POST $URL/api/v1/admin/agents/revoke -H "$AUTH" -H "$JSON" -d '{"hand
 ### Enrolling a runner
 
 ```bash
-FLEET_TOKEN=fgt_... FLEET_CLAIM=1 ./autopilot.sh codex
+./autopilot.sh codex                          # auto-enrolls on first contact (default)
+FLEET_CLAIM=0 ./autopilot.sh codex            # opt out — label-claim path only
+FLEET_TOKEN=fgt_... ./autopilot.sh codex      # pre-minted token (elevated tier / reset)
 ```
 
 `FLEET_SERVER` already defaults to production. Without **both** variables the runners are

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -87,6 +87,14 @@ export const config = {
   // Unset = the admin routes are not registered (404).
   adminToken: process.env.ADMIN_TOKEN || undefined,
 
+  // TOFU auto-enrollment: any runner's first contact mints its own
+  // standard-tier token (POST /api/v1/agents/enroll), so operators never
+  // hand tokens out. Turn off to require operator-minted tokens only.
+  autoEnroll: bool(process.env.AUTO_ENROLL, true),
+  // Max concurrently-active server claims per handle — bounds how much of
+  // the queue one auto-enrolled identity can sit on.
+  maxActiveClaims: num(process.env.MAX_ACTIVE_CLAIMS, 3),
+
   leaseTtlSeconds: num(process.env.LEASE_TTL_SECONDS, 1800),
   // One-shot fleet drain commands (stop/abort) expire after this long, so a
   // handle minted (or a runner restarted) weeks after a drain is never killed

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -64,6 +64,7 @@ function every(baseMs: number, run: () => Promise<unknown>, onError: (err: unkno
 function registerOrchestrationDisabled(app: FastifyInstance): void {
   const disabled = { ok: false, error: "orchestration disabled" };
   const paths = [
+    { method: "POST" as const, url: "/api/v1/agents/enroll" },
     { method: "POST" as const, url: "/api/v1/work/claim" },
     { method: "POST" as const, url: "/api/v1/work/renew" },
     { method: "POST" as const, url: "/api/v1/work/release" },

--- a/server/src/orchestrator/auth.ts
+++ b/server/src/orchestrator/auth.ts
@@ -161,6 +161,41 @@ export async function mintAgentToken(
   return { token };
 }
 
+/** TOFU auto-enrollment: mint a standard-tier token for a handle on FIRST
+ *  contact, exactly once (unique {handle:1} index arbitrates racers). Returns
+ *  null when the handle already has a registry doc — live OR revoked: a
+ *  revocation must stick, and a lost token is an operator reset
+ *  (admin route / fleet-admin.mjs re-mint), never a self-service re-issue,
+ *  otherwise anyone could rotate a rival's token by re-enrolling their
+ *  handle. Squatting an unclaimed handle is possible by construction
+ *  (self-reported identity, assumed trust — ADR-0017); it is visible in the
+ *  registry listing and revocable. */
+export async function enrollAgent(
+  orch: Orchestrator,
+  opts: { handle: string; note?: string },
+): Promise<{ token: string } | null> {
+  const handle = opts.handle.trim();
+  if (!handle) throw new Error("handle required");
+
+  const token = TOKEN_PREFIX + randomBytes(TOKEN_RANDOM_BYTES).toString("hex");
+  const tokenHash = hashToken(token);
+  try {
+    await registry(orch).insertOne({
+      handle,
+      tokenHash,
+      tier: "standard",
+      createdAt: new Date(),
+      note: opts.note ?? "auto-enrolled",
+    });
+  } catch (err) {
+    // Duplicate handle (E11000) = already enrolled/revoked — no re-issue.
+    if (err instanceof Error && "code" in err && (err as { code?: number }).code === 11000) return null;
+    throw err;
+  }
+  cachePurgeHandle(handle);
+  return { token };
+}
+
 /** Revoke a handle's token (sets revokedAt). Returns false when the handle
  *  is unknown or already revoked. */
 export async function revokeAgentToken(orch: Orchestrator, handle: string): Promise<boolean> {

--- a/server/src/orchestrator/dispatch.ts
+++ b/server/src/orchestrator/dispatch.ts
@@ -100,6 +100,10 @@ interface AssignmentDoc {
   claimedAt: string;
   renewedAt: string;
   active: boolean;
+  /** False when GitHub silently dropped the assignee (handle without repo
+   *  access — normal for auto-enrolled outside contributors). Missing on
+   *  docs from before this field existed = assignee was set. */
+  assigneeSet?: boolean;
   releasedAt?: string;
   outcome?: ReleaseOutcome;
   prNumber?: number;
@@ -121,6 +125,9 @@ export interface ClaimContext {
 
 export type ClaimResult =
   | { status: "claimed"; issue: ClaimedIssue; assignmentId: string; leaseTtlSeconds: number }
+  /** This handle already holds `maxActiveClaims` active assignments —
+   *  bounds how much of the queue one (auto-enrolled) identity can sit on. */
+  | { status: "capped" }
   /** Queue empty — the route answers `{ok:true, issue:null}`. */
   | { status: "empty" }
   /** GitHub rate-limited mid-claim — the route answers 429. */
@@ -272,6 +279,12 @@ export async function claimNext(
   const gh = orch.gh;
   if (!gh) return { status: "disabled", reason: "no github token" };
 
+  // Anti-grief bound for auto-enrolled identities (ADR-0017): one handle can
+  // hold at most maxActiveClaims live assignments. Checked before any lease
+  // is taken so a capped agent costs one Mongo count, nothing else.
+  const activeCount = await assignmentsCol(orch).countDocuments({ handle: ctx.handle, active: true });
+  if (activeCount >= config.maxActiveClaims) return { status: "capped" };
+
   const candidates = await orderedCandidates(orch, ctx.stages);
   const ttl = config.leaseTtlSeconds;
 
@@ -300,6 +313,7 @@ export async function claimNext(
     // issue-status reconciler converges that, and it beats corrupting live
     // state on every stale candidate.
     let step = 0;
+    let assigneeSet = false;
     try {
       const removedAvailable = await gh.removeLabel(n, AVAILABLE_LABEL);
       if (!removedAvailable) {
@@ -312,7 +326,19 @@ export async function claimNext(
       step = 1; // available removed — from here, undo means re-adding it
       await gh.addLabels(n, [CLAIMED_LABEL]);
       step = 2; // claimed added — undo removes it too
-      await gh.addAssignees(n, [ctx.handle]);
+      try {
+        await gh.addAssignees(n, [ctx.handle]);
+        assigneeSet = true;
+      } catch (err) {
+        if (err instanceof GitHubApiError && err.code === "assignee-ignored") {
+          // GitHub silently drops assignees without repo access — NORMAL for
+          // auto-enrolled outside contributors (they can't be assignees on
+          // the label path either). The lease + assignment doc carry the
+          // claim identity; the labels still gate the queue. Proceed.
+        } else {
+          throw err;
+        }
+      }
     } catch (err) {
       // Best-effort undo of any partial write, on EVERY failure path (while
       // still holding the lease — see above). Available-first means a
@@ -329,21 +355,16 @@ export async function claimNext(
         await delLeaseIfOwned(orch, n, idStr).catch(() => undefined);
         return { status: "rate-limited", retryAfterSeconds: err.retryAfterSeconds ?? 60 };
       }
-      if (err instanceof GitHubApiError && (err.code === "assignee-ignored" || err.status === 403)) {
-        // Misconfiguration, not a per-issue failure: the handle isn't
-        // assignable on the repo, or the bot token lacks write access
-        // (a permission 403 — isRateLimit already excluded the quota case).
-        // Undo, free the lease, and ABORT the claim rather than burning one
-        // failing GitHub write per candidate across the whole queue.
+      if (err instanceof GitHubApiError && err.status === 403) {
+        // Misconfiguration, not a per-issue failure: the BOT token lacks
+        // write access (a permission 403 — isRateLimit already excluded the
+        // quota case; an unassignable HANDLE is handled inline above and
+        // never aborts). Undo, free the lease, and ABORT the claim rather
+        // than burning one failing GitHub write per candidate across the
+        // whole queue.
         await undoPartialWrites();
         await delLeaseIfOwned(orch, n, idStr).catch(() => undefined);
-        return {
-          status: "disabled",
-          reason:
-            err.code === "assignee-ignored"
-              ? "handle not assignable on the repo (missing repo access?)"
-              : "github token lacks write access",
-        };
+        return { status: "disabled", reason: "github token lacks write access" };
       }
       if (err instanceof GitHubApiError && err.status >= 400 && err.status < 500) {
         // Per-issue 4xx: undo, free the lease, try the next candidate.
@@ -373,10 +394,14 @@ export async function claimNext(
       claimedAt: now,
       renewedAt: now,
       active: true,
+      assigneeSet,
     };
     const labels = candidate.labels.filter((l) => l !== AVAILABLE_LABEL);
     if (!labels.includes(CLAIMED_LABEL)) labels.push(CLAIMED_LABEL);
-    const assignees = candidate.assignees.includes(ctx.handle)
+    // Mirror only what GitHub actually holds: an unassignable handle
+    // (assigneeSet=false) must not appear in the mirror's assignees, or the
+    // renew guard would trust an assignee GitHub never accepted.
+    const assignees = !assigneeSet || candidate.assignees.includes(ctx.handle)
       ? candidate.assignees
       : [...candidate.assignees, ctx.handle];
     try {
@@ -613,10 +638,14 @@ export async function renewLeasesForHandle(orch: Orchestrator, handle: string): 
         { _id: doc.issueNumber },
         { projection: { labels: 1, assignees: 1 } },
       );
+      // The assignee check only applies when the claim actually set one —
+      // auto-enrolled outside contributors can't be assignees on GitHub
+      // (assigneeSet:false), so for them "still claimed" is label-only.
+      const expectAssignee = doc.assigneeSet !== false;
       if (
         !issue ||
         !(issue.labels ?? []).includes(CLAIMED_LABEL) ||
-        !(issue.assignees ?? []).includes(doc.handle)
+        (expectAssignee && !(issue.assignees ?? []).includes(doc.handle))
       ) {
         continue; // no longer claimed by this handle — let the lease lapse
       }

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -254,6 +254,22 @@ export const commandSchema = z.object({
 });
 export type FleetCommand = z.infer<typeof commandSchema>;
 
+/** TOFU auto-enrollment: a runner's FIRST contact mints its token (no
+ *  operator hand-out). `handle` is the runner's self-reported GitHub login —
+ *  assumed trust, same as telemetry's `hello.handle`; squatting a handle is
+ *  visible in the registry and revocable. Strict GitHub-login shape so an
+ *  arbitrary string can never become a registry identity (it flows into
+ *  GitHub assignee calls). */
+export const enrollRequestSchema = z.object({
+  handle: z
+    .string()
+    .max(39)
+    .regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/, "not a valid GitHub login"),
+  harness: z.string().max(32).optional(),
+  model: z.string().max(128).optional(),
+});
+export type EnrollRequest = z.infer<typeof enrollRequestSchema>;
+
 export const claimRequestSchema = z.object({
   stages: z.array(z.enum(["research", "ideate", "build"])).optional(), // default: all three
   harness: z.string().max(32).optional(),

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -3,6 +3,10 @@
  *
  * All require `Authorization: Bearer fgt_...` verified via
  * orchestrator/auth.verifyAgentToken (401 otherwise):
+ *  - POST /api/v1/agents/enroll — UNAUTHENTICATED TOFU enrollment (ADR-0017):
+ *    body enrollRequestSchema; 200 {ok,token,handle,tier:"standard"} exactly
+ *    once per handle; 409 ever after (revocations stick — operator re-mints);
+ *    403 when AUTO_ENROLL=0. Rate-limited per IP like every agent route.
  *  - POST /api/v1/work/claim   — body claimRequestSchema. 200
  *    {ok:true, issue: ClaimedIssue, assignmentId, leaseTtlSeconds, handle}
  *    (handle = the registry identity the claim was made for — the runner
@@ -23,10 +27,10 @@ import { z } from "zod";
 import { config } from "../config.js";
 import { GitHubApiError } from "../github/gh-api.js";
 import { IpRateLimiter } from "../guards.js";
-import { bearerToken, verifyAgentToken, type AgentIdentity } from "../orchestrator/auth.js";
+import { bearerToken, enrollAgent, verifyAgentToken, type AgentIdentity } from "../orchestrator/auth.js";
 import { claimNext, releaseAssignment, renewLease, type ClaimResult } from "../orchestrator/dispatch.js";
 import type { Orchestrator } from "../orchestrator/stores.js";
-import { claimRequestSchema, releaseRequestSchema } from "../protocol.js";
+import { claimRequestSchema, enrollRequestSchema, releaseRequestSchema } from "../protocol.js";
 import type { FleetStore } from "../state.js";
 
 const renewRequestSchema = z.object({ issue: z.number().int().positive() });
@@ -55,6 +59,39 @@ export function registerDispatchRoutes(
     }
     return identity;
   };
+
+  // TOFU auto-enrollment (ADR-0017): a runner's first contact mints its own
+  // standard-tier token, so "just run autopilot.sh" works with no operator
+  // hand-out. Unauthenticated by design — the handle is self-reported
+  // assumed-trust identity (same as telemetry's hello.handle); the strict
+  // login-shape schema keeps arbitrary strings out of the registry, the
+  // unique index makes first-contact wins atomic, a revoked or existing
+  // handle is NEVER re-issued here, and per-IP rate limiting bounds abuse.
+  app.post("/api/v1/agents/enroll", async (req, reply) => {
+    if (await rateLimited(req, reply)) return reply;
+    if (!config.autoEnroll) {
+      return reply.code(403).send({ ok: false, error: "auto-enrollment disabled — ask the operator for a token" });
+    }
+    const parsed = enrollRequestSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return reply.code(400).send({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" });
+    }
+    const minted = await enrollAgent(orch, {
+      handle: parsed.data.handle,
+      note: `auto-enrolled${parsed.data.harness ? ` (${parsed.data.harness})` : ""}`,
+    });
+    if (!minted) {
+      return reply.code(409).send({
+        ok: false,
+        error: "handle already enrolled — recover the stored token or ask the operator to reset it",
+      });
+    }
+    store.addEvent("agent_online", `@${parsed.data.handle} enrolled with the fleet server`, {
+      handle: parsed.data.handle,
+      ...(parsed.data.harness ? { harness: parsed.data.harness } : {}),
+    });
+    return { ok: true, token: minted.token, handle: parsed.data.handle, tier: "standard" };
+  });
 
   app.post("/api/v1/work/claim", async (req, reply) => {
     if (await rateLimited(req, reply)) return reply;
@@ -95,6 +132,10 @@ export function registerDispatchRoutes(
         };
       case "empty":
         return { ok: true, issue: null };
+      case "capped":
+        // Shaped like empty (issue:null) so every runner just falls into its
+        // queue-empty path; the reason lets an operator see why.
+        return { ok: true, issue: null, reason: "active-claim-cap" };
       case "rate-limited":
         return reply.code(429).send({
           ok: false,

--- a/server/test/auth.test.mjs
+++ b/server/test/auth.test.mjs
@@ -20,6 +20,7 @@ import { dockerAvailable, startRedis, startMongo } from "./helpers/containers.mj
 import {
   AGENT_TIERS,
   bearerToken,
+  enrollAgent,
   mintAgentToken,
   revokeAgentToken,
   listRegisteredAgents,
@@ -150,6 +151,49 @@ test("re-mint without revoke replaces the old token", { skip }, async () => {
   const second = await mintAgentToken(orch, { handle: "dave", tier: "standard" });
   assert.equal(await verifyAgentToken(orch, first.token), null, "replaced token must stop verifying");
   assert.ok(await verifyAgentToken(orch, second.token));
+});
+
+// ---------------------------------------------------------------------------
+// TOFU auto-enrollment (ADR-0017): first contact mints, everything after that
+// is refused — a revocation or an existing registration must stick, or anyone
+// could rotate a rival's token by re-enrolling their handle.
+// ---------------------------------------------------------------------------
+
+test("enroll: first contact mints a standard-tier token that verifies", { skip }, async () => {
+  const minted = await enrollAgent(orch, { handle: "tofu-first" });
+  assert.ok(minted, "first enrollment must mint");
+  assert.match(minted.token, TOKEN_RE);
+  assert.deepEqual(await verifyAgentToken(orch, minted.token), { handle: "tofu-first", tier: "standard" });
+  const doc = await orch.db.collection("agents_registry").findOne({ handle: "tofu-first" });
+  assert.equal(doc.tier, "standard", "auto-enrollment never grants above standard");
+  assert.ok(!JSON.stringify(doc).includes(minted.token), "plaintext token leaked into the registry doc");
+});
+
+test("enroll: second contact for the same handle is refused, first token survives", { skip }, async () => {
+  const first = await enrollAgent(orch, { handle: "tofu-dup" });
+  assert.ok(first);
+  assert.equal(await enrollAgent(orch, { handle: "tofu-dup" }), null, "re-enroll must NOT re-issue");
+  assert.ok(await verifyAgentToken(orch, first.token), "original token must be untouched by the refused attempt");
+});
+
+test("enroll: a revoked handle can NOT re-enroll itself (revocation sticks)", { skip }, async () => {
+  const first = await enrollAgent(orch, { handle: "tofu-revoked" });
+  assert.ok(first);
+  await revokeAgentToken(orch, "tofu-revoked");
+  assert.equal(await enrollAgent(orch, { handle: "tofu-revoked" }), null, "self-service un-revoke must be impossible");
+  assert.equal(await verifyAgentToken(orch, first.token), null, "revoked token stays dead");
+  // The operator path still works: an explicit re-mint replaces the doc.
+  const remint = await mintAgentToken(orch, { handle: "tofu-revoked", tier: "standard" });
+  assert.ok(await verifyAgentToken(orch, remint.token), "operator re-mint recovers the handle");
+});
+
+test("enroll: concurrent racers on one handle mint exactly one token", { skip }, async () => {
+  const results = await Promise.all(
+    Array.from({ length: 8 }, () => enrollAgent(orch, { handle: "tofu-race" })),
+  );
+  const minted = results.filter(Boolean);
+  assert.equal(minted.length, 1, "the unique {handle:1} index must arbitrate to exactly one winner");
+  assert.equal(await orch.db.collection("agents_registry").countDocuments({ handle: "tofu-race" }), 1);
 });
 
 test("listRegisteredAgents exposes no hashes and ISO dates", { skip }, async () => {

--- a/server/test/dispatch.test.mjs
+++ b/server/test/dispatch.test.mjs
@@ -429,28 +429,60 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       assert.equal(await anyAssignment(47), null, "no half-recorded assignment");
     });
 
-    await t.test("unassignable handle → claim aborts 'disabled', labels reverted, queue not walked", async () => {
+    await t.test("unassignable handle (auto-enrolled outsider) → claim PROCEEDS without an assignee", async () => {
+      // ADR-0017 auto-enrollment: outside contributors can't be assignees on
+      // GitHub (it silently drops logins without repo access) — that must
+      // not block their claim; the lease + assignment doc carry identity.
       await seed([
         { number: 48, labels: ["status: available", "stage: research"], createdAt: "2026-04-01T00:00:00Z" },
-        { number: 49, labels: ["status: available", "stage: research"], createdAt: "2026-04-02T00:00:00Z" },
       ]);
       mock.assignableUsers = new Set(["someone-else"]); // GitHub silently ignores "alice"
       const result = await dispatch.claimNext(o, new FleetStore(), { handle: "alice", tier: "standard" });
-      assert.equal(result.status, "disabled", "misconfigured handle fails loudly, not a phantom claim");
-      assert.match(result.reason, /not assignable/);
+      assert.equal(result.status, "claimed", "the drop is normal, not a failure");
+      assert.equal(result.issue.number, 48);
       const gh48 = mock.getIssue(48);
-      assert.ok(gh48.labels.includes("status: available"), "labels reverted");
-      assert.ok(!gh48.labels.includes("status: claimed"));
-      assert.deepEqual(gh48.assignees, [], "mirror/GitHub never show a phantom assignee");
-      assert.equal(await o.redis.exists(leaseKey(48)), 0);
-      assert.equal(await anyAssignment(48), null);
-      assert.equal(
-        mock.calls.filter((c) => c.path.includes("/issues/49/")).length,
-        0,
-        "one misconfiguration probe does not cost O(queue) GitHub writes",
-      );
+      assert.ok(gh48.labels.includes("status: claimed"), "labels claimed as usual");
+      assert.ok(!gh48.labels.includes("status: available"));
+      assert.deepEqual(gh48.assignees, [], "no phantom assignee on GitHub");
+      const assignment = await activeAssignment(48);
+      assert.equal(assignment.assigneeSet, false, "the doc records that no assignee landed");
       const mirror = await o.db.collection("issues").findOne({ _id: 48 });
-      assert.deepEqual(mirror.assignees, [], "optimistic mirror never ran");
+      assert.deepEqual(mirror.assignees, [], "the mirror only holds what GitHub accepted");
+
+      // The renew guard must not demand an assignee GitHub never accepted:
+      // an authed heartbeat still extends this lease.
+      await o.redis.expire(leaseKey(48), 5);
+      await dispatch.renewLeasesForHandle(o, "alice");
+      const ttl = await o.redis.ttl(leaseKey(48));
+      assert.ok(ttl > 5, `assignee-less claim must still renew (ttl=${ttl})`);
+    });
+
+    await t.test("active-claim cap: one handle cannot sit on the whole queue", async () => {
+      const specs = Array.from({ length: config.maxActiveClaims + 2 }, (_, i) => ({
+        number: 60 + i,
+        labels: ["status: available", "stage: research"],
+        createdAt: `2026-04-0${i + 1}T00:00:00Z`,
+      }));
+      await seed(specs);
+      for (let i = 0; i < config.maxActiveClaims; i++) {
+        const r = await dispatch.claimNext(o, new FleetStore(), { handle: "greedy", tier: "standard" });
+        assert.equal(r.status, "claimed", `claim ${i + 1}/${config.maxActiveClaims} under the cap`);
+      }
+      const capped = await dispatch.claimNext(o, new FleetStore(), { handle: "greedy", tier: "standard" });
+      assert.equal(capped.status, "capped", "claim over the cap is refused");
+      // The cap is per-handle: another agent still gets work.
+      const other = await dispatch.claimNext(o, new FleetStore(), { handle: "modest", tier: "standard" });
+      assert.equal(other.status, "claimed");
+      // Releasing frees headroom.
+      const first = await activeAssignment(60);
+      await dispatch.releaseAssignment(o, new FleetStore(), {
+        handle: "greedy",
+        issue: 60,
+        outcome: "done",
+      });
+      assert.ok(first, "sanity: #60 was greedy's");
+      const after = await dispatch.claimNext(o, new FleetStore(), { handle: "greedy", tier: "standard" });
+      assert.equal(after.status, "claimed", "released claim restores headroom");
     });
 
     await t.test("permission 403 (not rate limit) → claim aborts 'disabled', queue not walked", async () => {
@@ -888,6 +920,58 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       });
       assert.equal(emptyClaim.statusCode, 200);
       assert.equal(emptyClaim.json().issue, null, "empty queue is ok:true, issue:null");
+    });
+
+    await t.test("enroll route: TOFU mint once, 409 after, strict handle shape, config-off → 403", async () => {
+      const { config: cfg } = await import("../dist/config.js");
+      const auth = await import("../dist/orchestrator/auth.js");
+      await seed([]);
+      const app = Fastify();
+      apps.push(app);
+      registerDispatchRoutes(app, new FleetStore(), o);
+
+      const first = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/enroll",
+        payload: { handle: "route-enrollee", harness: "claude" },
+      });
+      assert.equal(first.statusCode, 200);
+      const body = first.json();
+      assert.equal(body.ok, true);
+      assert.match(body.token, /^fgt_[0-9a-f]{32}$/, "a real usable token comes back exactly once");
+      assert.equal(body.tier, "standard", "auto-enrollment never grants above standard");
+      assert.deepEqual(
+        await auth.verifyAgentToken(o, body.token),
+        { handle: "route-enrollee", tier: "standard" },
+        "the minted token verifies for claims/heartbeats",
+      );
+
+      const dup = await app.inject({
+        method: "POST",
+        url: "/api/v1/agents/enroll",
+        payload: { handle: "route-enrollee" },
+      });
+      assert.equal(dup.statusCode, 409, "second contact never re-issues");
+      assert.ok(!dup.body.includes("fgt_"), "no token material on the refusal path");
+
+      // The handle flows into GitHub assignee calls — only a real GitHub
+      // login shape may enter the registry.
+      for (const bad of ["-lead", "trail-", "dou--ble", "a b", "x".repeat(40), "we/inject", ""]) {
+        const r = await app.inject({ method: "POST", url: "/api/v1/agents/enroll", payload: { handle: bad } });
+        assert.equal(r.statusCode, 400, `handle ${JSON.stringify(bad)} must be rejected`);
+      }
+
+      cfg.autoEnroll = false;
+      try {
+        const off = await app.inject({
+          method: "POST",
+          url: "/api/v1/agents/enroll",
+          payload: { handle: "someone-new" },
+        });
+        assert.equal(off.statusCode, 403, "AUTO_ENROLL=0 = operator-minted tokens only");
+      } finally {
+        cfg.autoEnroll = true;
+      }
     });
 
     await t.test("claim route: 429 rate-limited, redacted 502 on GitHub 5xx, 503 without a github token", async () => {

--- a/start_work.sh
+++ b/start_work.sh
@@ -31,9 +31,11 @@
 # Args: [claude|codex|hermes] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
 # Env:  AGENT MODEL MAX ISSUE STAGE POLL_SECONDS DRY_RUN AGENT_TIMEOUT
 #       PROVIDER HERMES_PROFILE HERMES_FLAGS FOR_GOOD_REPO REPO_DIR
-#       FLEET_SERVER FLEET_TOKEN FLEET_CLAIM(=0) — set FLEET_CLAIM=1 with a
-#       server-minted FLEET_TOKEN to let the fleet server claim atomically for
-#       you (falls back to the label-claim path on ANY failure; default off)
+#       FLEET_SERVER FLEET_TOKEN FLEET_CLAIM(=0) — set FLEET_CLAIM=1 to let the
+#       fleet server claim atomically for you; with no FLEET_TOKEN it
+#       AUTO-ENROLLS this gh identity on first contact (token stored in
+#       ~/.forgood/). Falls back to the label-claim path on ANY failure.
+#       (autopilot.sh defaults FLEET_CLAIM=1; standalone runs stay opt-in.)
 set -euo pipefail
 cd "$(dirname "$0")"
 source "scripts/fg-common.sh"


### PR DESCRIPTION
Part of #398. Follow-up to #592 (merged), directed by the maintainer: server-orchestrated claiming should be the **primary** path — any contributor just runs `./autopilot.sh` and gets work from the server — without anyone distributing tokens.

## What changes

- **`POST /api/v1/agents/enroll`** (unauthenticated, per-IP rate-limited): a runner's first contact mints a `standard`-tier token exactly once per GitHub handle (the unique registry index arbitrates racers); **409 forever after** — revocations stick, recovery is an operator re-mint, so nobody can rotate a rival's token by re-enrolling their handle. Strict GitHub-login schema (the handle flows into GitHub assignee calls). `AUTO_ENROLL=0` disables. Handle **squatting** is the documented assumed-trust trade-off: visible in the registry, revocable, bounded by a per-handle active-claim cap (`MAX_ACTIVE_CLAIMS=3`) — and the adversarial review gate remains the merge-time defence.
- **Unassignable handles no longer abort claims**: GitHub silently drops assignees without repo access (i.e. every outside contributor), so the claim proceeds with `assigneeSet:false` — identity lives in the lease + assignment doc, the renew guard goes label-only for those claims, and the mirror records only assignees GitHub accepted. A bot-token 403 still aborts loudly.
- **Runners**: `fleet_ensure_token` resolves env var → stored `~/.forgood/` token (regular, owned, non-symlink file only; 0600) → auto-enroll. `autopilot.sh` now **defaults `FLEET_CLAIM=1`** and enrolls at startup, so authed heartbeats carry pause/stop/abort for the whole fleet. Every failure still falls back to the label path byte-for-byte; `FLEET_CLAIM=0` opts out; standalone `start_work.sh` stays opt-in.
- ADR-0017, `docs/AUTOMATION.md`, `server/README.md` updated to match.

## Validation

119/119 server tests (docker-backed Redis/Mongo + mock GitHub; new coverage: enroll mint-once/409/revocation-sticks/8-way race, claim cap incl. release-restores-headroom, assignee-less claim + lease renewal, route-level 400/403/409), shell fleet tests incl. enroll → store 0600 → reuse-without-re-enroll → symlink refusal → 409 fallback, `bash -n` clean, `npm run validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)