### PR TITLE
feat(server): mirror-backed runner queue reads — fleet loops cost zero GitHub budget (ADR-0018)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,7 @@
 # Deploy the site to GitHub Pages.
 #
 # Two paths, one job:
-#   • Every 15 min (cron) → refresh ONLY the data snapshot (the JSON the board
+#   • Hourly (cron) → refresh ONLY the data snapshot (the JSON the board
 #     reads) and redeploy. The built site is restored from cache, so the slow
 #     Vite build is SKIPPED — a quick, data-only refresh.
 #   • When the web SOURCE changes (push to web/src, public, config…) → the cache
@@ -10,13 +10,20 @@
 #
 # We deliberately do NOT trigger on issues / issue_comment / research changes:
 # that fired a deploy on every label flip and comment across a busy pipeline
-# (dozens an hour). The 15-minute cron keeps the board fresh instead — findings,
+# (dozens an hour). The hourly cron keeps this backup copy fresh instead —
 # issues and the leaderboard are re-read from the repo + API each run.
 name: Deploy site
 
 on:
   schedule:
-    - cron: "*/15 * * * *"        # data-only refresh (fast path)
+    - cron: "17 * * * *"          # hourly data-only refresh (fast path). The
+                                  # primary site (forgood.thecolab.ai) self-
+                                  # refreshes every 10 min from its own host
+                                  # (server/scripts/refresh-web-data.sh);
+                                  # this Pages copy is the backup, so hourly
+                                  # is plenty — and Actions minutes/API calls
+                                  # four times cheaper. Off-the-hour (:17)
+                                  # dodges GitHub's top-of-hour cron crunch.
   push:
     branches: [main]
     paths:                        # full rebuild only when the site itself changes

