### PR TITLE
research: compare checkout basket delivery costs (Closes #581)

### DIFF
--- a/research/data/checkout-basket-delivery-costs-nz.json
+++ b/research/data/checkout-basket-delivery-costs-nz.json
@@ -1,0 +1,134 @@
+{
+  "title": "Issue #581 live pre-payment delivery quote audit",
+  "date_utc": "2026-07-05",
+  "agent": "codex",
+  "model": "gpt-5-codex",
+  "scope": "Small, reproducible audit of identical single-item baskets where NZ retailer pages exposed a delivery quote before login, payment, or order placement. No order was placed and no personal address was used.",
+  "test_locations": [
+    {
+      "class": "metro",
+      "label": "Auckland Central",
+      "input_used": "1010 / Auckland Central",
+      "source": "NZ Post address lookup returned 101/438 Queen Street, Auckland Central, Auckland 1010 as Postal\\Physical."
+    },
+    {
+      "class": "rural",
+      "label": "RD 2 Wairoa / Wairoa 4197",
+      "input_used": "4197 / Wairoa; NZ Post rural validation query used 2035 State Highway 2, RD 2, Wairoa 4197",
+      "source": "NZ Post address lookup returned 2035 State Highway 2, RD 2, Wairoa 4197 as Postal."
+    },
+    {
+      "class": "remote",
+      "label": "Chatham Islands",
+      "input_used": "8942 / Chatham Islands",
+      "source": "Chatham Islands Council and NZ Government list Waitangi, Chatham Islands 8942 for council contact/postal details."
+    }
+  ],
+  "observations": [
+    {
+      "retailer": "Briscoes",
+      "product": "Urban Loft Louie Bath Towel",
+      "product_url": "https://www.briscoes.co.nz/product/1129496/urban-loft-louie-bath-towel/",
+      "basket": "1 x Urban Loft Louie Bath Towel, colour Platinum, SKU 1129496006, product page price $14.99",
+      "quote_surface": "Product page delivery postcode panel before adding to cart",
+      "quotes": [
+        {
+          "location_class": "metro",
+          "input": "1010",
+          "result": "Standard Delivery, delivery within 1-3 business days, $8.00; Express Evening Delivery, delivery tonight between 6pm and 9pm, $14.00"
+        },
+        {
+          "location_class": "rural",
+          "input": "4197",
+          "result": "Rural Delivery, delivery within 5-10 business days, $10.00"
+        },
+        {
+          "location_class": "remote",
+          "input": "8942",
+          "result": "Standard Delivery, delivery within 1-3 business days, note says standard excludes rural postcodes and outer islands, $8.00"
+        }
+      ],
+      "limitations": "The postcode-only remote result conflicts with Briscoes' FAQ note that outer islands incur additional costs, so it should be treated as a pre-payment product-page quote rather than proof of final landed cost after full address validation."
+    },
+    {
+      "retailer": "Bunnings NZ",
+      "product": "Craftright 8m Tape Measure",
+      "product_url": "https://www.bunnings.co.nz/craftright-8m-tape-measure_p5660481",
+      "basket": "1 x Craftright 8m Tape Measure, I/N 5660481, product page price $4.98",
+      "quote_surface": "Product page delivery postcode/suburb estimator before adding to cart",
+      "quotes": [
+        {
+          "location_class": "metro",
+          "input": "Auckland Central, Auckland",
+          "result": "$8 delivery fee; delivered between Thu 9 - Mon 13 Jul; single item only; delivery calculated at checkout for multiple items; available"
+        },
+        {
+          "location_class": "rural",
+          "input": "Wairoa",
+          "result": "$8 delivery fee; delivered between Thu 9 - Mon 13 Jul; single item only; delivery calculated at checkout for multiple items; available"
+        },
+        {
+          "location_class": "remote",
+          "input": "Chatham Islands",
+          "result": "$8 delivery fee; delivered between Thu 9 - Mon 13 Jul; single item only; delivery calculated at checkout for multiple items; available"
+        }
+      ],
+      "limitations": "The page explicitly says the quote is for a single item only and that delivery is calculated at checkout for multiple items."
+    },
+    {
+      "retailer": "Mitre 10",
+      "product": "Number 8 Tape Measure 5m",
+      "product_url": "https://www.mitre10.co.nz/shop/number-8-tape-measure-5m/p/229913",
+      "basket": "1 x Number 8 Tape Measure 5m, SKU 229913, product page price $3.58",
+      "quote_surface": "Product page delivery location picker before adding to cart",
+      "quotes": [
+        {
+          "location_class": "metro",
+          "input": "Auckland Central, Auckland, 1010",
+          "result": "Delivery - From $8.00; deliver to Auckland Central, 1010"
+        },
+        {
+          "location_class": "rural",
+          "input": "Wairoa, Wairoa District, 4197",
+          "result": "Delivery - From $8.00; deliver to Wairoa, 4197"
+        },
+        {
+          "location_class": "remote",
+          "input": "Chatham Islands, Chatham Island, 8942",
+          "result": "Delivery - From $8.00; deliver to Chatham Islands, 8942"
+        }
+      ],
+      "limitations": "The product page showed a 'From $8.00' estimate, not a final checkout fee; Mitre 10's delivery page separately says rural parcel orders under 25kg are $13.50 and that costs are calculated and displayed at checkout."
+    },
+    {
+      "retailer": "Chemist Warehouse NZ",
+      "product": "Healtheries Vitamin C 1,000mg + Prebiotics & Probiotics 80 Tablets",
+      "product_url": "https://www.chemistwarehouse.co.nz/buy/96405/healtheries-vitamin-c-1,000mg-prebiotics-probiotics-80-tablets",
+      "basket": "1 x product, product page/cart price $18.99",
+      "quote_surface": "Cart before checkout",
+      "quotes": [
+        {
+          "location_class": "all",
+          "input": "No address accepted before next step in this run",
+          "result": "Cart showed Shipping: Calculated at next step; add $80.01 to cart to get free standard shipping."
+        }
+      ],
+      "limitations": "The browser session did not advance to an address quote without further checkout/contact details."
+    },
+    {
+      "retailer": "The Warehouse",
+      "product": "WS Photocopy Paper A4 80gsm 500 Sheet Ream",
+      "product_url": "https://www.thewarehouse.co.nz/p/ws-photocopy-paper-a4-80gsm-500-sheet-ream-white/R651351.html",
+      "basket": "1 x WS Photocopy Paper A4 80gsm 500 Sheet Ream, item no. 9418362009356, product page price $8.90",
+      "quote_surface": "Product page island selector before cart",
+      "quotes": [
+        {
+          "location_class": "north_island",
+          "input": "North Island",
+          "result": "Available in the North Island; standard delivery estimated 2-4 business days; no dollar delivery fee shown on product page."
+        }
+      ],
+      "limitations": "Clicking the cart after adding the item triggered Cloudflare security verification in this environment, so no metro/rural/remote checkout fee was verified."
+    }
+  ]
+}

--- a/research/findings/other/checkout-basket-delivery-costs-nz.md
+++ b/research/findings/other/checkout-basket-delivery-costs-nz.md
@@ -1,0 +1,89 @@
+---
+title: "Identical small checkout baskets show rural and remote delivery premiums are not consistently exposed before payment"
+domain: "other"
+issue: "#581"
+confidence: "Medium"
+author: "codex"
+agent: "codex"
+model: "gpt-5-codex"
+date: "2026-07-05"
+status: "draft"
+---
+
+# Identical small checkout baskets show rural and remote delivery premiums are not consistently exposed before payment
+
+## Executive answer
+
+- A narrow live audit of five NZ retailers found only **two** that exposed comparable metro/rural/remote single-item delivery quotes before login, payment, or full checkout: Briscoes and Bunnings NZ [audit data, 5 Jul 2026](../../data/checkout-basket-delivery-costs-nz.json).
+- For the Briscoes towel basket, postcode 1010 showed $8 standard delivery and $14 express, postcode 4197 showed $10 rural delivery, and postcode 8942 showed $8 standard delivery even though Briscoes' FAQ says outer islands, including the Chatham Islands, incur additional costs [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Briscoes FAQ](https://www.briscoes.co.nz/faqs/).
+- For the Bunnings tape-measure basket, Auckland Central, Wairoa, and Chatham Islands all showed the same $8 single-item delivery fee before cart, with the page warning that delivery is calculated at checkout for multiple items [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Bunnings product page](https://www.bunnings.co.nz/craftright-8m-tape-measure_p5660481).
+- Mitre 10's tape-measure page showed "Delivery - From $8.00" for Auckland Central, Wairoa, and Chatham Islands, but this is not a final checkout quote; Mitre 10's own delivery page separately lists $8 metro and $13.50 rural parcel delivery under 25kg and says delivery costs are calculated and displayed at checkout [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Mitre 10 delivery and returns](https://www.mitre10.co.nz/delivery-returns).
+- Chemist Warehouse and The Warehouse did not yield comparable metro/rural/remote fees in this run: Chemist Warehouse stopped at "Shipping: Calculated at next step", while The Warehouse showed island-level availability but cart access hit Cloudflare security verification in this environment [audit data](../../data/checkout-basket-delivery-costs-nz.json).
+
+**Overall confidence:** Medium - the observations are reproducible browser/session notes for a small set of named baskets, backed by retailer policy pages where available, but they are not a representative market sample and do not prove final payable totals after full address validation, account state, promotions, or payment-step checkout.
+
+## Evidence
+
+### Scope and test locations
+
+This finding answers the issue narrowly: what **identical small baskets** show at visible pre-payment delivery-quote surfaces across metro, rural, and remote NZ locations, not what every retailer would charge after a completed order or account-authenticated checkout [Issue #581](https://github.com/thecolab-ai/the-for-good-project/issues/581), [audit data](../../data/checkout-basket-delivery-costs-nz.json). I used public/non-personal location inputs: Auckland Central 1010 for metro, Wairoa/RD 2 Wairoa 4197 for rural, and Chatham Islands 8942 for remote [audit data](../../data/checkout-basket-delivery-costs-nz.json). The NZ Post address lookup skill returned "101/438 Queen Street, Auckland Central, Auckland 1010" as Postal/Physical and "2035 State Highway 2, RD 2, Wairoa 4197" as Postal; Chatham Islands Council and the NZ Government list Chatham Islands Council at Waitangi / Chatham Islands 8942 [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Chatham Islands Council contact](https://www.cic.govt.nz/contact), [NZ Government Chatham Islands Council page](https://www.govt.nz/organisations/chatham-islands-council/).
+
+I did not enter payment details, place orders, create accounts, use private addresses, or test pharmacy-only/prescription goods [audit data](../../data/checkout-basket-delivery-costs-nz.json). This matters because earlier findings in this stream already showed several retailers disclose that delivery is calculated at checkout or depends on address, item, basket, seller, or service type [online retailer delivery-fees snapshot](online-retailer-delivery-fees-snapshot.md), [rural delivery surcharge finding](rural-delivery-surcharge-nz.md).
+
+### Live quote results
+
+| Retailer and basket | Metro input and visible quote | Rural input and visible quote | Remote input and visible quote | How to read it |
+|---|---:|---:|---:|---|
+| Briscoes: 1 x Urban Loft Louie Bath Towel, $14.99 product-page price | 1010: $8 standard, $14 express | 4197: $10 rural | 8942: $8 standard | Strong product-page quote for postcode inputs, but weak for remote because the same retailer FAQ says outer islands incur additional costs [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Briscoes FAQ](https://www.briscoes.co.nz/faqs/) |
+| Bunnings NZ: 1 x Craftright 8m Tape Measure, $4.98 product-page price | Auckland Central: $8 | Wairoa: $8 | Chatham Islands: $8 | Strong single-item product-page quote; explicitly not a multi-item checkout guarantee [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Bunnings product page](https://www.bunnings.co.nz/craftright-8m-tape-measure_p5660481) |
+| Mitre 10: 1 x Number 8 Tape Measure 5m, $3.58 product-page price | Auckland Central 1010: from $8 | Wairoa 4197: from $8 | Chatham Islands 8942: from $8 | Weak estimate, because the page says "from" and Mitre 10's delivery table lists a rural parcel price of $13.50 [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Mitre 10 delivery and returns](https://www.mitre10.co.nz/delivery-returns) |
+| Chemist Warehouse: 1 x Healtheries Vitamin C product, $18.99 cart price | Not reached | Not reached | Not reached | Cart said shipping was calculated at next step; no address quote was obtained [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Chemist Warehouse product page](https://www.chemistwarehouse.co.nz/buy/96405/healtheries-vitamin-c-1,000mg-prebiotics-probiotics-80-tablets) |
+| The Warehouse: 1 x WS Photocopy Paper A4 80gsm, $8.90 product-page price | Not reached | Not reached | Not reached | Product page showed North Island standard delivery timing but no dollar fee; cart access hit Cloudflare security verification [audit data](../../data/checkout-basket-delivery-costs-nz.json), [The Warehouse product page](https://www.thewarehouse.co.nz/p/ws-photocopy-paper-a4-80gsm-500-sheet-ream-white/R651351.html) |
+
+### What the baskets add beyond policy pages
+
+The checkout-style observations partially confirm published policy tables for simple parcels: Briscoes' rural quote was $10 against $8 metro, matching its FAQ row that standard delivery is $8 and rural delivery is $10 [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Briscoes FAQ](https://www.briscoes.co.nz/faqs/). The same Briscoes test also showed why postcode-only or early product-page quoting can mislead a shopper-facing comparison: postcode 8942 returned $8 standard delivery on the towel page, while the FAQ says outer islands, naming the Chatham Islands, incur additional costs [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Briscoes FAQ](https://www.briscoes.co.nz/faqs/).
+
+Bunnings' product page produced the cleanest identical-basket result in this run: the same $8 delivery fee appeared for Auckland Central, Wairoa, and Chatham Islands for a single Craftright tape measure [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Bunnings product page](https://www.bunnings.co.nz/craftright-8m-tape-measure_p5660481). That result should not be generalised to a Bunnings order basket, because the page itself noted that the $8 figure was for a single item only and that delivery is calculated at checkout for multiple items [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Bunnings shop online help](https://www.bunnings.co.nz/help-centre/shop-online).
+
+Mitre 10 demonstrates the biggest measurement trap: the same product page showed "from $8" for all three location classes, but the retailer's delivery page states metro parcel orders under 25kg are $8, rural parcel orders under 25kg are $13.50, rural addresses are defined by NZ Post address data, and final delivery costs can be calculated and displayed at checkout [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Mitre 10 delivery and returns](https://www.mitre10.co.nz/delivery-returns). A shopper tool should therefore store Mitre 10's page-picker result as an estimate field, not as the landed cost [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Mitre 10 delivery and returns](https://www.mitre10.co.nz/delivery-returns).
+
+## Surprising or load-bearing claims
+
+| Claim | Source 1 | Source 2 | Confidence |
+|---|---|---|---|
+| Identical single-item baskets did not consistently show a rural/remote premium before payment: Briscoes showed a $2 rural premium, Bunnings showed no premium, and Mitre 10 showed only a "from $8" estimate. | [Audit data](../../data/checkout-basket-delivery-costs-nz.json) | [Briscoes FAQ](https://www.briscoes.co.nz/faqs/), [Mitre 10 delivery and returns](https://www.mitre10.co.nz/delivery-returns) | Medium |
+| Briscoes' postcode 8942 product-page quote is not enough to prove final Chatham Islands landed cost, because the same retailer's FAQ says outer islands including the Chatham Islands incur additional costs. | [Audit data](../../data/checkout-basket-delivery-costs-nz.json) | [Briscoes FAQ](https://www.briscoes.co.nz/faqs/) | Medium |
+| A product-page "from" delivery estimate can understate the rural price implied by the same retailer's policy table. | [Audit data](../../data/checkout-basket-delivery-costs-nz.json) | [Mitre 10 delivery and returns](https://www.mitre10.co.nz/delivery-returns) | Medium |
+| Two major tested retailers did not expose comparable metro/rural/remote delivery fees in this run before more checkout friction: Chemist Warehouse deferred shipping to the next step and The Warehouse cart hit Cloudflare verification. | [Audit data](../../data/checkout-basket-delivery-costs-nz.json) | [Chemist Warehouse product page](https://www.chemistwarehouse.co.nz/buy/96405/healtheries-vitamin-c-1,000mg-prebiotics-probiotics-80-tablets), [The Warehouse product page](https://www.thewarehouse.co.nz/p/ws-photocopy-paper-a4-80gsm-500-sheet-ream-white/R651351.html) | Medium-Low |
+
+## What would change this conclusion
+
+- A browser-recorded checkout audit using full public/commercial addresses, screenshots, and cart IDs for at least 15-20 retailers would change the exact count of retailers that expose final fees before payment [audit data](../../data/checkout-basket-delivery-costs-nz.json).
+- Retailer back-end delivery rules, promotions, stock location, and product eligibility can change daily, so repeating the same baskets after 5 July 2026 could change individual quotes [Briscoes FAQ](https://www.briscoes.co.nz/faqs/), [Mitre 10 delivery and returns](https://www.mitre10.co.nz/delivery-returns).
+- A full-account checkout run, stopped immediately before payment, could verify whether Briscoes actually adds outer-island costs for Chatham Islands after street-address validation [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Briscoes FAQ](https://www.briscoes.co.nz/faqs/).
+- I could not verify final payable delivery fees for Chemist Warehouse or The Warehouse in this run; a human or browser harness that can pass those next-step/session checks without using private personal data would be needed [audit data](../../data/checkout-basket-delivery-costs-nz.json).
+- I could not verify whether retailers classify "Wairoa 4197" the same way they classify the NZ Post-returned "RD 2, Wairoa 4197" address; Mitre 10 says NZ Post address data defines rural parcel addresses, but not every tested page accepted full RD address input [audit data](../../data/checkout-basket-delivery-costs-nz.json), [Mitre 10 delivery and returns](https://www.mitre10.co.nz/delivery-returns).
+
+## Open follow-up questions
+
+- Which retailers expose final delivery fees only after full street-address validation, and can a consent-safe harness capture those prices without storing personal data?
+- For outer-island addresses, how often do postcode/suburb estimators disagree with final checkout charges?
+- Do multi-item baskets change Bunnings' flat $8 single-item quote for rural or remote locations, as its product page warning implies [audit data](../../data/checkout-basket-delivery-costs-nz.json)?
+
+## Sources
+
+1. Local audit data. "Issue #581 live pre-payment delivery quote audit." 5 July 2026. [../../data/checkout-basket-delivery-costs-nz.json](../../data/checkout-basket-delivery-costs-nz.json).
+2. GitHub issue #581. "research: What do identical checkout baskets show for NZ online delivery costs across metro, rural, and remote addresses?" Accessed 5 July 2026. https://github.com/thecolab-ai/the-for-good-project/issues/581
+3. Briscoes. Urban Loft Louie Bath Towel product page. Accessed 5 July 2026 with `agent-browser`. https://www.briscoes.co.nz/product/1129496/urban-loft-louie-bath-towel/
+4. Briscoes. FAQs, delivery times and costs. Accessed 5 July 2026 via WebFetch/browser-readable HTML. https://www.briscoes.co.nz/faqs/
+5. Bunnings NZ. Craftright 8m Tape Measure product page. Accessed 5 July 2026 with `agent-browser`. https://www.bunnings.co.nz/craftright-8m-tape-measure_p5660481
+6. Bunnings NZ. Shop online help page. Accessed 5 July 2026 via WebFetch/browser-readable HTML. https://www.bunnings.co.nz/help-centre/shop-online
+7. Mitre 10. Number 8 Tape Measure 5m product page. Accessed 5 July 2026 with `agent-browser`. https://www.mitre10.co.nz/shop/number-8-tape-measure-5m/p/229913
+8. Mitre 10. Delivery & Returns. Accessed 5 July 2026 via WebFetch/browser-readable HTML. https://www.mitre10.co.nz/delivery-returns
+9. Chemist Warehouse NZ. Healtheries Vitamin C product page. Accessed 5 July 2026 with `agent-browser`. https://www.chemistwarehouse.co.nz/buy/96405/healtheries-vitamin-c-1,000mg-prebiotics-probiotics-80-tablets
+10. The Warehouse. WS Photocopy Paper A4 80gsm 500 Sheet Ream product page. Accessed 5 July 2026 with `agent-browser`; cart access triggered Cloudflare security verification. https://www.thewarehouse.co.nz/p/ws-photocopy-paper-a4-80gsm-500-sheet-ream-white/R651351.html
+11. Chatham Islands Council. Contact page. Accessed 5 July 2026. https://www.cic.govt.nz/contact
+12. New Zealand Government. Chatham Islands Council organisation page. Accessed 5 July 2026. https://www.govt.nz/organisations/chatham-islands-council/
+13. Existing stream finding. "Selected NZ online retailers publish a mixed delivery-fee picture." [online-retailer-delivery-fees-snapshot.md](online-retailer-delivery-fees-snapshot.md).
+14. Existing stream finding. "Published NZ retailer rural-delivery tables show small parcel add-ons where disclosed." [rural-delivery-surcharge-nz.md](rural-delivery-surcharge-nz.md).


### PR DESCRIPTION
Closes #581. Stream: #258. Adds a narrow live pre-payment checkout basket audit across metro, rural, and remote NZ locations.