### PR TITLE
feat(server): additive token minting — many independently-revocable tokens per handle

### DIFF
--- a/docs/adr/0017-server-orchestrated-pull-claim.md
+++ b/docs/adr/0017-server-orchestrated-pull-claim.md
@@ -60,7 +60,9 @@ and fail-open at every layer:
    SHA-256 hash is stored server-side, and revocation is immediate and *sticky*: a revoked
    or already-enrolled handle is never re-issued by enrollment — recovery is an operator
    re-mint (`fleet-admin.mjs` / admin route), otherwise anyone could rotate a rival's
-   token by re-enrolling their handle. The accepted trade-off is **first-contact handle
+   token by re-enrolling their handle. Operator minting is **additive**: a handle may
+   hold any number of live tokens (one per machine/runner), each independently
+   revocable by tokenId — only self-enrollment is once-per-handle. The accepted trade-off is **first-contact handle
    squatting** (identity is assumed-trust, exactly like telemetry's `hello.handle` and the
    label path's claim comments): squatting is visible in the registry, revocable, bounded
    by a per-handle active-claim cap (`MAX_ACTIVE_CLAIMS`, default 3) and per-IP rate

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.log
 .env
 fleet-state.json
+docker-compose.override.yml

--- a/server/README.md
+++ b/server/README.md
@@ -197,16 +197,21 @@ curl -s -X POST $URL/api/v1/admin/agents -H "$AUTH" -H "$JSON" \
 ```
 
 The response contains the plaintext token (`fgt_…`) — **shown exactly once**; only its
-SHA-256 hash is stored. Hand it to the runner as `FLEET_TOKEN`. The `handle` is the GitHub
-identity the server assigns claimed issues to, so it must be a real account with repo
-access via the bot token's writes. Revocation via this admin API is immediate and
+SHA-256 hash is stored — plus a short non-secret `tokenId`. **Minting is additive**: a
+handle may hold any number of live tokens (mint one per machine/runner) and each is
+independently revocable, so multi-machine fleets don't have to copy token files around.
+Hand the token to the runner as `FLEET_TOKEN`. The `handle` is the GitHub identity the
+server assigns claimed issues to. Revocation via this admin API is immediate and
 server-side. Revoking out-of-band with `scripts/fleet-admin.mjs revoke` is also immediate
 on a running server when `REDIS_URL` is set (the CLI publishes an `auth:purge` message the
 server turns into a cache purge); without Redis the running server's verify cache can
-honour the old token for up to 30s. A handle can be re-minted after revoke:
+honour the old token for up to 30s.
 
 ```bash
-curl -s $URL/api/v1/admin/agents -H "$AUTH"                       # list (no hashes)
+curl -s $URL/api/v1/admin/agents -H "$AUTH"     # list — one row per token, incl. tokenId, no hashes
+# revoke ONE machine's token…
+curl -s -X POST $URL/api/v1/admin/agents/revoke -H "$AUTH" -H "$JSON" -d '{"handle":"my-work-bot","tokenId":"abc123def456"}'
+# …or every live token the handle holds:
 curl -s -X POST $URL/api/v1/admin/agents/revoke -H "$AUTH" -H "$JSON" -d '{"handle":"my-work-bot"}'
 ```
 

--- a/server/scripts/fleet-admin.mjs
+++ b/server/scripts/fleet-admin.mjs
@@ -14,16 +14,18 @@
  *
  * Usage:
  *   node scripts/fleet-admin.mjs mint <handle> --tier <framer|trusted|standard> [--note "..."]
- *       Mint (or re-mint) an agent token. Prints JSON with the PLAINTEXT
- *       token exactly once — it is stored only as a sha256 hash. Re-minting
- *       an existing handle replaces its token and clears any revocation.
+ *       Mint an agent token. ADDITIVE: a handle may hold any number of live
+ *       tokens (one per machine/runner), each independently revocable by its
+ *       tokenId. Prints JSON with the PLAINTEXT token exactly once — it is
+ *       stored only as a sha256 hash.
  *
  *   node scripts/fleet-admin.mjs list
- *       List registered agents (handle, tier, note, createdAt, revokedAt).
- *       Never prints token hashes.
+ *       List registered tokens (handle, tokenId, tier, note, createdAt,
+ *       revokedAt — one row per token). Never prints token hashes.
  *
- *   node scripts/fleet-admin.mjs revoke <handle>
- *       Revoke a handle's token. Exit 2 if unknown or already revoked.
+ *   node scripts/fleet-admin.mjs revoke <handle> [--token <tokenId>]
+ *       Revoke ALL of a handle's live tokens, or just one (--token, see
+ *       `list`). Exit 2 if nothing live matched.
  *       NOTE: takes effect on a RUNNING server immediately when REDIS_URL is
  *       set (an auth:purge pub/sub message clears its verify cache); without
  *       Redis the running server's cache holds the old verdict for up to 30s
@@ -76,7 +78,7 @@ function usageDie(message) {
       "usage:",
       "  fleet-admin.mjs mint <handle> --tier <framer|trusted|standard> [--note <text>]",
       "  fleet-admin.mjs list",
-      "  fleet-admin.mjs revoke <handle>",
+      "  fleet-admin.mjs revoke <handle> [--token <tokenId>]",
       "  fleet-admin.mjs assignments [--active]",
       "  fleet-admin.mjs command (<handle> | --all) <pause|resume|stop|abort> [--reason <text>] [--by <who>]",
       "  fleet-admin.mjs command (<handle> | --all) --clear",
@@ -146,26 +148,23 @@ async function cmdMint(positionals, values) {
   if (!AGENT_TIERS.includes(tier)) usageDie(`--tier must be one of: ${AGENT_TIERS.join(", ")}`);
 
   // Mirrors mintAgentToken() in src/orchestrator/auth.ts — keep in sync.
+  // Additive: every mint INSERTS one more independently-revocable token for
+  // the handle (one per machine/runner).
   const token = TOKEN_PREFIX + randomBytes(TOKEN_RANDOM_BYTES).toString("hex");
   const tokenHash = hashToken(token);
+  const tokenId = tokenHash.slice(0, 12);
   await withMongo(async (db) => {
-    await db.collection("agents_registry").updateOne(
-      { handle },
-      {
-        $set: {
-          handle,
-          tokenHash,
-          tier,
-          createdAt: new Date(),
-          ...(values.note !== undefined ? { note: values.note } : {}),
-        },
-        $unset: { revokedAt: "", ...(values.note === undefined ? { note: "" } : {}) },
-      },
-      { upsert: true },
-    );
+    await db.collection("agents_registry").insertOne({
+      handle,
+      tokenHash,
+      tokenId,
+      tier,
+      createdAt: new Date(),
+      ...(values.note !== undefined ? { note: values.note } : {}),
+    });
   });
   await publishAuthPurge(handle);
-  out({ ok: true, handle, tier, token, note: "token shown once — store it now" });
+  out({ ok: true, handle, tier, token, tokenId, note: "token shown once — store it now" });
 }
 
 async function cmdList() {
@@ -179,17 +178,26 @@ async function cmdList() {
   out({ ok: true, agents });
 }
 
-async function cmdRevoke(positionals) {
+async function cmdRevoke(positionals, values) {
   const handle = (positionals[0] ?? "").trim();
   if (!handle) usageDie("revoke requires <handle>");
+  const tokenId = values.token; // --token <tokenId> = revoke just that one
   const revoked = await withMongo(async (db) => {
     const result = await db
       .collection("agents_registry")
-      .updateOne({ handle, revokedAt: null }, { $set: { revokedAt: new Date() } });
+      .updateMany(
+        { handle, revokedAt: null, ...(tokenId ? { tokenId } : {}) },
+        { $set: { revokedAt: new Date() } },
+      );
     return result.matchedCount > 0;
   });
   if (revoked) await publishAuthPurge(handle);
-  out({ ok: revoked, handle, ...(revoked ? {} : { error: "unknown handle or already revoked" }) });
+  out({
+    ok: revoked,
+    handle,
+    ...(tokenId ? { tokenId } : {}),
+    ...(revoked ? {} : { error: "no live token matched that handle/tokenId" }),
+  });
   if (!revoked) process.exit(2);
 }
 
@@ -262,6 +270,7 @@ async function main() {
     options: {
       tier: { type: "string" },
       note: { type: "string" },
+      token: { type: "string" },
       reason: { type: "string" },
       by: { type: "string" },
       active: { type: "boolean" },
@@ -276,7 +285,7 @@ async function main() {
     case "list":
       return cmdList();
     case "revoke":
-      return cmdRevoke(positionals);
+      return cmdRevoke(positionals, values);
     case "assignments":
       return cmdAssignments(values);
     case "command":

--- a/server/src/orchestrator/auth.ts
+++ b/server/src/orchestrator/auth.ts
@@ -3,10 +3,11 @@
  *
  * Server-minted bearer tokens (`fgt_<32 hex>`) tied to a GitHub handle + a
  * trust tier, stored in Mongo `agents_registry` as a sha256 hex `tokenHash`
- * — NEVER the plaintext. A handle may be re-minted after revoke (the
- * registry has a unique {handle:1} index, so re-mint replaces the doc's
- * tokenHash and clears revokedAt). Lookup is by tokenHash; a doc with
- * `revokedAt` set never verifies.
+ * — NEVER the plaintext. One registry doc PER TOKEN: a handle may hold any
+ * number of live tokens (one per machine/runner), minted additively and
+ * revoked individually (by tokenId) or handle-wide. Only TOFU self-enrollment
+ * is exactly-once per handle (partial unique index over autoEnrolled docs).
+ * Lookup is by tokenHash; a doc with `revokedAt` set never verifies.
  *
  * Security notes:
  *  - Plaintext tokens exist only in the mint response — they are never
@@ -41,18 +42,27 @@ export interface AgentIdentity {
 /** Registry row as exposed to admins — never includes tokenHash. */
 export interface RegisteredAgent {
   handle: string;
+  /** Short non-secret id (hash prefix) for listing + targeted revocation. */
+  tokenId: string;
   tier: AgentTier;
   note?: string;
   createdAt: string;
   revokedAt?: string;
 }
 
-/** Mongo doc shape for `agents_registry` (internal — hash never leaves). */
+/** Mongo doc shape for `agents_registry` — ONE DOC PER TOKEN (a handle may
+ *  hold any number of independently-revocable tokens, e.g. one per machine;
+ *  internal — hash never leaves). */
 interface RegistryDoc {
   handle: string;
   tokenHash: string;
+  /** First 12 hex of tokenHash — non-secret listing/revocation id. */
+  tokenId: string;
   tier: AgentTier;
   note?: string;
+  /** Set on TOFU self-enrollment docs — the partial unique index on these
+   *  is what makes first-contact minting exactly-once per handle. */
+  autoEnrolled?: boolean;
   createdAt: Date;
   revokedAt?: Date | null; // written as $unset (missing); null allowed so the
   // `revokedAt: null` filter (matches missing OR null) typechecks.
@@ -125,40 +135,36 @@ export function bearerToken(req: FastifyRequest): string | undefined {
 }
 
 /**
- * Mint a token for a handle: generates `fgt_<random>`, upserts the registry
- * doc (replacing any prior token for the handle, clearing revokedAt), and
- * returns the PLAINTEXT token — shown once, never stored or logged.
+ * Mint a token for a handle: generates `fgt_<random>`, INSERTS a new registry
+ * doc — a handle may hold any number of live tokens (one per machine/runner),
+ * each independently revocable by its tokenId — and returns the PLAINTEXT
+ * token, shown once, never stored or logged.
  */
 export async function mintAgentToken(
   orch: Orchestrator,
   opts: { handle: string; tier: AgentTier; note?: string },
-): Promise<{ token: string }> {
+): Promise<{ token: string; tokenId: string }> {
   const handle = opts.handle.trim();
   if (!handle) throw new Error("handle required");
   if (!AGENT_TIERS.includes(opts.tier)) throw new Error(`invalid tier: ${String(opts.tier)}`);
 
   const token = TOKEN_PREFIX + randomBytes(TOKEN_RANDOM_BYTES).toString("hex");
   const tokenHash = hashToken(token);
+  const tokenId = tokenHash.slice(0, 12);
 
-  await registry(orch).updateOne(
-    { handle },
-    {
-      $set: {
-        handle,
-        tokenHash,
-        tier: opts.tier,
-        createdAt: new Date(),
-        ...(opts.note !== undefined ? { note: opts.note } : {}),
-      },
-      $unset: { revokedAt: "", ...(opts.note === undefined ? { note: "" } : {}) },
-    },
-    { upsert: true },
-  );
+  await registry(orch).insertOne({
+    handle,
+    tokenHash,
+    tokenId,
+    tier: opts.tier,
+    createdAt: new Date(),
+    ...(opts.note !== undefined ? { note: opts.note } : {}),
+  });
 
-  // Any cached identity for this handle belongs to the replaced token.
+  // Cached identities for this handle may carry a stale tier — refresh.
   cachePurgeHandle(handle);
 
-  return { token };
+  return { token, tokenId };
 }
 
 /** TOFU auto-enrollment: mint a standard-tier token for a handle on FIRST
@@ -177,18 +183,27 @@ export async function enrollAgent(
   const handle = opts.handle.trim();
   if (!handle) throw new Error("handle required");
 
+  // ANY existing doc for the handle — live, revoked, operator-minted —
+  // refuses self-enrollment: an already-provisioned or revoked identity is
+  // an operator conversation, and a squatter must not TOFU a handle whose
+  // owner already holds operator-minted tokens. The check-then-insert race
+  // is closed by the partial unique index over autoEnrolled docs.
+  if ((await registry(orch).countDocuments({ handle }, { limit: 1 })) > 0) return null;
+
   const token = TOKEN_PREFIX + randomBytes(TOKEN_RANDOM_BYTES).toString("hex");
   const tokenHash = hashToken(token);
   try {
     await registry(orch).insertOne({
       handle,
       tokenHash,
+      tokenId: tokenHash.slice(0, 12),
       tier: "standard",
+      autoEnrolled: true,
       createdAt: new Date(),
       note: opts.note ?? "auto-enrolled",
     });
   } catch (err) {
-    // Duplicate handle (E11000) = already enrolled/revoked — no re-issue.
+    // Duplicate auto-enroll (E11000 on the partial index) = a racer won.
     if (err instanceof Error && "code" in err && (err as { code?: number }).code === 11000) return null;
     throw err;
   }
@@ -196,12 +211,17 @@ export async function enrollAgent(
   return { token };
 }
 
-/** Revoke a handle's token (sets revokedAt). Returns false when the handle
- *  is unknown or already revoked. */
-export async function revokeAgentToken(orch: Orchestrator, handle: string): Promise<boolean> {
-  const result = await registry(orch).updateOne(
+/** Revoke tokens (sets revokedAt): all of a handle's live tokens, or — with
+ *  `tokenId` — exactly one of them (per-machine revocation). Returns false
+ *  when nothing live matched. */
+export async function revokeAgentToken(
+  orch: Orchestrator,
+  handle: string,
+  tokenId?: string,
+): Promise<boolean> {
+  const result = await registry(orch).updateMany(
     // `revokedAt: null` matches both "missing" and "explicit null".
-    { handle, revokedAt: null },
+    { handle, revokedAt: null, ...(tokenId ? { tokenId } : {}) },
     { $set: { revokedAt: new Date() } },
   );
   cachePurgeHandle(handle);
@@ -210,12 +230,15 @@ export async function revokeAgentToken(orch: Orchestrator, handle: string): Prom
 
 /** List registry entries for `GET /api/v1/admin/agents` — no hashes. */
 export async function listRegisteredAgents(orch: Orchestrator): Promise<RegisteredAgent[]> {
+  // tokenHash is fetched ONLY to derive tokenId for docs minted before the
+  // field existed — it is never returned.
   const docs = await registry(orch)
-    .find({}, { projection: { _id: 0, tokenHash: 0 } })
-    .sort({ handle: 1 })
+    .find({}, { projection: { _id: 0 } })
+    .sort({ handle: 1, createdAt: 1 })
     .toArray();
   return docs.map((doc) => ({
     handle: doc.handle,
+    tokenId: doc.tokenId ?? doc.tokenHash.slice(0, 12),
     tier: doc.tier,
     ...(doc.note !== undefined ? { note: doc.note } : {}),
     createdAt: new Date(doc.createdAt).toISOString(),

--- a/server/src/orchestrator/stores.ts
+++ b/server/src/orchestrator/stores.ts
@@ -110,14 +110,31 @@ async function ensureIndexes(db: Db): Promise<void> {
       if ((err as { codeName?: string }).codeName !== "NamespaceExists") throw err;
     });
 
+  // Registry v2 migration: v1 enforced one-token-per-handle with a unique
+  // {handle:1} index; a handle now holds ANY number of tokens (one per
+  // machine), so drop the legacy unique index if this deployment carries it.
+  const reg = db.collection("agents_registry");
+  const regIndexes = await reg.indexes().catch(() => []);
+  if (regIndexes.some((i) => i.name === "handle_1" && i.unique)) {
+    await reg.dropIndex("handle_1").catch(() => undefined);
+  }
+
   await Promise.all([
     db.collection("issues").createIndex({ state: 1, labels: 1 }),
     db.collection("issues").createIndex({ updatedAt: -1 }),
     db.collection("assignments").createIndex({ issueNumber: 1, active: 1 }),
     db.collection("assignments").createIndex({ handle: 1 }),
-    db.collection("agents_registry").createIndex({ handle: 1 }, { unique: true }),
+    reg.createIndex({ handle: 1 }, { name: "handle_lookup" }),
+    // TOFU self-enrollment stays exactly-once per handle: only the
+    // autoEnrolled docs are under the unique constraint, so operator mints
+    // are unlimited while racing first-contact enrolls still get exactly
+    // one winner (auth.enrollAgent relies on the E11000 from this).
+    reg.createIndex(
+      { handle: 1 },
+      { unique: true, partialFilterExpression: { autoEnrolled: true }, name: "handle_autoenroll_unique" },
+    ),
     // Not in the spec's index list but every token verification is a lookup
     // by tokenHash — cheap, idempotent, and saves a collection scan per claim.
-    db.collection("agents_registry").createIndex({ tokenHash: 1 }),
+    reg.createIndex({ tokenHash: 1 }),
   ]);
 }

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -34,7 +34,11 @@ const mintBodySchema = z.object({
   note: z.string().max(300).optional(),
 });
 
-const revokeBodySchema = z.object({ handle: handleField });
+const revokeBodySchema = z.object({
+  handle: handleField,
+  /** Revoke one specific token (see the registry listing) instead of all. */
+  tokenId: z.string().regex(/^[0-9a-f]{12}$/).optional(),
+});
 
 const commandBodySchema = z
   .object({
@@ -86,21 +90,25 @@ export function registerAdminRoutes(
 
   /** Mint (or re-mint) an agent token. The plaintext appears in this response
    *  ONCE and is never stored or logged (registry keeps only the sha256). */
+  // Mint is ADDITIVE: each call issues one more independently-revocable
+  // token for the handle (one per machine/runner). tokenId names it in
+  // listings and targeted revokes.
   app.post("/api/v1/admin/agents", guarded, async (req, reply) => {
     const parsed = mintBodySchema.safeParse(req.body);
     if (!parsed.success) return badRequest(reply, parsed.error);
-    const { token } = await mintAgentToken(orch, parsed.data);
-    return { ok: true, handle: parsed.data.handle, tier: parsed.data.tier, token };
+    const { token, tokenId } = await mintAgentToken(orch, parsed.data);
+    return { ok: true, handle: parsed.data.handle, tier: parsed.data.tier, token, tokenId };
   });
 
+  // Revoke every live token for the handle, or — with tokenId — just one.
   app.post("/api/v1/admin/agents/revoke", guarded, async (req, reply) => {
     const parsed = revokeBodySchema.safeParse(req.body);
     if (!parsed.success) return badRequest(reply, parsed.error);
-    const revoked = await revokeAgentToken(orch, parsed.data.handle);
+    const revoked = await revokeAgentToken(orch, parsed.data.handle, parsed.data.tokenId);
     if (!revoked) {
-      return reply.code(404).send({ ok: false, error: "unknown or already-revoked handle" });
+      return reply.code(404).send({ ok: false, error: "no live token matched that handle/tokenId" });
     }
-    return { ok: true, handle: parsed.data.handle };
+    return { ok: true, handle: parsed.data.handle, ...(parsed.data.tokenId ? { tokenId: parsed.data.tokenId } : {}) };
   });
 
   /** Registry listing — RegisteredAgent rows only, never token hashes. */

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -83,7 +83,8 @@ export function registerDispatchRoutes(
     if (!minted) {
       return reply.code(409).send({
         ok: false,
-        error: "handle already enrolled — recover the stored token or ask the operator to reset it",
+        error:
+          "handle already enrolled — copy its stored ~/.forgood token to this machine, or ask the operator to mint an additional token",
       });
     }
     store.addEvent("agent_online", `@${parsed.data.handle} enrolled with the fleet server`, {

--- a/server/test/auth.test.mjs
+++ b/server/test/auth.test.mjs
@@ -140,17 +140,27 @@ test("re-mint after revoke: new token verifies, old stays dead", { skip }, async
   assert.deepEqual(await verifyAgentToken(orch, second.token), { handle: "carol", tier: "framer" });
   assert.equal(await verifyAgentToken(orch, first.token), null, "pre-revoke token must stay dead");
 
-  // Exactly one doc per handle (unique {handle:1} index → re-mint replaces).
+  // One doc PER TOKEN now: the revoked one stays as the audit trail.
   const count = await orch.db.collection("agents_registry").countDocuments({ handle: "carol" });
-  assert.equal(count, 1);
+  assert.equal(count, 2);
 });
 
-test("re-mint without revoke replaces the old token", { skip }, async () => {
-  const first = await mintAgentToken(orch, { handle: "dave", tier: "standard" });
-  assert.ok(await verifyAgentToken(orch, first.token), "sanity: first token verifies");
-  const second = await mintAgentToken(orch, { handle: "dave", tier: "standard" });
-  assert.equal(await verifyAgentToken(orch, first.token), null, "replaced token must stop verifying");
-  assert.ok(await verifyAgentToken(orch, second.token));
+test("mints are additive: a handle holds many live tokens, revocable individually", { skip }, async () => {
+  const first = await mintAgentToken(orch, { handle: "dave", tier: "standard", note: "laptop" });
+  const second = await mintAgentToken(orch, { handle: "dave", tier: "standard", note: "server" });
+  assert.notEqual(first.tokenId, second.tokenId);
+  assert.ok(await verifyAgentToken(orch, first.token), "first token stays live after a second mint");
+  assert.ok(await verifyAgentToken(orch, second.token), "both tokens verify concurrently");
+
+  // Targeted revoke kills exactly one machine's token.
+  assert.ok(await revokeAgentToken(orch, "dave", first.tokenId));
+  assert.equal(await verifyAgentToken(orch, first.token), null, "revoked token dead");
+  assert.ok(await verifyAgentToken(orch, second.token), "sibling token untouched");
+
+  // Handle-wide revoke sweeps the rest.
+  assert.ok(await revokeAgentToken(orch, "dave"));
+  assert.equal(await verifyAgentToken(orch, second.token), null);
+  assert.equal(await revokeAgentToken(orch, "dave"), false, "nothing live left to revoke");
 });
 
 // ---------------------------------------------------------------------------
@@ -182,9 +192,18 @@ test("enroll: a revoked handle can NOT re-enroll itself (revocation sticks)", { 
   await revokeAgentToken(orch, "tofu-revoked");
   assert.equal(await enrollAgent(orch, { handle: "tofu-revoked" }), null, "self-service un-revoke must be impossible");
   assert.equal(await verifyAgentToken(orch, first.token), null, "revoked token stays dead");
-  // The operator path still works: an explicit re-mint replaces the doc.
+  // The operator path still works: an explicit mint adds a fresh live token.
   const remint = await mintAgentToken(orch, { handle: "tofu-revoked", tier: "standard" });
   assert.ok(await verifyAgentToken(orch, remint.token), "operator re-mint recovers the handle");
+});
+
+test("enroll: an operator-minted handle can NOT be TOFU-squatted", { skip }, async () => {
+  await mintAgentToken(orch, { handle: "provisioned-user", tier: "trusted", note: "minted first" });
+  assert.equal(
+    await enrollAgent(orch, { handle: "provisioned-user" }),
+    null,
+    "self-enrollment must refuse a handle the operator already provisioned",
+  );
 });
 
 test("enroll: concurrent racers on one handle mint exactly one token", { skip }, async () => {


### PR DESCRIPTION
Part of #398, follow-up to #611. Directed by the maintainer: operators must be able to mint as many tokens as they like for a user (one per machine/runner).

- `agents_registry` becomes one doc **per token**: mint always inserts, each token carries a short non-secret `tokenId` for listing + targeted revocation. `revoke {handle}` sweeps all live tokens; `revoke {handle, tokenId}` kills exactly one machine's. Admin route and `fleet-admin.mjs` (`--token`) match.
- TOFU auto-enrollment stays exactly-once per handle via a partial unique index over `autoEnrolled` docs (replacing the legacy unique `{handle:1}` index; `connectOrchestrator` drops the old index on existing deployments). Enrollment also now refuses handles the operator has already provisioned — a minted user can't be TOFU-squatted.
- ADR-0017 / README / CLI docs updated.

120/120 server tests (new coverage: concurrent live tokens per handle, targeted + handle-wide revoke, provisioned-handle squat refusal), `npm run validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)