--- a/docs/adr/0018-mirror-backed-runner-reads.md
+++ b/docs/adr/0018-mirror-backed-runner-reads.md
@@ -1,0 +1,70 @@
+# ADR-0018: Runner queue reads come from the fleet server's mirror, not GitHub
+
+- **Status:** proposed (ratified on merge by the human maintainer, who directed this on
+  2026-07-06 after repeated rate-limit stalls; agents do not self-ratify pipeline changes)
+- **Date:** 2026-07-06
+- **Deciders:** @adam91holt (human maintainer); drafted by an agent (Claude Fable 5) acting
+  on his direct instructions
+- **Relates to:** ADR-0017 (pull-claim orchestration), ADR-0016 (the 2026-07-05 fleet stall
+  — set off by a GitHub rate-limit outage), ADR-0013 (pipeline guardrails), #398
+
+## Context
+
+Every runner loop on every machine starts with `fetch_open_issues()` — a paginated GitHub
+read of the whole open-issue queue (~3 REST calls at today's queue size) that feeds every
+local filter (my-rework, TTL-freed rework, next available). All of a contributor's machines
+share their ONE GitHub identity's rate-limit pools (5,000 REST/h, 5,000 GraphQL points/h,
+30 search/min), so fleet throughput scales the burn linearly while the budget stays flat.
+The fleet has been stalled by exactly this before: the 2026-07-05 incident (ADR-0016) began
+with a GitHub rate-limit outage, `fg-common` carries a REST fallback for `gh pr comment`
+because the GraphQL pool has been exhausted in hot bursts, and runners back off for an hour
+when a pass trips a limit.
+
+Meanwhile ADR-0017 gave the fleet server a MongoDB mirror of exactly this data — fed by
+HMAC-verified webhooks within seconds of every label flip, reconciled by an interval sync —
+sitting behind one public HTTPS endpoint with no GitHub budget attached.
+
+## Decision
+
+1. **The server serves the runners' queue snapshot.** `GET /api/v1/issues/open`
+   (unauthenticated, per-IP rate-limited, public mirror data) returns the open-issue
+   snapshot **byte-compatible** with `fetch_open_issues()`'s GitHub read
+   (`[{number, createdAt, labels:[{name}], assignees:[{login}]}]`), so every downstream
+   `jq` filter works unchanged. The two must be updated together.
+2. **Freshness is a hard gate, not advisory.** The route answers **503 unless the
+   reconciling sync has completed recently** (within 10 sync intervals — sync itself must
+   be running, i.e. the server holds a working bot token). Webhooks alone are not
+   sufficient: without a completed backfill the mirror can be missing issues entirely, and
+   an incomplete snapshot would silently hide work from the fleet. Stale/incomplete →
+   refuse → runners read GitHub directly.
+3. **Runners are mirror-first, GitHub-always-fallback.** `fetch_open_issues()` tries the
+   server (5s timeout, response validated) and falls back to the direct GitHub read on ANY
+   failure — server absent, 503-stale, malformed. `FLEET_SNAPSHOT=0` opts a runner out
+   entirely. A dead server can never stall the fleet (the ADR-0016/#398 invariant).
+4. **Correctness still rests on GitHub, not the mirror.** The snapshot only *selects*
+   candidates; every mutating step re-checks live GitHub state exactly as before
+   (`claim_issue` re-reads labels, the server's claim loop test-and-sets the
+   `status: available` removal). A stale mirror can waste an attempt, never corrupt state.
+5. **The Pages deploy cron drops from every 15 minutes to hourly.** The self-hosted site
+   (forgood.thecolab.ai) self-refreshes every 10 minutes on its own host
+   (`server/scripts/refresh-web-data.sh`); the GitHub Pages copy is the backup, so hourly
+   is plenty and cuts the Actions-side API/minutes load 4×.
+
+## Consequences
+
+- A runner loop that finds nothing to do now costs **zero GitHub API calls**; the fleet's
+  per-loop GitHub load no longer scales with machine count. The contributor identity's
+  budget is spent only on actual work (claims on the label path, PR pushes, comments).
+- The fleet server becomes a read dependency for queue *latency* (never availability):
+  if it is down or stale every runner transparently pays the old GitHub price again.
+- Webhook-fed selection means a label flip is visible to the whole fleet in seconds —
+  faster than the old per-loop polling, not just cheaper.
+- One more shape contract to keep in sync (`routes/queue.ts` ↔ `fetch_open_issues()`),
+  covered by a route test asserting the exact byte shape.
+
+## What would change this decision
+
+The server growing a second replica (the 503-staleness gate assumes one sync writer); a
+GitHub-side change to rate-limit accounting that makes per-loop reads cheap; or evidence
+that runners act on stale snapshots in a way the GitHub re-checks fail to catch (that
+would force a freshness token or ETag into the claim flow itself).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,5 +54,6 @@ routine fixes, copy changes, or web styling.
 | [0015](0015-autopilot-alternates-review-and-work.md) | autopilot.sh — one command alternates review and work, detects idle, and pulls latest main each cycle | Proposed |
 | [0016](0016-fleet-telemetry-defaults-and-merge-heal.md) | Fleet telemetry counters on by default (logs opt-in at every client) + deterministic index-cascade merge-healing in the runners | Proposed |
 | [0017](0017-server-orchestrated-pull-claim.md) | The fleet server arbitrates work claims for enrolled agents (pull-claim v1) | Proposed |
+| [0018](0018-mirror-backed-runner-reads.md) | Runner queue reads come from the fleet server's mirror, not GitHub | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -272,6 +272,23 @@ issue_field()   { gh issue view "$1" --repo "$REPO" --json "$2" --jq ".$2"; }
 # normal core quota, includes the fields we need, and returns PRs too, so filter
 # out `.pull_request` entries here.
 fetch_open_issues() {
+  # Mirror-first (ADR-0018): the fleet server serves this exact snapshot
+  # shape from its Mongo mirror — ONE unauthenticated HTTPS call, zero
+  # GitHub budget. With every runner loop on every machine drawing from the
+  # same per-identity GitHub pools, this read was the fleet's biggest
+  # rate-limit tax (and rate-limit stalls have taken the fleet down before —
+  # ADR-0016). Fall back to the direct GitHub read whenever the server is
+  # absent, stale (it answers 503 rather than serve a stale mirror), or
+  # returns anything malformed — a dead server can never stall the fleet.
+  # FLEET_SNAPSHOT=0 opts out (direct GitHub only).
+  if [ -n "${FLEET_SERVER:-}" ] && [ "${FLEET_SNAPSHOT:-1}" = "1" ]; then
+    local resp snap
+    if resp="$(curl -sS -m 5 "$FLEET_SERVER/api/v1/issues/open" 2>/dev/null)" \
+       && snap="$(printf '%s' "$resp" | jq -ce 'select(.ok == true) | .issues | select(type == "array")' 2>/dev/null)"; then
+      printf '%s' "$snap"
+      return 0
+    fi
+  fi
   gh api --paginate "repos/$OWNER/$NAME/issues?state=open&per_page=100" \
     --jq '[.[] | select(.pull_request|not) | {number, createdAt: .created_at, labels: [.labels[] | {name}], assignees: [.assignees[] | {login}]}]'
 }

--- a/server/scripts/refresh-web-data.sh
+++ b/server/scripts/refresh-web-data.sh
@@ -31,7 +31,12 @@ if [ -z "${GITHUB_TOKEN:-}" ] && [ -f "$ROOT/server/.env" ]; then
   export GITHUB_TOKEN
 fi
 
-echo "$(date -Is) refreshing web data snapshot..."
+# Write OUTSIDE the checkout (ADR-0018): the tracked web/public/data/* stays
+# untouched, so the 10-min cron can never dirty the repo or bloat a commit —
+# the compose override mounts this dir into the container at /app/public/data.
+export DATA_OUT_DIR="${DATA_OUT_DIR:-$HOME/.forgood/web-data}"
+
+echo "$(date -Is) refreshing web data snapshot -> $DATA_OUT_DIR"
 cd "$ROOT/web"
 node scripts/build-data.mjs
-echo "$(date -Is) done: $(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/snapshot.json","utf8")).generatedAt)')"
+echo "$(date -Is) done: $(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.env.DATA_OUT_DIR + "/snapshot.json","utf8")).generatedAt)')"

