### PR TITLE
team/reorder members

### DIFF
--- a/web/src/lib/team.ts
+++ b/web/src/lib/team.ts
@@ -37,13 +37,6 @@ export type TeamMember = {
 // people replace these one signed-off consent at a time (see header above).
 export const TEAM: TeamMember[] = [
   {
-    id: "gligorkot",
-    role: "Contributor",
-    focus: "Reviews and contributes to the open project, keeping the public work tied to real people.",
-    name: "Gligor Kotushevski",
-    photo: "team/gligorkot.jpg",
-  },
-  {
     id: "steward",
     role: "Founder & steward",
     focus: "Sets direction, makes the human gate calls, and carries the relationships.",
@@ -51,11 +44,11 @@ export const TEAM: TeamMember[] = [
     photo: "team/adam91holt.jpg",
   },
   {
-    id: "research-lead",
-    role: "Research lead",
-    focus: "Owns the cited-and-honest standard — what we investigate and how hard we check it.",
-    name: null,
-    photo: null,
+    id: "gligorkot",
+    role: "Contributor",
+    focus: "Reviews and contributes to the open project, keeping the public work tied to real people.",
+    name: "Gligor Kotushevski",
+    photo: "team/gligorkot.jpg",
   },
   {
     id: "engineering",
@@ -71,13 +64,6 @@ export const TEAM: TeamMember[] = [
     focus: "Brings charities, councils and agencies the real problems worth working on.",
     name: "Rachel McBride",
     photo: "team/rachelmcbride.jpg",
-  },
-  {
-    id: "ethics",
-    role: "Method & ethics",
-    focus: "Guards the guardrails: no personal data, no overstatement, a human at every gate.",
-    name: null,
-    photo: null,
   },
 ];
 


### PR DESCRIPTION
## What

Reorders the team page so the founder (Adam Holt) appears first, and removes the two empty placeholder slots (research-lead, method & ethics) that had no consented person behind them.

## Why

Adam is the founder and steward — he should lead the page. The two placeholder slots (`name: null`, `photo: null`) were the designed "consent pending" cards, but with no real people behind them they add visual noise without information.

## Changes

- **Adam Holt** → first (founder & steward, unchanged)
- **Gligor Kotushevski** → second (contributor, unchanged)
- **Muhammad Asim** → third (engineering, unchanged)
- **Rachel McBride** → fourth (partnerships & field, unchanged)
- **Removed:** `research-lead` slot (null/null)
- **Removed:** `ethics` slot (null/null)

All four remaining members have real GitHub identities, commit history, photos in `web/public/team/`, and entries in `projects/brand-identity/CONSENT.md`.

## Verification

- `npm run build` (tsc + vite build) passes clean
- The consent note on the Team page gracefully no-ops when `consentedCount === total` — the "slots still showing a placeholder" clause simply doesn't render

No consent changes — no names or photos added or removed, only the slot order and the two empty placeholders dropped.