### PR TITLE
feat(live): who's working on what, for how long — active claims panel + task durations

### DIFF
--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -153,6 +153,8 @@ export interface AgentPresence {
   connectedAt: string;
   lastSeen: string;
   task: TaskInfo | null;
+  /** When the CURRENT task (by ref/kind) started — "working on X for 34m". */
+  taskSince: string | null;
   session: SessionCounters;
   /** Current tokens/sec for this agent over the sliding window. */
   tps: number;

--- a/server/src/routes/queue.ts
+++ b/server/src/routes/queue.ts
@@ -75,6 +75,60 @@ export function registerQueueRoutes(
     return { ok: true, statuses, openIssues: open.length, openPrs };
   });
 
+  // Who is working on what, right now — the dashboard's "active claims"
+  // panel. Active assignments joined with the mirror's issue titles and the
+  // LIVE Redis lease TTL (a lease near zero with an active doc = a worker
+  // gone quiet; the sweeper will reap it). All public data: the same
+  // labels/assignees GitHub shows, plus timing.
+  app.get("/api/v1/work/active", async (req, reply) => {
+    if (!limiter.allow(req.ip)) return reply.code(429).send({ ok: false, error: "slow down" });
+    const active = await orch.db
+      .collection<{
+        _id: unknown;
+        issueNumber: number;
+        handle: string;
+        harness?: string;
+        model?: string;
+        tier: string;
+        claimedAt: string;
+        renewedAt: string;
+      }>("assignments")
+      .find(
+        { active: true },
+        { projection: { issueNumber: 1, handle: 1, harness: 1, model: 1, tier: 1, claimedAt: 1, renewedAt: 1 } },
+      )
+      .sort({ claimedAt: 1 })
+      .toArray();
+    const titles = new Map<number, { title?: string; labels?: string[] }>(
+      (
+        await orch.db
+          .collection<{ _id: number; title?: string; labels?: string[] }>("issues")
+          .find({ _id: { $in: active.map((a) => a.issueNumber) } }, { projection: { title: 1, labels: 1 } })
+          .toArray()
+      ).map((i) => [i._id, i]),
+    );
+    const work = await Promise.all(
+      active.map(async (a) => {
+        const ttl = await orch.redis.ttl(`lease:issue:${a.issueNumber}`).catch(() => -2);
+        const issue = titles.get(a.issueNumber);
+        const stage = (issue?.labels ?? []).find((l) => l.startsWith("stage: "))?.slice(7) ?? null;
+        return {
+          issue: a.issueNumber,
+          title: issue?.title ?? null,
+          stage,
+          handle: a.handle,
+          harness: a.harness ?? null,
+          model: a.model ?? null,
+          claimedAt: a.claimedAt,
+          renewedAt: a.renewedAt,
+          /** -1/-2 = lease missing (expiring/reaped); dashboards show stalled. */
+          leaseSecondsLeft: ttl,
+        };
+      }),
+    );
+    return { ok: true, count: work.length, work };
+  });
+
   // The runners' whole-queue snapshot (ADR-0018). Shape is BYTE-COMPATIBLE
   // with fg-common's fetch_open_issues() so every downstream jq filter
   // (rework_issues, issues_with_status, pick_available) works unchanged —

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -138,6 +138,7 @@ export class FleetStore extends EventEmitter {
       connectedAt: nowIso,
       lastSeen: nowIso,
       task: hello.task ?? null,
+      taskSince: hello.task ? nowIso : null,
       session: emptyCounters(),
       lastTps: 0,
       lastTpsAt: null,
@@ -151,7 +152,10 @@ export class FleetStore extends EventEmitter {
     rec.lastSeen = nowIso;
     rec.expiresAt = now + config.agentTtlSeconds * 1000;
     if (resolvedLocation) rec.location = resolvedLocation;
-    if (hello.task) rec.task = hello.task;
+    if (hello.task) {
+      if (hello.task.ref !== rec.task?.ref || hello.task.kind !== rec.task?.kind) rec.taskSince = nowIso;
+      rec.task = hello.task;
+    }
     this.agents.set(agentId, rec);
     if (!existing) {
       this.addEvent("agent_online", `@${hello.handle} came online (${hello.harness} · ${hello.model})`, {
@@ -200,6 +204,7 @@ export class FleetStore extends EventEmitter {
 
     if (hb.task) {
       const changed = hb.task.ref !== rec.task?.ref || hb.task.kind !== rec.task?.kind;
+      if (changed) rec.taskSince = new Date(now).toISOString();
       rec.task = hb.task;
       if (changed && (hb.task.ref || hb.task.title)) this.emitTaskEvent(rec, hb.task);
     }
@@ -215,6 +220,7 @@ export class FleetStore extends EventEmitter {
     const rec = this.agents.get(id);
     if (!rec) return;
     const changed = task.ref !== rec.task?.ref || task.kind !== rec.task?.kind;
+    if (changed) rec.taskSince = new Date().toISOString();
     rec.task = task;
     rec.lastSeen = new Date().toISOString();
     rec.expiresAt = Date.now() + config.agentTtlSeconds * 1000;

--- a/server/test/dispatch.test.mjs
+++ b/server/test/dispatch.test.mjs
@@ -845,6 +845,41 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       assert.equal(board.openPrs, 1);
     });
 
+    await t.test("active-work route: who works on what, for how long, lease health", async () => {
+      await seed([
+        { number: 81, title: "research: X", labels: ["status: available", "stage: research"], createdAt: "2026-05-01T00:00:00Z" },
+        { number: 82, title: "research: Y", labels: ["status: available", "stage: ideate"], createdAt: "2026-05-02T00:00:00Z" },
+      ]);
+      const claimed = await dispatch.claimNext(o, new FleetStore(), {
+        handle: "worker-one",
+        tier: "standard",
+        harness: "codex",
+        model: "gpt-x",
+      });
+      assert.equal(claimed.status, "claimed");
+
+      const app = Fastify();
+      apps.push(app);
+      registerQueueRoutes(app, new FleetStore(), o);
+      const res = await app.inject({ method: "GET", url: "/api/v1/work/active" });
+      assert.equal(res.statusCode, 200);
+      const body = res.json();
+      assert.equal(body.count, 1);
+      const [row] = body.work;
+      assert.equal(row.issue, 81);
+      assert.equal(row.title, "research: X");
+      assert.equal(row.stage, "research");
+      assert.equal(row.handle, "worker-one");
+      assert.equal(row.harness, "codex");
+      assert.equal(typeof row.claimedAt, "string");
+      assert.ok(row.leaseSecondsLeft > 0, "live lease TTL surfaced");
+
+      // Released work leaves the panel.
+      await dispatch.releaseAssignment(o, new FleetStore(), { handle: "worker-one", issue: 81, outcome: "done" });
+      const after = await app.inject({ method: "GET", url: "/api/v1/work/active" });
+      assert.equal(after.json().count, 0);
+    });
+
     await t.test("open-issues snapshot route: fetch_open_issues shape, stale mirror → 503", async () => {
       await seed([
         {

--- a/web/src/components/live/ActiveWork.tsx
+++ b/web/src/components/live/ActiveWork.tsx
@@ -1,0 +1,75 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { initials } from "@/lib/format";
+import { formatSince, type ActiveWorkItem } from "@/lib/live";
+import { harnessColor, useIsDark } from "./harness";
+
+const REPO_URL = "https://github.com/thecolab-ai/the-for-good-project";
+
+/** Lease health: the claim auto-renews on heartbeats, so a shrinking TTL
+ *  means the worker has gone quiet — the sweeper reaps it at zero. */
+function leaseHealth(secondsLeft: number): { color: string; label: string } {
+  if (secondsLeft <= 0) return { color: "bg-red-500", label: "stalled — lease expired, requeuing" };
+  if (secondsLeft < 300) return { color: "bg-amber-500", label: `lease ${Math.floor(secondsLeft / 60)}m — worker quiet` };
+  return { color: "bg-emerald-500", label: "lease healthy (renewing on heartbeats)" };
+}
+
+/** "Claims" feed: who is working on what via the orchestrator, since when,
+ *  and whether their lease is healthy. Server-claimed work only — label-path
+ *  workers appear in the fleet table via their self-reported task instead. */
+export function ActiveWorkFeed({ work }: { work: ActiveWorkItem[] }) {
+  const dark = useIsDark();
+  if (!work.length) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        No server-orchestrated claims right now. Rows appear the moment a worker
+        claims an issue through the fleet server.
+      </div>
+    );
+  }
+  return (
+    <ul className="divide-y divide-border/50">
+      {work.map((w) => {
+        const color = harnessColor(w.harness ?? "unknown", dark);
+        const lease = leaseHealth(w.leaseSecondsLeft);
+        return (
+          <li key={`${w.issue}-${w.handle}-${w.claimedAt}`} className="flex items-center gap-2.5 py-2">
+            <a href={`https://github.com/${w.handle}`} target="_blank" rel="noreferrer" className="shrink-0">
+              <Avatar className="h-7 w-7 ring-2" style={{ ["--tw-ring-color" as string]: color }}>
+                <AvatarImage src={`https://github.com/${w.handle}.png?size=56`} alt={w.handle} />
+                <AvatarFallback className="text-[10px]">{initials(w.handle)}</AvatarFallback>
+              </Avatar>
+            </a>
+            <div className="min-w-0 flex-1 leading-tight">
+              <div className="flex min-w-0 items-baseline gap-1.5 text-[13px]">
+                <span className="shrink-0 font-medium">@{w.handle}</span>
+                <span className="shrink-0 text-muted-foreground">·</span>
+                <a
+                  href={`${REPO_URL}/issues/${w.issue}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="shrink-0 font-mono text-foreground hover:underline"
+                >
+                  #{w.issue}
+                </a>
+                {w.title ? <span className="truncate text-foreground/60">{w.title}</span> : null}
+              </div>
+              <div className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground">
+                {w.stage ? (
+                  <span className="rounded-full bg-secondary/70 px-1.5 py-px font-medium">{w.stage}</span>
+                ) : null}
+                {w.harness ? <span className="font-mono" style={{ color }}>{w.harness}</span> : null}
+                <span>
+                  working for <span className="font-mono font-semibold text-foreground">{formatSince(w.claimedAt)}</span>
+                </span>
+              </div>
+            </div>
+            <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-muted-foreground" title={lease.label}>
+              <span className={`h-2 w-2 rounded-full ${lease.color}`} />
+              lease
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/web/src/components/live/AgentTable.tsx
+++ b/web/src/components/live/AgentTable.tsx
@@ -2,7 +2,7 @@ import { Bot, GitPullRequest, Hammer, Layers, Search } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { initials, relativeTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
-import { compactNumber, type AgentPresence } from "@/lib/live";
+import { compactNumber, formatSince, type AgentPresence } from "@/lib/live";
 import { harnessColor, useIsDark } from "./harness";
 
 const KIND_META = {
@@ -107,6 +107,11 @@ function AgentRow({ agent, trail, selected, onSelect }:
             </a>
           ) : null}
           {agent.task?.title ? <span className="truncate text-foreground/60">· {agent.task.title}</span> : null}
+          {agent.task && agent.task.kind !== "idle" && agent.taskSince ? (
+            <span className="shrink-0 whitespace-nowrap font-mono text-[10px] tabular-nums text-foreground/50">
+              {formatSince(agent.taskSince)}
+            </span>
+          ) : null}
         </div>
       </td>
 

--- a/web/src/components/live/FleetConsole.tsx
+++ b/web/src/components/live/FleetConsole.tsx
@@ -2,8 +2,9 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   ArrowLeft, Bot, ChevronLeft, CircleDot, Cpu, Eye, FileText, GitBranch, GitPullRequest, Globe,
-  Link2, MessageSquare, Moon, Pause, Play, Radio, Signal, Sun, Wifi, WifiOff, Wrench, Zap,
+  Hammer, Link2, MessageSquare, Moon, Pause, Play, Radio, Signal, Sun, Wifi, WifiOff, Wrench, Zap,
 } from "lucide-react";
+import { ActiveWorkFeed } from "./ActiveWork";
 import { LogoMark, GitHubIcon } from "@/components/layout/Logo";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useTheme } from "@/hooks/useTheme";
@@ -23,7 +24,7 @@ import { FleetGlobe, type GlobePoint } from "./FleetGlobe";
 import { harnessColor, useIsDark } from "./harness";
 
 type CommentFilter = "all" | "issues" | "prs";
-type FeedTab = "activity" | "comments" | "findings";
+type FeedTab = "activity" | "claims" | "comments" | "findings";
 
 const CONFIDENCE_STYLE: Record<string, string> = {
   High: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
@@ -486,6 +487,7 @@ export function FleetConsole({ snapshot }: { snapshot: Snapshot }) {
                 <div className="flex items-center gap-1 rounded-lg bg-secondary/50 p-0.5">
                   {([
                     { k: "activity", label: "Activity", icon: Radio, count: live.events.length },
+                    { k: "claims", label: "Claims", icon: Hammer, count: live.activeWork.length },
                     { k: "comments", label: "Comments", icon: MessageSquare, count: filteredComments.length },
                     { k: "findings", label: "Findings", icon: FileText, count: recentFindings.length },
                   ] as const).map(({ k, label, icon: Icon, count }) => (
@@ -527,8 +529,9 @@ export function FleetConsole({ snapshot }: { snapshot: Snapshot }) {
               </div>
               <div className="console-scroll min-h-0 flex-1 overflow-y-auto px-3 pb-3">
                 {feedTab === "activity" ? <LiveEventFeed events={live.events} />
-                  : feedTab === "comments" ? <CommentFeed comments={filteredComments} />
-                    : <FindingsFeed findings={recentFindings} />}
+                  : feedTab === "claims" ? <ActiveWorkFeed work={live.activeWork} />
+                    : feedTab === "comments" ? <CommentFeed comments={filteredComments} />
+                      : <FindingsFeed findings={recentFindings} />}
               </div>
             </section>
           </div>

--- a/web/src/lib/live.ts
+++ b/web/src/lib/live.ts
@@ -40,6 +40,8 @@ export interface AgentPresence {
   connectedAt: string;
   lastSeen: string;
   task: TaskInfo | null;
+  /** When the CURRENT task (by ref/kind) started — "working on X for 34m". */
+  taskSince: string | null;
   session: SessionCounters;
   tps: number;
   lastTps: number;
@@ -98,6 +100,21 @@ export interface EventItem {
 export interface LogLine {
   at: string;
   line: string;
+}
+
+/** One row of "who is working on what" — GET /api/v1/work/active (the
+ *  orchestrator's live assignments joined with issue titles + lease TTLs). */
+export interface ActiveWorkItem {
+  issue: number;
+  title: string | null;
+  stage: string | null;
+  handle: string;
+  harness: string | null;
+  model: string | null;
+  claimedAt: string;
+  renewedAt: string;
+  /** Live Redis lease TTL; <= 0 means expiring/stalled (sweeper will reap). */
+  leaseSecondsLeft: number;
 }
 
 export interface FleetSnapshot {
@@ -178,6 +195,8 @@ export interface LiveFleet {
   /** Short per-agent TPS trails for the card sparklines. */
   agentTrails: Record<string, number[]>;
   logs: Record<string, LogLine[]>;
+  /** Live claims: who is working on which issue, since when, lease health. */
+  activeWork: ActiveWorkItem[];
 }
 
 const MAX_TPS_POINTS = 90; // ~3 minutes of 2s ticks
@@ -198,6 +217,7 @@ const EMPTY: LiveFleet = {
   historyTotals: null,
   agentTrails: {},
   logs: {},
+  activeWork: [],
 };
 
 export async function fetchAgentLogs(agentId: string): Promise<LogLine[]> {
@@ -237,6 +257,17 @@ export function useLiveFleet(): LiveFleet {
         setState((prev) => ({ ...prev, historicalTps, historyTotals: json.totals ?? null }));
       } catch {
         /* history is optional */
+      }
+    };
+
+    const fetchActiveWork = async () => {
+      try {
+        const res = await fetch(`${base}/api/v1/work/active`);
+        if (!res.ok) return; // 503 = orchestration off — panel just stays empty
+        const json = (await res.json()) as { work?: ActiveWorkItem[] };
+        setState((prev) => ({ ...prev, activeWork: json.work ?? [] }));
+      } catch {
+        /* active-work is optional */
       }
     };
 
@@ -329,10 +360,13 @@ export function useLiveFleet(): LiveFleet {
 
     connect();
     void fetchHistory();
+    void fetchActiveWork();
     const historyTimer = setInterval(() => void fetchHistory(), 30_000);
+    const workTimer = setInterval(() => void fetchActiveWork(), 15_000);
     return () => {
       closed = true;
       clearInterval(historyTimer);
+      clearInterval(workTimer);
       if (reconnectTimer) clearTimeout(reconnectTimer);
       ws?.close();
     };
@@ -343,6 +377,16 @@ export function useLiveFleet(): LiveFleet {
 
 // ---------------------------------------------------------------------------
 // Formatting helpers for the live views
+
+/** "2h 05m" / "34m" / "45s" since an ISO timestamp (clamped at 0). */
+export function formatSince(iso: string | null | undefined, now = Date.now()): string {
+  if (!iso) return "—";
+  const ms = Math.max(0, now - new Date(iso).getTime());
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return `${Math.floor(ms / 1000)}s`;
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${String(mins % 60).padStart(2, "0")}m`;
+}
 
 export function compactNumber(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;


### PR DESCRIPTION
Part of #398. The live dashboard now answers "who's working on what and for how long" from the orchestrator's real assignment data: a **Claims** tab (issue + title + stage, worker, live duration, lease-health dot backed by the actual Redis TTL) polling a new public `GET /api/v1/work/active`, plus `taskSince` on agent presence so the fleet table shows per-task durations for every worker including label-path ones. 122/122 tests, web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)