--- a/server/src/routes/queue.ts
+++ b/server/src/routes/queue.ts
@@ -7,17 +7,29 @@
  *    nothing — discover can never appear here, ADR-0014).
  *  - GET /api/v1/board — counts by "status: *" label over open issues +
  *    open issue/PR counts.
+ *  - GET /api/v1/issues/open — the runners' queue snapshot (ADR-0018):
+ *    byte-compatible with fg-common's fetch_open_issues() GitHub read
+ *    ([{number, createdAt, labels:[{name}], assignees:[{login}]}]), served
+ *    from the mirror so a fleet loop costs ZERO GitHub budget. 503 when the
+ *    mirror is stale (sync hasn't advanced recently) — runners then fall
+ *    back to the direct GitHub read rather than trusting stale data.
  *
  * index.ts registers this only when orchestration is connected (otherwise
  * the paths answer 503 "orchestration disabled").
  */
 import type { FastifyInstance } from "fastify";
+import { config } from "../config.js";
 import { IpRateLimiter } from "../guards.js";
 import { listQueue } from "../orchestrator/dispatch.js";
 import type { Orchestrator } from "../orchestrator/stores.js";
 import type { FleetStore } from "../state.js";
 
 const STATUS_PREFIX = "status: ";
+
+/** How stale sync_state.lastIncrementalAt may be before the snapshot route
+ *  refuses to serve (runners fall back to GitHub). Sync runs every
+ *  syncIntervalSeconds (default 60s), so 10 missed passes = stale. */
+const SNAPSHOT_STALE_FACTOR = 10;
 
 export function registerQueueRoutes(
   app: FastifyInstance,
@@ -61,5 +73,40 @@ export function registerQueueRoutes(
     }
     const openPrs = await orch.db.collection("pulls").countDocuments({ state: "open" });
     return { ok: true, statuses, openIssues: open.length, openPrs };
+  });
+
+  // The runners' whole-queue snapshot (ADR-0018). Shape is BYTE-COMPATIBLE
+  // with fg-common's fetch_open_issues() so every downstream jq filter
+  // (rework_issues, issues_with_status, pick_available) works unchanged —
+  // update both together. Served only while the mirror is demonstrably
+  // fresh: the reconciling sync must have completed within
+  // SNAPSHOT_STALE_FACTOR sync intervals, otherwise 503 and the runner
+  // falls back to its direct GitHub read. Webhooks alone are NOT enough
+  // here — without a completed backfill sync the mirror may be missing
+  // issues entirely, and an incomplete snapshot would silently hide work.
+  app.get("/api/v1/issues/open", async (req, reply) => {
+    if (!limiter.allow(req.ip)) return reply.code(429).send({ ok: false, error: "slow down" });
+    const sync = await orch.db
+      .collection<{ lastIncrementalAt?: string }>("sync_state")
+      .findOne({ _id: "sync" } as never);
+    const staleMs = config.syncIntervalSeconds * SNAPSHOT_STALE_FACTOR * 1000;
+    const last = sync?.lastIncrementalAt ? Date.parse(sync.lastIncrementalAt) : NaN;
+    if (!Number.isFinite(last) || Date.now() - last > staleMs) {
+      return reply.code(503).send({ ok: false, error: "mirror stale — use the direct GitHub read" });
+    }
+    const open = await orch.db
+      .collection<{ number: number; createdAt: string; labels: string[]; assignees: string[] }>("issues")
+      .find({ state: "open" }, { projection: { number: 1, createdAt: 1, labels: 1, assignees: 1 } })
+      .toArray();
+    return {
+      ok: true,
+      generatedAt: sync?.lastIncrementalAt,
+      issues: open.map((i) => ({
+        number: i.number,
+        createdAt: i.createdAt,
+        labels: (i.labels ?? []).map((name) => ({ name })),
+        assignees: (i.assignees ?? []).map((login) => ({ login })),
+      })),
+    };
   });
 }

