### PR TITLE
fix(server): self-hosted site served a build-time data snapshot forever — add host refresh script

### DIFF
--- a/server/scripts/refresh-web-data.sh
+++ b/server/scripts/refresh-web-data.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# refresh-web-data.sh — regenerate the site's data snapshot on the HOST.
+#
+# WHY: the container image bakes web/public/data/* at build time, and the
+# 15-min refresh cron in .github/workflows/pages.yml only updates the GitHub
+# Pages deployment — a self-hosted fleet server (STATIC_DIR serving the site)
+# would drift stale forever. This script runs web/scripts/build-data.mjs in
+# the repo checkout and the deployment bind-mounts web/public/data into the
+# container (see docker-compose.override.yml on the deploy box), so the site
+# serves a fresh snapshot without an image rebuild.
+#
+# Run from cron/systemd every ~10 min on the box that hosts the compose stack:
+#   */10 * * * *  /path/to/repo/server/scripts/refresh-web-data.sh >> ~/.forgood/refresh-web-data.log 2>&1
+#
+# Auth: uses FLEET_GITHUB_TOKEN from server/.env (the fleet bot token) as
+# GITHUB_TOKEN so the ~40 API calls don't run anonymous (60/h rate limit).
+# Never prints the token. Findings/streams file listings come from THIS
+# checkout's disk state — they refresh when the checkout does; the GitHub-API
+# numbers (board, streams, contributors, PRs) are always live.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOCK="${TMPDIR:-/tmp}/fg-refresh-web-data.lock"
+
+# Skip (don't queue) if a previous run is still going.
+exec 9>"$LOCK"
+flock -n 9 || { echo "$(date -Is) another refresh is running — skipping"; exit 0; }
+
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -f "$ROOT/server/.env" ]; then
+  GITHUB_TOKEN="$(grep '^FLEET_GITHUB_TOKEN=' "$ROOT/server/.env" | head -1 | cut -d= -f2- || true)"
+  export GITHUB_TOKEN
+fi
+
+echo "$(date -Is) refreshing web data snapshot..."
+cd "$ROOT/web"
+node scripts/build-data.mjs
+echo "$(date -Is) done: $(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/snapshot.json","utf8")).generatedAt)')"


### PR DESCRIPTION
Part of #398. The self-hosted site (container `STATIC_DIR`) served a **build-time** `snapshot.json` forever — the 15-min refresh in `pages.yml` only updates GitHub Pages. Prod was serving July-3 data.

Fix: `server/scripts/refresh-web-data.sh` runs `web/scripts/build-data.mjs` on the deploy host (flock'd; auth from `FLEET_GITHUB_TOKEN` in `server/.env`), cron'd every 10 min, with the checkout's `web/public/data` bind-mounted read-only over the image's baked copy via a git-ignored `docker-compose.override.yml`. Verified live: forgood.thecolab.ai now serves a fresh snapshot. Also ignores the override file so machine-local ops config can't be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)