--- a/server/test/dispatch.test.mjs
+++ b/server/test/dispatch.test.mjs
@@ -845,6 +845,59 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       assert.equal(board.openPrs, 1);
     });
 
+    await t.test("open-issues snapshot route: fetch_open_issues shape, stale mirror → 503", async () => {
+      await seed([
+        {
+          number: 91,
+          labels: ["status: available", "stage: research", "priority: high"],
+          assignees: ["worker-a"],
+          createdAt: "2026-06-01T00:00:00Z",
+        },
+        { number: 92, labels: ["status: claimed"], createdAt: "2026-06-02T00:00:00Z" },
+      ]);
+      const app = Fastify();
+      apps.push(app);
+      registerQueueRoutes(app, new FleetStore(), o);
+      const syncState = o.db.collection("sync_state");
+
+      // No sync has ever completed → the mirror may be INCOMPLETE (webhooks
+      // only cover touched issues) → refuse, runners fall back to GitHub.
+      await syncState.deleteMany({});
+      let res = await app.inject({ method: "GET", url: "/api/v1/issues/open" });
+      assert.equal(res.statusCode, 503, "no completed sync = untrusted mirror");
+
+      // Stale sync → 503 too.
+      await syncState.updateOne(
+        { _id: "sync" },
+        { $set: { lastIncrementalAt: new Date(Date.now() - 3_600_000).toISOString() } },
+        { upsert: true },
+      );
+      res = await app.inject({ method: "GET", url: "/api/v1/issues/open" });
+      assert.equal(res.statusCode, 503, "stale sync = untrusted mirror");
+
+      // Fresh sync → the snapshot, byte-compatible with fetch_open_issues():
+      // labels as [{name}], assignees as [{login}], createdAt present.
+      const freshAt = new Date().toISOString();
+      await syncState.updateOne({ _id: "sync" }, { $set: { lastIncrementalAt: freshAt } });
+      res = await app.inject({ method: "GET", url: "/api/v1/issues/open" });
+      assert.equal(res.statusCode, 200);
+      const body = res.json();
+      assert.equal(body.ok, true);
+      assert.equal(body.generatedAt, freshAt);
+      const i91 = body.issues.find((i) => i.number === 91);
+      assert.deepEqual(i91, {
+        number: 91,
+        createdAt: "2026-06-01T00:00:00Z",
+        labels: [
+          { name: "status: available" },
+          { name: "stage: research" },
+          { name: "priority: high" },
+        ],
+        assignees: [{ login: "worker-a" }],
+      });
+      assert.ok(body.issues.some((i) => i.number === 92), "ALL open issues included, not just available");
+    });
+
     await t.test("work routes (needs Implementer C's auth)", async () => {
       const auth = await import("../dist/orchestrator/auth.js");
       await seed([{ number: 121, labels: ["status: available", "stage: research"] }]);

--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -19,7 +19,11 @@ import matter from "gray-matter";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const WEB_DIR = path.resolve(__dirname, "..");
 const REPO_ROOT = path.resolve(WEB_DIR, "..");
-const OUT_DIR = path.join(WEB_DIR, "public", "data");
+// DATA_OUT_DIR: self-hosted deployments write the live snapshot to an
+// UNTRACKED dir (mounted into the serving container) so the 10-min refresh
+// cron never dirties the checkout (ADR-0018). Default: the tracked path,
+// exactly as before (CI/Pages and local dev unchanged).
+const OUT_DIR = process.env.DATA_OUT_DIR || path.join(WEB_DIR, "public", "data");
 
 const REPO = process.env.FOR_GOOD_REPO || "thecolab-ai/the-for-good-project";
 const [OWNER, NAME] = REPO.split("/");


### PR DESCRIPTION
Part of #398, implements ADR-0018 (included). Runner loops kept stalling on shared GitHub rate-limit pools — the per-loop open-issue snapshot now comes from the fleet server's mirror (one unauthenticated HTTPS call, zero GitHub budget), byte-compatible with the old read, hard 503-staleness gate, total GitHub fallback. Pages snapshot cron drops to hourly (the self-hosted site self-refreshes every 10 min). 121/121 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)