### PR TITLE
feat(web): full-bleed app-shell for Findings & Streams

### DIFF
--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -10,7 +10,7 @@ export function AppLayout() {
     <TooltipProvider delayDuration={200}>
       <div className="flex min-h-screen flex-col">
         <Header repoUrl={data?.repo.url} />
-        <main className="container flex-1 overflow-x-hidden py-8">
+        <main className="container flex-1 overflow-x-clip py-8">
           <Outlet />
         </main>
         <Footer repoUrl={data?.repo.url} generatedAt={data?.generatedAt} />

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -87,6 +87,14 @@
   .hud-label {
     @apply text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground;
   }
+  /* Let a page inside the centred .container span the full viewport width for
+     an application-console feel. The layout's main clips overflow-x, so the
+     100vw never introduces a horizontal scrollbar. */
+  .full-bleed {
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+  }
   .hud-glow {
     text-shadow: 0 0 24px hsl(var(--ring) / 0.45);
   }

--- a/web/src/lib/meta.ts
+++ b/web/src/lib/meta.ts
@@ -54,4 +54,19 @@ export const CONFIDENCE_COLOR: Record<string, string> = {
   Unknown: "#78716C",
 };
 
+// Per-domain accent colour — single source of truth for coverage bars, facet
+// dots, and list rails across Findings/Sources. Keep in sync with DOMAIN_LABELS.
+export const DOMAIN_COLOR: Record<string, string> = {
+  "child-welfare": "#DB2777",
+  "grant-access": "#0E8A16",
+  "civic-transparency": "#1D76DB",
+  "ai-policy": "#8B5CF6",
+  biosecurity: "#0EA5E9",
+  other: "#78716C",
+};
+
+export function domainColor(d: string | null | undefined): string {
+  return (d && DOMAIN_COLOR[d]) || "#78716C";
+}
+
 export const STAGE_ORDER: Exclude<Stage, "none">[] = ["discover", "research", "ideate", "build"];

--- a/web/src/pages/Findings.tsx
+++ b/web/src/pages/Findings.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from "@/components/shared/EmptyState";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { DomainBadge } from "@/components/shared/Badges";
-import { CONFIDENCE_COLOR, domainLabel } from "@/lib/meta";
+import { CONFIDENCE_COLOR, domainLabel, domainColor } from "@/lib/meta";
 import { cn } from "@/lib/utils";
 import type { Finding } from "@/lib/types";
 
@@ -18,16 +18,6 @@ const VIEW_KEY = "fgp-findings-view";
 const readView = (): View => { try { return (localStorage.getItem(VIEW_KEY) as View) || "grid"; } catch { return "grid"; } };
 const writeView = (v: View) => { try { localStorage.setItem(VIEW_KEY, v); } catch { /* ignore */ } };
 
-// A per-domain tint so the distribution bar and facet dots read at a glance.
-const DOMAIN_TINT: Record<string, string> = {
-  "child-welfare": "#DB2777",
-  "grant-access": "#0E8A16",
-  "civic-transparency": "#1D76DB",
-  "ai-policy": "#8B5CF6",
-  biosecurity: "#0EA5E9",
-  other: "#78716C",
-};
-const domainTint = (d: string) => DOMAIN_TINT[d] || "#78716C";
 const CONF_RANK: Record<string, number> = { High: 3, Medium: 2, Low: 1, Unknown: 0 };
 
 // A compact confidence dot + label used across both views.
@@ -99,9 +89,9 @@ function ListRow({ f }: { f: Finding }) {
       to={`/findings/${f.slug}`}
       className="group flex items-center gap-3 border-b border-border/60 px-3 py-2.5 transition-colors hover:bg-secondary/50 sm:gap-4"
     >
-      <span className="h-8 w-1 shrink-0 rounded-full" style={{ backgroundColor: domainTint(f.domain) }} />
+      <span className="h-8 w-1 shrink-0 rounded-full" title={domainLabel(f.domain)} style={{ backgroundColor: domainColor(f.domain) }} />
       <div className="min-w-0 flex-1">
-        <div className="truncate font-medium leading-snug group-hover:text-brand-cyan-dark">{f.title}</div>
+        <div className="truncate font-medium leading-snug group-hover:text-brand-cyan-dark" title={f.title}>{f.title}</div>
         <div className="truncate text-xs text-muted-foreground">{f.summary}</div>
       </div>
       <div className="hidden w-32 shrink-0 md:block"><DomainBadge domain={f.domain} /></div>
@@ -167,13 +157,13 @@ export default function Findings() {
   return (
     <div className="full-bleed px-4 md:px-6">
       {/* Command bar — sticky, dense, app-console feel */}
-      <div className="sticky top-0 z-20 -mx-4 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
+      <div className="sticky top-16 z-20 -mx-4 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
           <div className="flex items-center gap-2">
             <BookOpen className="h-5 w-5 text-brand-cyan-dark" />
             <h1 className="font-serif text-lg font-bold">Research findings</h1>
           </div>
-          <div className="flex flex-wrap items-center gap-1.5">
+          <div className="hidden flex-wrap items-center gap-1.5 md:flex">
             <Vital icon={BookOpen} value={all.length} label="findings" accent="#2E4057" />
             <Vital icon={Layers} value={domainCounts.length} label="domains" accent="#8B5CF6" />
             <Vital icon={Link2} value={totalSources} label="sources" accent="#0EA5E9" />
@@ -181,20 +171,20 @@ export default function Findings() {
           </div>
 
           <div className="ml-auto flex flex-wrap items-center gap-2">
-            <div className="relative min-w-[180px]">
+            <div className="relative min-w-[180px] flex-1 sm:flex-initial">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input placeholder="Search findings…" value={q} onChange={(e) => setQ(e.target.value)} className="h-9 pl-9" />
+              <Input aria-label="Search findings" placeholder="Search findings…" value={q} onChange={(e) => setQ(e.target.value)} className="h-9 pl-9" />
             </div>
             <div className="inline-flex items-center gap-1 rounded-lg bg-secondary p-1">
               {([["recent", "Recent"], ["sources", "Sources"], ["confidence", "Confidence"]] as [SortKey, string][]).map(([k, lbl]) => (
-                <button key={k} type="button" onClick={() => setSort(k)} className={cn("inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors", sort === k ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}>
+                <button key={k} type="button" onClick={() => setSort(k)} aria-pressed={sort === k} className={cn("inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors", sort === k ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}>
                   {k === "recent" ? null : <ArrowUpDown className="h-3 w-3" />}{lbl}
                 </button>
               ))}
             </div>
             <div className="inline-flex items-center gap-1 rounded-lg bg-secondary p-1">
-              <button type="button" onClick={() => setViewPersist("grid")} title="Grid" className={cn("rounded-md p-1.5 transition-colors", view === "grid" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><LayoutGrid className="h-4 w-4" /></button>
-              <button type="button" onClick={() => setViewPersist("list")} title="List" className={cn("rounded-md p-1.5 transition-colors", view === "list" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><Rows3 className="h-4 w-4" /></button>
+              <button type="button" onClick={() => setViewPersist("grid")} aria-label="Grid view" aria-pressed={view === "grid"} title="Grid" className={cn("rounded-md p-1.5 transition-colors", view === "grid" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><LayoutGrid className="h-4 w-4" /></button>
+              <button type="button" onClick={() => setViewPersist("list")} aria-label="List view" aria-pressed={view === "list"} title="List" className={cn("rounded-md p-1.5 transition-colors", view === "list" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><Rows3 className="h-4 w-4" /></button>
             </div>
           </div>
         </div>
@@ -204,23 +194,25 @@ export default function Findings() {
       <div className="mt-5 grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]">
         {/* Facet rail */}
         <aside className="hidden lg:block">
-          <div className="sticky top-[4.75rem] space-y-5">
+          <div className="sticky top-[8rem] space-y-5">
             {/* Domain distribution bar */}
-            <div>
-              <div className="hud-label mb-2">Coverage</div>
-              <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-secondary">
-                {domainCounts.map(([d, n]) => (
-                  <span key={d} title={`${domainLabel(d)}: ${n}`} style={{ width: `${(n / all.length) * 100}%`, backgroundColor: domainTint(d) }} />
-                ))}
+            {domainCounts.length > 1 ? (
+              <div>
+                <div className="hud-label mb-2">Coverage</div>
+                <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-secondary">
+                  {domainCounts.map(([d, n]) => (
+                    <span key={d} title={`${domainLabel(d)}: ${n}`} style={{ width: `${(n / all.length) * 100}%`, backgroundColor: domainColor(d) }} />
+                  ))}
+                </div>
               </div>
-            </div>
+            ) : null}
 
             <div>
               <div className="hud-label mb-1.5">Domain</div>
               <div className="space-y-0.5">
                 <Facet label="All domains" count={all.length} active={domain === "all"} onClick={() => setDomain("all")} />
                 {domainCounts.map(([d, n]) => (
-                  <Facet key={d} label={domainLabel(d)} count={n} tint={domainTint(d)} active={domain === d} onClick={() => setDomain(domain === d ? "all" : d)} />
+                  <Facet key={d} label={domainLabel(d)} count={n} tint={domainColor(d)} active={domain === d} onClick={() => setDomain(domain === d ? "all" : d)} />
                 ))}
               </div>
             </div>
@@ -239,6 +231,17 @@ export default function Findings() {
 
         {/* Results */}
         <section className="min-w-0">
+          {/* Mobile domain filter — the facet rail is desktop-only, so surface
+              domain filtering here below lg. */}
+          <div className="mb-3 flex gap-1.5 overflow-x-auto pb-1 lg:hidden">
+            <button type="button" onClick={() => setDomain("all")} aria-pressed={domain === "all"} className={cn("shrink-0 rounded-full border px-3 py-1 text-xs font-medium", domain === "all" ? "border-transparent bg-secondary text-foreground" : "border-border text-muted-foreground")}>All</button>
+            {domainCounts.map(([d, n]) => (
+              <button key={d} type="button" onClick={() => setDomain(domain === d ? "all" : d)} aria-pressed={domain === d} className={cn("inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium", domain === d ? "border-transparent bg-secondary text-foreground" : "border-border text-muted-foreground")}>
+                <span className="h-2 w-2 rounded-full" style={{ backgroundColor: domainColor(d) }} />{domainLabel(d)} <span className="tabular-nums opacity-60">{n}</span>
+              </button>
+            ))}
+          </div>
+
           <div className="mb-3 flex items-center justify-between gap-2 text-sm text-muted-foreground">
             <span><span className="font-medium text-foreground">{filtered.length}</span> {filtered.length === 1 ? "finding" : "findings"}{hasFilter ? " matched" : ""}</span>
             {hasFilter ? <button type="button" onClick={clearAll} className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-secondary hover:text-foreground"><X className="h-3.5 w-3.5" /> Clear filters</button> : null}

--- a/web/src/pages/Findings.tsx
+++ b/web/src/pages/Findings.tsx
@@ -1,82 +1,272 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { BookOpen, Link2, Search, Cpu } from "lucide-react";
+import { BookOpen, Link2, Search, Cpu, LayoutGrid, Rows3, Layers, ShieldCheck, ArrowUpDown, X } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
-import { PageHeader } from "@/components/shared/PageHeader";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { DomainBadge } from "@/components/shared/Badges";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { CONFIDENCE_COLOR, domainLabel } from "@/lib/meta";
+import { cn } from "@/lib/utils";
+import type { Finding } from "@/lib/types";
+
+type View = "grid" | "list";
+type SortKey = "recent" | "sources" | "confidence";
+
+const VIEW_KEY = "fgp-findings-view";
+const readView = (): View => { try { return (localStorage.getItem(VIEW_KEY) as View) || "grid"; } catch { return "grid"; } };
+const writeView = (v: View) => { try { localStorage.setItem(VIEW_KEY, v); } catch { /* ignore */ } };
+
+// A per-domain tint so the distribution bar and facet dots read at a glance.
+const DOMAIN_TINT: Record<string, string> = {
+  "child-welfare": "#DB2777",
+  "grant-access": "#0E8A16",
+  "civic-transparency": "#1D76DB",
+  "ai-policy": "#8B5CF6",
+  biosecurity: "#0EA5E9",
+  other: "#78716C",
+};
+const domainTint = (d: string) => DOMAIN_TINT[d] || "#78716C";
+const CONF_RANK: Record<string, number> = { High: 3, Medium: 2, Low: 1, Unknown: 0 };
+
+// A compact confidence dot + label used across both views.
+function Confidence({ value, showLabel = true }: { value: string; showLabel?: boolean }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs font-medium" style={{ color: CONFIDENCE_COLOR[value] }}>
+      <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CONFIDENCE_COLOR[value] }} />
+      {showLabel ? `${value} confidence` : null}
+    </span>
+  );
+}
+
+// A dense KPI chip for the command bar.
+function Vital({ icon: Icon, value, label, accent = "#2E4057" }: { icon: typeof BookOpen; value: React.ReactNode; label: string; accent?: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card/60 px-2.5 py-1 backdrop-blur-sm">
+      <Icon className="h-3.5 w-3.5" style={{ color: accent }} />
+      <span className="font-mono text-sm font-semibold tabular-nums text-foreground">{value}</span>
+      <span className="hidden text-[10px] uppercase tracking-wider text-muted-foreground sm:inline">{label}</span>
+    </span>
+  );
+}
+
+// A clickable facet row: label + count, active state, own tint dot.
+function Facet({ label, count, active, tint, onClick }: { label: string; count: number; active: boolean; tint?: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+        active ? "bg-secondary font-medium text-foreground" : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
+      )}
+    >
+      {tint ? <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: tint }} /> : null}
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">{count}</span>
+    </button>
+  );
+}
+
+function GridCard({ f }: { f: Finding }) {
+  return (
+    <Link to={`/findings/${f.slug}`}>
+      <Card className="group h-full transition-all hover:-translate-y-0.5 hover:border-brand-cyan/40 hover:shadow-md">
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between gap-2">
+            <DomainBadge domain={f.domain} />
+            <Confidence value={f.confidence} showLabel={false} />
+          </div>
+          <div className="mt-2 line-clamp-2 font-serif text-base font-semibold leading-snug group-hover:text-brand-cyan-dark">{f.title}</div>
+        </CardHeader>
+        <CardContent>
+          <p className="line-clamp-2 text-sm text-muted-foreground">{f.summary}</p>
+          <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            {f.agent ? <span className="inline-flex items-center gap-1 rounded-full bg-secondary/70 px-2 py-0.5 font-medium"><Cpu className="h-3 w-3" /> {f.agent}</span> : null}
+            {f.date ? <span>{f.date}</span> : null}
+            <span className="ml-auto inline-flex items-center gap-1"><Link2 className="h-3.5 w-3.5" /> {f.sources.length}</span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function ListRow({ f }: { f: Finding }) {
+  return (
+    <Link
+      to={`/findings/${f.slug}`}
+      className="group flex items-center gap-3 border-b border-border/60 px-3 py-2.5 transition-colors hover:bg-secondary/50 sm:gap-4"
+    >
+      <span className="h-8 w-1 shrink-0 rounded-full" style={{ backgroundColor: domainTint(f.domain) }} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium leading-snug group-hover:text-brand-cyan-dark">{f.title}</div>
+        <div className="truncate text-xs text-muted-foreground">{f.summary}</div>
+      </div>
+      <div className="hidden w-32 shrink-0 md:block"><DomainBadge domain={f.domain} /></div>
+      <div className="hidden w-28 shrink-0 lg:flex"><Confidence value={f.confidence} /></div>
+      <div className="hidden w-24 shrink-0 items-center gap-1 text-xs text-muted-foreground xl:flex" title={f.model || f.agent}>
+        {f.agent ? <><Cpu className="h-3.5 w-3.5" /> <span className="truncate">{f.agent}</span></> : null}
+      </div>
+      <div className="w-14 shrink-0 text-right text-xs tabular-nums text-muted-foreground"><span className="inline-flex items-center gap-1"><Link2 className="h-3.5 w-3.5" />{f.sources.length}</span></div>
+      <div className="hidden w-20 shrink-0 text-right text-xs text-muted-foreground sm:block">{f.date}</div>
+    </Link>
+  );
+}
 
 export default function Findings() {
   const { data, error, loading } = useSnapshot();
   const [q, setQ] = useState("");
   const [domain, setDomain] = useState("all");
+  const [conf, setConf] = useState("all");
+  const [sort, setSort] = useState<SortKey>("recent");
+  const [view, setView] = useState<View>(readView);
 
-  const domains = useMemo(() => [...new Set(data?.findings.map((f) => f.domain) || [])], [data]);
+  const all = useMemo(() => data?.findings ?? [], [data]);
+
+  // Facet counts computed over the full set so they stay stable as you filter.
+  const domainCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const f of all) m.set(f.domain, (m.get(f.domain) || 0) + 1);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]);
+  }, [all]);
+  const confCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const f of all) m.set(f.confidence, (m.get(f.confidence) || 0) + 1);
+    return m;
+  }, [all]);
+  const totalSources = useMemo(() => all.reduce((n, f) => n + f.sources.length, 0), [all]);
+  const highPct = all.length ? Math.round(((confCounts.get("High") || 0) / all.length) * 100) : 0;
+
+  const setViewPersist = (v: View) => { setView(v); writeView(v); };
+
   if (loading) return <Loading />;
   if (error || !data) return <ErrorState message={error || "No data"} />;
 
-  const findings = data.findings.filter((f) => (domain === "all" || f.domain === domain) && (!q || f.title.toLowerCase().includes(q.toLowerCase()) || f.summary.toLowerCase().includes(q.toLowerCase())));
+  const needle = q.toLowerCase();
+  const filtered = all
+    .filter((f) => (domain === "all" || f.domain === domain) && (conf === "all" || f.confidence === conf) && (!q || f.title.toLowerCase().includes(needle) || f.summary.toLowerCase().includes(needle)))
+    .sort((a, b) => {
+      if (sort === "sources") return b.sources.length - a.sources.length;
+      if (sort === "confidence") return (CONF_RANK[b.confidence] || 0) - (CONF_RANK[a.confidence] || 0);
+      return (b.date || "").localeCompare(a.date || "");
+    });
+
+  const hasFilter = domain !== "all" || conf !== "all" || q !== "";
+  const clearAll = () => { setDomain("all"); setConf("all"); setQ(""); };
+
+  if (all.length === 0) {
+    return (
+      <EmptyState icon={BookOpen} title="No findings published yet">
+        Findings land here as research issues get answered and merged. Pick a research question on the board to write the first one.
+      </EmptyState>
+    );
+  }
 
   return (
-    <div>
-      <PageHeader title="Research findings">Cited answers to the questions the community is working on. Every claim is sourced; confidence is marked honestly.</PageHeader>
+    <div className="full-bleed px-4 md:px-6">
+      {/* Command bar — sticky, dense, app-console feel */}
+      <div className="sticky top-0 z-20 -mx-4 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-5 w-5 text-brand-cyan-dark" />
+            <h1 className="font-serif text-lg font-bold">Research findings</h1>
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Vital icon={BookOpen} value={all.length} label="findings" accent="#2E4057" />
+            <Vital icon={Layers} value={domainCounts.length} label="domains" accent="#8B5CF6" />
+            <Vital icon={Link2} value={totalSources} label="sources" accent="#0EA5E9" />
+            <Vital icon={ShieldCheck} value={`${highPct}%`} label="high conf" accent="#0E8A16" />
+          </div>
 
-      {data.findings.length === 0 ? (
-        <EmptyState icon={BookOpen} title="No findings published yet">
-          Findings land here as research issues get answered and merged. Pick a research question on the board to write the first one.
-        </EmptyState>
-      ) : (
-        <>
-          <div className="mb-6 flex flex-wrap gap-2">
-            <div className="relative min-w-[200px] flex-1">
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <div className="relative min-w-[180px]">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input placeholder="Search findings…" value={q} onChange={(e) => setQ(e.target.value)} className="pl-9" />
+              <Input placeholder="Search findings…" value={q} onChange={(e) => setQ(e.target.value)} className="h-9 pl-9" />
             </div>
-            <Select value={domain} onValueChange={setDomain}>
-              <SelectTrigger className="w-[180px]"><SelectValue placeholder="Domain" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All domains</SelectItem>
-                {domains.map((d) => <SelectItem key={d} value={d}>{domainLabel(d)}</SelectItem>)}
-              </SelectContent>
-            </Select>
+            <div className="inline-flex items-center gap-1 rounded-lg bg-secondary p-1">
+              {([["recent", "Recent"], ["sources", "Sources"], ["confidence", "Confidence"]] as [SortKey, string][]).map(([k, lbl]) => (
+                <button key={k} type="button" onClick={() => setSort(k)} className={cn("inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors", sort === k ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}>
+                  {k === "recent" ? null : <ArrowUpDown className="h-3 w-3" />}{lbl}
+                </button>
+              ))}
+            </div>
+            <div className="inline-flex items-center gap-1 rounded-lg bg-secondary p-1">
+              <button type="button" onClick={() => setViewPersist("grid")} title="Grid" className={cn("rounded-md p-1.5 transition-colors", view === "grid" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><LayoutGrid className="h-4 w-4" /></button>
+              <button type="button" onClick={() => setViewPersist("list")} title="List" className={cn("rounded-md p-1.5 transition-colors", view === "list" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><Rows3 className="h-4 w-4" /></button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Body: facet rail + results */}
+      <div className="mt-5 grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]">
+        {/* Facet rail */}
+        <aside className="hidden lg:block">
+          <div className="sticky top-[4.75rem] space-y-5">
+            {/* Domain distribution bar */}
+            <div>
+              <div className="hud-label mb-2">Coverage</div>
+              <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-secondary">
+                {domainCounts.map(([d, n]) => (
+                  <span key={d} title={`${domainLabel(d)}: ${n}`} style={{ width: `${(n / all.length) * 100}%`, backgroundColor: domainTint(d) }} />
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="hud-label mb-1.5">Domain</div>
+              <div className="space-y-0.5">
+                <Facet label="All domains" count={all.length} active={domain === "all"} onClick={() => setDomain("all")} />
+                {domainCounts.map(([d, n]) => (
+                  <Facet key={d} label={domainLabel(d)} count={n} tint={domainTint(d)} active={domain === d} onClick={() => setDomain(domain === d ? "all" : d)} />
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="hud-label mb-1.5">Confidence</div>
+              <div className="space-y-0.5">
+                <Facet label="Any confidence" count={all.length} active={conf === "all"} onClick={() => setConf("all")} />
+                {["High", "Medium", "Low", "Unknown"].filter((c) => confCounts.get(c)).map((c) => (
+                  <Facet key={c} label={c} count={confCounts.get(c) || 0} tint={CONFIDENCE_COLOR[c]} active={conf === c} onClick={() => setConf(conf === c ? "all" : c)} />
+                ))}
+              </div>
+            </div>
+          </div>
+        </aside>
+
+        {/* Results */}
+        <section className="min-w-0">
+          <div className="mb-3 flex items-center justify-between gap-2 text-sm text-muted-foreground">
+            <span><span className="font-medium text-foreground">{filtered.length}</span> {filtered.length === 1 ? "finding" : "findings"}{hasFilter ? " matched" : ""}</span>
+            {hasFilter ? <button type="button" onClick={clearAll} className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-secondary hover:text-foreground"><X className="h-3.5 w-3.5" /> Clear filters</button> : null}
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
-            {findings.map((f) => (
-              <Link key={f.path} to={`/findings/${f.slug}`}>
-                <Card className="group h-full transition-all hover:-translate-y-0.5 hover:shadow-md">
-                  <CardHeader>
-                    <div className="flex items-center justify-between gap-2">
-                      <DomainBadge domain={f.domain} />
-                      <span className="inline-flex items-center gap-1.5 text-xs font-medium" style={{ color: CONFIDENCE_COLOR[f.confidence] }}>
-                        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: CONFIDENCE_COLOR[f.confidence] }} /> {f.confidence} confidence
-                      </span>
-                    </div>
-                    <div className="mt-2 font-serif text-lg font-semibold leading-snug group-hover:text-brand-cyan-dark">{f.title}</div>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="line-clamp-3 text-sm text-muted-foreground">{f.summary}</p>
-                    <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                      <span>{f.author && f.author !== "unknown" ? `by ${f.author}` : ""}{f.date ? ` · ${f.date}` : ""}</span>
-                      {f.agent ? (
-                        <span className="inline-flex items-center gap-1 rounded-full bg-secondary/70 px-2 py-0.5 font-medium">
-                          <Cpu className="h-3 w-3" /> {f.agent}{f.model ? ` · ${f.model}` : ""}
-                        </span>
-                      ) : null}
-                      <span className="ml-auto inline-flex items-center gap-1"><Link2 className="h-3.5 w-3.5" /> {f.sources.length} source{f.sources.length === 1 ? "" : "s"}</span>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-            ))}
-          </div>
-        </>
-      )}
+          {filtered.length === 0 ? (
+            <EmptyState icon={Search} title="Nothing matches">Clear the search or filters to see all findings.</EmptyState>
+          ) : view === "grid" ? (
+            <div className="grid gap-4 sm:grid-cols-2 2xl:grid-cols-3">
+              {filtered.map((f) => <GridCard key={f.path} f={f} />)}
+            </div>
+          ) : (
+            <Card className="overflow-hidden p-0">
+              {/* Column header for the list */}
+              <div className="flex items-center gap-3 border-b border-border bg-secondary/40 px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground sm:gap-4">
+                <span className="w-1 shrink-0" />
+                <span className="min-w-0 flex-1">Finding</span>
+                <span className="hidden w-32 shrink-0 md:block">Domain</span>
+                <span className="hidden w-28 shrink-0 lg:block">Confidence</span>
+                <span className="hidden w-24 shrink-0 xl:block">Agent</span>
+                <span className="w-14 shrink-0 text-right">Src</span>
+                <span className="hidden w-20 shrink-0 text-right sm:block">Date</span>
+              </div>
+              {filtered.map((f) => <ListRow key={f.path} f={f} />)}
+            </Card>
+          )}
+        </section>
+      </div>
     </div>
   );
 }

--- a/web/src/pages/Sources.tsx
+++ b/web/src/pages/Sources.tsx
@@ -1,80 +1,238 @@
 import { useMemo, useState } from "react";
-import { Link2, Search, ExternalLink, Database } from "lucide-react";
+import { Link2, Search, ExternalLink, Database, Globe, Layers, FileText, LayoutGrid, Rows3, X } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
-import { PageHeader } from "@/components/shared/PageHeader";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { DomainBadge } from "@/components/shared/Badges";
 import { domainLabel } from "@/lib/meta";
+import { cn } from "@/lib/utils";
 import type { SourceRef } from "@/lib/types";
+
+type View = "hosts" | "list";
+const VIEW_KEY = "fgp-sources-view";
+const readView = (): View => { try { return (localStorage.getItem(VIEW_KEY) as View) || "hosts"; } catch { return "hosts"; } };
+const writeView = (v: View) => { try { localStorage.setItem(VIEW_KEY, v); } catch { /* ignore */ } };
+
+const DOMAIN_TINT: Record<string, string> = {
+  "child-welfare": "#DB2777",
+  "grant-access": "#0E8A16",
+  "civic-transparency": "#1D76DB",
+  "ai-policy": "#8B5CF6",
+  biosecurity: "#0EA5E9",
+  other: "#78716C",
+};
+const domainTint = (d: string) => DOMAIN_TINT[d] || "#78716C";
+
+function Vital({ icon: Icon, value, label, accent = "#2E4057" }: { icon: typeof Database; value: React.ReactNode; label: string; accent?: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card/60 px-2.5 py-1 backdrop-blur-sm">
+      <Icon className="h-3.5 w-3.5" style={{ color: accent }} />
+      <span className="font-mono text-sm font-semibold tabular-nums text-foreground">{value}</span>
+      <span className="hidden text-[10px] uppercase tracking-wider text-muted-foreground sm:inline">{label}</span>
+    </span>
+  );
+}
+
+function Facet({ label, count, active, tint, favicon, onClick }: { label: string; count: number; active: boolean; tint?: string; favicon?: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+        active ? "bg-secondary font-medium text-foreground" : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground",
+      )}
+    >
+      {tint ? <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: tint }} /> : null}
+      {favicon ? <img src={`https://icons.duckduckgo.com/ip3/${favicon}.ico`} alt="" className="h-3.5 w-3.5 shrink-0 rounded" onError={(e) => (e.currentTarget.style.visibility = "hidden")} /> : null}
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">{count}</span>
+    </button>
+  );
+}
+
+function SourceLink({ s }: { s: SourceRef }) {
+  return (
+    <a href={s.url} target="_blank" rel="noreferrer" className="group flex items-start gap-2 rounded-lg p-1.5 text-sm transition-colors hover:bg-secondary/60">
+      <Link2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1">
+        <span className="line-clamp-1 group-hover:text-brand-cyan-dark">{s.label}</span>
+        {s.findingTitle ? <span className="line-clamp-1 text-xs text-muted-foreground">cited in {s.findingTitle}</span> : null}
+      </span>
+      <ExternalLink className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+    </a>
+  );
+}
 
 export default function Sources() {
   const { data, error, loading } = useSnapshot();
   const [q, setQ] = useState("");
+  const [domain, setDomain] = useState("all");
+  const [host, setHost] = useState("all");
+  const [view, setView] = useState<View>(readView);
 
-  const grouped = useMemo(() => {
-    const map = new Map<string, { host: string; items: SourceRef[] }>();
-    (data?.sources || []).forEach((s) => {
-      if (!map.has(s.host)) map.set(s.host, { host: s.host, items: [] });
-      map.get(s.host)!.items.push(s);
-    });
-    return [...map.values()].sort((a, b) => b.items.length - a.items.length);
-  }, [data]);
+  const sources = useMemo(() => data?.sources ?? [], [data]);
+
+  const domainCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const s of sources) m.set(s.domain, (m.get(s.domain) || 0) + 1);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]);
+  }, [sources]);
+
+  const hostCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const s of sources) m.set(s.host, (m.get(s.host) || 0) + 1);
+    return [...m.entries()].sort((a, b) => b[1] - a[1]);
+  }, [sources]);
+
+  const findingsCited = useMemo(() => new Set(sources.map((s) => s.findingPath)).size, [sources]);
+
+  const setViewPersist = (v: View) => { setView(v); writeView(v); };
 
   if (loading) return <Loading />;
   if (error || !data) return <ErrorState message={error || "No data"} />;
 
-  const filteredGroups = grouped
-    .map((g) => ({ ...g, items: g.items.filter((s) => !q || s.host.includes(q.toLowerCase()) || s.label.toLowerCase().includes(q.toLowerCase())) }))
-    .filter((g) => g.items.length > 0);
+  const needle = q.toLowerCase();
+  const filtered = sources.filter((s) =>
+    (domain === "all" || s.domain === domain) &&
+    (host === "all" || s.host === host) &&
+    (!q || s.host.includes(needle) || s.label.toLowerCase().includes(needle) || (s.findingTitle || "").toLowerCase().includes(needle)),
+  );
+
+  // Grouped view: filtered items regrouped by host, biggest first.
+  const groups = (() => {
+    const map = new Map<string, SourceRef[]>();
+    for (const s of filtered) { if (!map.has(s.host)) map.set(s.host, []); map.get(s.host)!.push(s); }
+    return [...map.entries()].sort((a, b) => b[1].length - a[1].length);
+  })();
+
+  const hasFilter = domain !== "all" || host !== "all" || q !== "";
+  const clearAll = () => { setDomain("all"); setHost("all"); setQ(""); };
+
+  if (sources.length === 0) {
+    return (
+      <EmptyState icon={Database} title="No sources yet">
+        As findings get published with citations, the sources they rely on are aggregated here — a live map of the project's evidence base.
+      </EmptyState>
+    );
+  }
 
   return (
-    <div>
-      <PageHeader title="Data sources">Every source cited across the research, grouped by where it comes from. This is the evidence base the findings stand on.</PageHeader>
+    <div className="full-bleed px-4 md:px-6">
+      {/* Command bar */}
+      <div className="sticky top-0 z-20 -mx-4 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <div className="flex items-center gap-2">
+            <Database className="h-5 w-5 text-brand-cyan-dark" />
+            <h1 className="font-serif text-lg font-bold">Data sources</h1>
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Vital icon={Link2} value={sources.length} label="sources" accent="#0EA5E9" />
+            <Vital icon={Globe} value={hostCounts.length} label="sites" accent="#2E4057" />
+            <Vital icon={Layers} value={domainCounts.length} label="domains" accent="#8B5CF6" />
+            <Vital icon={FileText} value={findingsCited} label="findings cited" accent="#0E8A16" />
+          </div>
 
-      {data.sources.length === 0 ? (
-        <EmptyState icon={Database} title="No sources yet">
-          As findings get published with citations, the sources they rely on are aggregated here — a live map of the project's evidence base.
-        </EmptyState>
-      ) : (
-        <>
-          <div className="mb-6 flex items-center gap-3">
-            <div className="relative max-w-md flex-1">
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <div className="relative min-w-[180px]">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input placeholder="Search sources…" value={q} onChange={(e) => setQ(e.target.value)} className="pl-9" />
+              <Input placeholder="Search sources…" value={q} onChange={(e) => setQ(e.target.value)} className="h-9 pl-9" />
             </div>
-            <span className="text-sm text-muted-foreground">{data.stats.sources} sources · {grouped.length} domains</span>
+            <div className="inline-flex items-center gap-1 rounded-lg bg-secondary p-1">
+              <button type="button" onClick={() => setViewPersist("hosts")} title="Grouped by site" className={cn("rounded-md p-1.5 transition-colors", view === "hosts" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><LayoutGrid className="h-4 w-4" /></button>
+              <button type="button" onClick={() => setViewPersist("list")} title="Flat list" className={cn("rounded-md p-1.5 transition-colors", view === "list" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><Rows3 className="h-4 w-4" /></button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Body: facet rail + results */}
+      <div className="mt-5 grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]">
+        <aside className="hidden lg:block">
+          <div className="sticky top-[4.75rem] space-y-5">
+            <div>
+              <div className="hud-label mb-2">Coverage</div>
+              <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-secondary">
+                {domainCounts.map(([d, n]) => (
+                  <span key={d} title={`${domainLabel(d)}: ${n}`} style={{ width: `${(n / sources.length) * 100}%`, backgroundColor: domainTint(d) }} />
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="hud-label mb-1.5">Domain</div>
+              <div className="space-y-0.5">
+                <Facet label="All domains" count={sources.length} active={domain === "all"} onClick={() => setDomain("all")} />
+                {domainCounts.map(([d, n]) => (
+                  <Facet key={d} label={domainLabel(d)} count={n} tint={domainTint(d)} active={domain === d} onClick={() => setDomain(domain === d ? "all" : d)} />
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="hud-label mb-1.5">Top sites</div>
+              <div className="space-y-0.5">
+                {hostCounts.slice(0, 12).map(([h, n]) => (
+                  <Facet key={h} label={h} count={n} favicon={h} active={host === h} onClick={() => setHost(host === h ? "all" : h)} />
+                ))}
+              </div>
+            </div>
+          </div>
+        </aside>
+
+        <section className="min-w-0">
+          <div className="mb-3 flex items-center justify-between gap-2 text-sm text-muted-foreground">
+            <span><span className="font-medium text-foreground">{filtered.length}</span> {filtered.length === 1 ? "source" : "sources"}{view === "hosts" ? ` · ${groups.length} ${groups.length === 1 ? "site" : "sites"}` : ""}{hasFilter ? " matched" : ""}</span>
+            {hasFilter ? <button type="button" onClick={clearAll} className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-secondary hover:text-foreground"><X className="h-3.5 w-3.5" /> Clear filters</button> : null}
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2">
-            {filteredGroups.map((g) => (
-              <Card key={g.host}>
-                <CardHeader className="flex-row items-center justify-between space-y-0">
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <img src={`https://icons.duckduckgo.com/ip3/${g.host}.ico`} alt="" className="h-4 w-4 rounded" onError={(e) => (e.currentTarget.style.display = "none")} />
-                    {g.host}
-                  </CardTitle>
-                  <Badge variant="secondary">{g.items.length}</Badge>
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  {g.items.slice(0, 8).map((s, i) => (
-                    <a key={i} href={s.url} target="_blank" rel="noreferrer" className="flex items-start gap-2 rounded-lg p-1.5 text-sm transition-colors hover:bg-secondary/60">
-                      <Link2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                      <span className="min-w-0 flex-1">
-                        <span className="line-clamp-1 group-hover:text-brand-cyan-dark">{s.label}</span>
-                        <span className="text-xs text-muted-foreground">{domainLabel(s.domain)}</span>
-                      </span>
-                      <ExternalLink className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" />
-                    </a>
-                  ))}
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </>
-      )}
+          {filtered.length === 0 ? (
+            <EmptyState icon={Search} title="Nothing matches">Clear the search or filters to see all sources.</EmptyState>
+          ) : view === "hosts" ? (
+            <div className="grid gap-4 md:grid-cols-2 2xl:grid-cols-3">
+              {groups.map(([h, items]) => (
+                <Card key={h} className="flex flex-col">
+                  <CardHeader className="flex-row items-center justify-between space-y-0 pb-3">
+                    <CardTitle className="flex min-w-0 items-center gap-2 text-base">
+                      <img src={`https://icons.duckduckgo.com/ip3/${h}.ico`} alt="" className="h-4 w-4 shrink-0 rounded" onError={(e) => (e.currentTarget.style.display = "none")} />
+                      <span className="truncate">{h}</span>
+                    </CardTitle>
+                    <Badge variant="secondary" className="shrink-0">{items.length}</Badge>
+                  </CardHeader>
+                  <CardContent className="space-y-1">
+                    {items.map((s, i) => <SourceLink key={i} s={s} />)}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <Card className="overflow-hidden p-0">
+              <div className="flex items-center gap-3 border-b border-border bg-secondary/40 px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <span className="hidden w-40 shrink-0 sm:block">Site</span>
+                <span className="min-w-0 flex-1">Source</span>
+                <span className="hidden w-32 shrink-0 md:block">Domain</span>
+                <span className="hidden w-56 shrink-0 lg:block">Cited in</span>
+                <span className="w-4 shrink-0" />
+              </div>
+              {filtered.map((s, i) => (
+                <a key={i} href={s.url} target="_blank" rel="noreferrer" className="group flex items-center gap-3 border-b border-border/60 px-3 py-2 text-sm transition-colors hover:bg-secondary/50">
+                  <span className="hidden w-40 shrink-0 items-center gap-1.5 text-xs text-muted-foreground sm:flex">
+                    <img src={`https://icons.duckduckgo.com/ip3/${s.host}.ico`} alt="" className="h-3.5 w-3.5 shrink-0 rounded" onError={(e) => (e.currentTarget.style.visibility = "hidden")} />
+                    <span className="truncate">{s.host}</span>
+                  </span>
+                  <span className="min-w-0 flex-1 truncate group-hover:text-brand-cyan-dark">{s.label}</span>
+                  <span className="hidden w-32 shrink-0 md:block"><DomainBadge domain={s.domain} /></span>
+                  <span className="hidden w-56 shrink-0 truncate text-xs text-muted-foreground lg:block">{s.findingTitle}</span>
+                  <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+                </a>
+              ))}
+            </Card>
+          )}
+        </section>
+      </div>
     </div>
   );
 }

--- a/web/src/pages/Sources.tsx
+++ b/web/src/pages/Sources.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { DomainBadge } from "@/components/shared/Badges";
-import { domainLabel } from "@/lib/meta";
+import { domainLabel, domainColor } from "@/lib/meta";
 import { cn } from "@/lib/utils";
 import type { SourceRef } from "@/lib/types";
 
@@ -15,16 +15,6 @@ type View = "hosts" | "list";
 const VIEW_KEY = "fgp-sources-view";
 const readView = (): View => { try { return (localStorage.getItem(VIEW_KEY) as View) || "hosts"; } catch { return "hosts"; } };
 const writeView = (v: View) => { try { localStorage.setItem(VIEW_KEY, v); } catch { /* ignore */ } };
-
-const DOMAIN_TINT: Record<string, string> = {
-  "child-welfare": "#DB2777",
-  "grant-access": "#0E8A16",
-  "civic-transparency": "#1D76DB",
-  "ai-policy": "#8B5CF6",
-  biosecurity: "#0EA5E9",
-  other: "#78716C",
-};
-const domainTint = (d: string) => DOMAIN_TINT[d] || "#78716C";
 
 function Vital({ icon: Icon, value, label, accent = "#2E4057" }: { icon: typeof Database; value: React.ReactNode; label: string; accent?: string }) {
   return (
@@ -123,13 +113,13 @@ export default function Sources() {
   return (
     <div className="full-bleed px-4 md:px-6">
       {/* Command bar */}
-      <div className="sticky top-0 z-20 -mx-4 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
+      <div className="sticky top-16 z-20 -mx-4 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
           <div className="flex items-center gap-2">
             <Database className="h-5 w-5 text-brand-cyan-dark" />
             <h1 className="font-serif text-lg font-bold">Data sources</h1>
           </div>
-          <div className="flex flex-wrap items-center gap-1.5">
+          <div className="hidden flex-wrap items-center gap-1.5 md:flex">
             <Vital icon={Link2} value={sources.length} label="sources" accent="#0EA5E9" />
             <Vital icon={Globe} value={hostCounts.length} label="sites" accent="#2E4057" />
             <Vital icon={Layers} value={domainCounts.length} label="domains" accent="#8B5CF6" />
@@ -137,13 +127,13 @@ export default function Sources() {
           </div>
 
           <div className="ml-auto flex flex-wrap items-center gap-2">
-            <div className="relative min-w-[180px]">
+            <div className="relative min-w-[180px] flex-1 sm:flex-initial">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input placeholder="Search sources…" value={q} onChange={(e) => setQ(e.target.value)} className="h-9 pl-9" />
+              <Input aria-label="Search sources" placeholder="Search sources…" value={q} onChange={(e) => setQ(e.target.value)} className="h-9 pl-9" />
             </div>
             <div className="inline-flex items-center gap-1 rounded-lg bg-secondary p-1">
-              <button type="button" onClick={() => setViewPersist("hosts")} title="Grouped by site" className={cn("rounded-md p-1.5 transition-colors", view === "hosts" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><LayoutGrid className="h-4 w-4" /></button>
-              <button type="button" onClick={() => setViewPersist("list")} title="Flat list" className={cn("rounded-md p-1.5 transition-colors", view === "list" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><Rows3 className="h-4 w-4" /></button>
+              <button type="button" onClick={() => setViewPersist("hosts")} aria-label="Grouped by site" aria-pressed={view === "hosts"} title="Grouped by site" className={cn("rounded-md p-1.5 transition-colors", view === "hosts" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><LayoutGrid className="h-4 w-4" /></button>
+              <button type="button" onClick={() => setViewPersist("list")} aria-label="Flat list" aria-pressed={view === "list"} title="Flat list" className={cn("rounded-md p-1.5 transition-colors", view === "list" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}><Rows3 className="h-4 w-4" /></button>
             </div>
           </div>
         </div>
@@ -152,22 +142,24 @@ export default function Sources() {
       {/* Body: facet rail + results */}
       <div className="mt-5 grid gap-5 lg:grid-cols-[220px_minmax(0,1fr)]">
         <aside className="hidden lg:block">
-          <div className="sticky top-[4.75rem] space-y-5">
-            <div>
-              <div className="hud-label mb-2">Coverage</div>
-              <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-secondary">
-                {domainCounts.map(([d, n]) => (
-                  <span key={d} title={`${domainLabel(d)}: ${n}`} style={{ width: `${(n / sources.length) * 100}%`, backgroundColor: domainTint(d) }} />
-                ))}
+          <div className="sticky top-[8rem] space-y-5">
+            {domainCounts.length > 1 ? (
+              <div>
+                <div className="hud-label mb-2">Coverage</div>
+                <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-secondary">
+                  {domainCounts.map(([d, n]) => (
+                    <span key={d} title={`${domainLabel(d)}: ${n}`} style={{ width: `${(n / sources.length) * 100}%`, backgroundColor: domainColor(d) }} />
+                  ))}
+                </div>
               </div>
-            </div>
+            ) : null}
 
             <div>
               <div className="hud-label mb-1.5">Domain</div>
               <div className="space-y-0.5">
                 <Facet label="All domains" count={sources.length} active={domain === "all"} onClick={() => setDomain("all")} />
                 {domainCounts.map(([d, n]) => (
-                  <Facet key={d} label={domainLabel(d)} count={n} tint={domainTint(d)} active={domain === d} onClick={() => setDomain(domain === d ? "all" : d)} />
+                  <Facet key={d} label={domainLabel(d)} count={n} tint={domainColor(d)} active={domain === d} onClick={() => setDomain(domain === d ? "all" : d)} />
                 ))}
               </div>
             </div>
@@ -184,6 +176,16 @@ export default function Sources() {
         </aside>
 
         <section className="min-w-0">
+          {/* Mobile domain filter — facet rail is desktop-only. */}
+          <div className="mb-3 flex gap-1.5 overflow-x-auto pb-1 lg:hidden">
+            <button type="button" onClick={() => setDomain("all")} aria-pressed={domain === "all"} className={cn("shrink-0 rounded-full border px-3 py-1 text-xs font-medium", domain === "all" ? "border-transparent bg-secondary text-foreground" : "border-border text-muted-foreground")}>All</button>
+            {domainCounts.map(([d, n]) => (
+              <button key={d} type="button" onClick={() => setDomain(domain === d ? "all" : d)} aria-pressed={domain === d} className={cn("inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium", domain === d ? "border-transparent bg-secondary text-foreground" : "border-border text-muted-foreground")}>
+                <span className="h-2 w-2 rounded-full" style={{ backgroundColor: domainColor(d) }} />{domainLabel(d)} <span className="tabular-nums opacity-60">{n}</span>
+              </button>
+            ))}
+          </div>
+
           <div className="mb-3 flex items-center justify-between gap-2 text-sm text-muted-foreground">
             <span><span className="font-medium text-foreground">{filtered.length}</span> {filtered.length === 1 ? "source" : "sources"}{view === "hosts" ? ` · ${groups.length} ${groups.length === 1 ? "site" : "sites"}` : ""}{hasFilter ? " matched" : ""}</span>
             {hasFilter ? <button type="button" onClick={clearAll} className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-secondary hover:text-foreground"><X className="h-3.5 w-3.5" /> Clear filters</button> : null}
@@ -196,8 +198,8 @@ export default function Sources() {
               {groups.map(([h, items]) => (
                 <Card key={h} className="flex flex-col">
                   <CardHeader className="flex-row items-center justify-between space-y-0 pb-3">
-                    <CardTitle className="flex min-w-0 items-center gap-2 text-base">
-                      <img src={`https://icons.duckduckgo.com/ip3/${h}.ico`} alt="" className="h-4 w-4 shrink-0 rounded" onError={(e) => (e.currentTarget.style.display = "none")} />
+                    <CardTitle className="flex min-w-0 items-center gap-2 text-base" title={h}>
+                      <img src={`https://icons.duckduckgo.com/ip3/${h}.ico`} alt="" className="h-4 w-4 shrink-0 rounded" onError={(e) => (e.currentTarget.style.visibility = "hidden")} />
                       <span className="truncate">{h}</span>
                     </CardTitle>
                     <Badge variant="secondary" className="shrink-0">{items.length}</Badge>
@@ -219,13 +221,13 @@ export default function Sources() {
               </div>
               {filtered.map((s, i) => (
                 <a key={i} href={s.url} target="_blank" rel="noreferrer" className="group flex items-center gap-3 border-b border-border/60 px-3 py-2 text-sm transition-colors hover:bg-secondary/50">
-                  <span className="hidden w-40 shrink-0 items-center gap-1.5 text-xs text-muted-foreground sm:flex">
+                  <span className="hidden w-40 shrink-0 items-center gap-1.5 text-xs text-muted-foreground sm:flex" title={s.host}>
                     <img src={`https://icons.duckduckgo.com/ip3/${s.host}.ico`} alt="" className="h-3.5 w-3.5 shrink-0 rounded" onError={(e) => (e.currentTarget.style.visibility = "hidden")} />
                     <span className="truncate">{s.host}</span>
                   </span>
-                  <span className="min-w-0 flex-1 truncate group-hover:text-brand-cyan-dark">{s.label}</span>
+                  <span className="min-w-0 flex-1 truncate group-hover:text-brand-cyan-dark" title={s.label}>{s.label}</span>
                   <span className="hidden w-32 shrink-0 md:block"><DomainBadge domain={s.domain} /></span>
-                  <span className="hidden w-56 shrink-0 truncate text-xs text-muted-foreground lg:block">{s.findingTitle}</span>
+                  <span className="hidden w-56 shrink-0 truncate text-xs text-muted-foreground lg:block" title={s.findingTitle}>{s.findingTitle}</span>
                   <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
                 </a>
               ))}

--- a/web/src/pages/StreamDetail.tsx
+++ b/web/src/pages/StreamDetail.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, Check, Copy, FileText, Network, Users, Cpu, Wrench, ScrollText, ExternalLink, Lightbulb, ArrowRight, UserCheck } from "lucide-react";
+import { ArrowLeft, Check, Copy, FileText, Network, Users, Cpu, Wrench, ScrollText, ExternalLink, Lightbulb, ArrowRight, UserCheck, GitBranch, GitMerge } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { EmptyState } from "@/components/shared/EmptyState";
@@ -49,6 +49,17 @@ function CopyBriefButton({ doc }: { doc: StreamDoc }) {
     <button type="button" onClick={onCopy} className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-secondary">
       {copied ? <><Check className="h-3.5 w-3.5 text-emerald-600" /> Copied</> : <><Copy className="h-3.5 w-3.5" /> Copy brief</>}
     </button>
+  );
+}
+
+// A dense KPI chip for the command bar — matches Findings/Sources/Streams.
+function Vital({ icon: Icon, value, label, accent = "#2E4057" }: { icon: typeof FileText; value: React.ReactNode; label: string; accent?: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-card/60 px-2.5 py-1 backdrop-blur-sm">
+      <Icon className="h-3.5 w-3.5" style={{ color: accent }} />
+      <span className="font-mono text-sm font-semibold tabular-nums text-foreground">{value}</span>
+      <span className="hidden text-[10px] uppercase tracking-wider text-muted-foreground sm:inline">{label}</span>
+    </span>
   );
 }
 
@@ -118,24 +129,36 @@ export default function StreamDetail() {
   const image = doc?.image || summary?.image || "";
 
   return (
-    <div>
-      <Link to="/streams" className="mb-3 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"><ArrowLeft className="h-4 w-4" /> All streams</Link>
-
-      <div className="mb-4 flex flex-wrap items-center gap-2">
-        <span className="font-mono text-xs text-muted-foreground">Stream #{streamNum}</span>
-        <h1 className="font-serif text-2xl font-bold text-brand-navy dark:text-foreground md:text-3xl">{title}</h1>
-        {state ? <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium" style={{ backgroundColor: streamStateStyle(state).bg, color: streamStateStyle(state).color }}>{statusLabel(state)}</span> : null}
-        <DomainBadge domain={domain} />
+    <div className="full-bleed px-4 md:px-6">
+      {/* Sticky command bar — keeps title, status & key stats in view while scrolling */}
+      <div className="sticky top-16 z-20 -mx-4 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
+        <Link to="/streams" className="mb-1.5 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"><ArrowLeft className="h-3.5 w-3.5" /> All streams</Link>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <span className="font-mono text-xs text-muted-foreground">#{streamNum}</span>
+          <h1 className="min-w-0 flex-1 basis-full font-serif text-lg font-bold leading-tight text-brand-navy dark:text-foreground md:basis-auto md:text-xl">{title}</h1>
+          {state ? <span className="shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium" style={{ backgroundColor: streamStateStyle(state).bg, color: streamStateStyle(state).color }}>{statusLabel(state)}</span> : null}
+          <DomainBadge domain={domain} />
+          <div className="ml-auto flex items-center gap-1.5">
+            {hasOverview && doc ? <CopyBriefButton doc={doc} /> : null}
+          </div>
+        </div>
+        {/* Vitals strip */}
+        <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+          <Vital icon={GitBranch} value={`${summary?.openIssues ?? 0}/${summary?.issues ?? 0}`} label="issues" accent="#2E4057" />
+          <Vital icon={GitMerge} value={summary?.mergedPRs ?? 0} label="accepted" accent="#C2410C" />
+          <Vital icon={FileText} value={summary?.findings ?? findings.length} label="findings" accent="#8B5CF6" />
+          <Vital icon={Users} value={people.length} label="people" accent="#1D76DB" />
+        </div>
       </div>
 
       {image ? (
-        <figure className="mb-6 overflow-hidden rounded-lg border border-border bg-secondary">
-          <img src={publicAsset(image)} alt={`Overview illustration for ${title}`} className="aspect-[16/9] w-full object-cover" />
+        <figure className="mt-5 overflow-hidden rounded-lg border border-border bg-secondary">
+          <img src={publicAsset(image)} alt={`Overview illustration for ${title}`} className="aspect-[21/9] w-full object-cover" />
         </figure>
       ) : null}
 
       {/* Lifecycle stepper — where this stream is in its journey */}
-      <Card className="mb-6 overflow-x-auto p-5">
+      <Card className="mb-6 mt-5 overflow-x-auto p-5">
         <StreamProgress state={state} className="min-w-[560px]" />
       </Card>
 
@@ -249,18 +272,12 @@ export default function StreamDetail() {
         </div>
 
         {/* Sidebar: provenance (sticky) */}
-        <aside className="lg:sticky lg:top-20 lg:self-start">
+        <aside className="lg:sticky lg:top-[8rem] lg:self-start">
           <Card className="p-5">
             <div className="mb-3 font-serif text-base font-semibold">Provenance</div>
 
-            <div className="grid grid-cols-3 gap-2 border-b border-border pb-3 text-center">
-              <div><div className="text-lg font-bold tabular-nums">{summary?.issues ?? 0}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">issues</div></div>
-              <div><div className="text-lg font-bold tabular-nums">{summary?.mergedPRs ?? 0}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">accepted</div></div>
-              <div><div className="text-lg font-bold tabular-nums">{summary?.findings ?? findings.length}</div><div className="text-[10px] uppercase tracking-wide text-muted-foreground">findings</div></div>
-            </div>
-
             {steward ? (
-              <div className="mt-3">
+              <div>
                 <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Steward</div>
                 <a href={`https://github.com/${steward}`} target="_blank" rel="noreferrer" className="inline-flex items-center gap-2 text-sm hover:text-brand-cyan-dark">
                   <PersonAvatar login={steward} avatar={`https://github.com/${steward}.png`} size={22} /> @{steward}

--- a/web/src/pages/Streams.tsx
+++ b/web/src/pages/Streams.tsx
@@ -160,7 +160,7 @@ function StreamCard({ s, subtasks }: { s: StreamSummary; subtasks: IssueLite[] }
 
 function CardGrid({ streams, subtasksMap }: { streams: StreamSummary[]; subtasksMap: Map<number, IssueLite[]> }) {
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
       {streams.map((s) => <StreamCard key={s.stream} s={s} subtasks={subtasksMap.get(s.stream) ?? []} />)}
     </div>
   );
@@ -347,7 +347,7 @@ export default function Streams() {
   const nothing = view === "table" ? tableRows.length === 0 : (!showDecisions && !showProgress && !showShipped);
 
   return (
-    <div>
+    <div className="full-bleed px-4 md:px-6">
       <PageHeader title="Streams">
         Every problem we're working, start to finish. Each stream begins as one Discover issue and fans out into researched, reviewed, merged work. Open one to see the original problem, the research behind it, the synthesised answer, and the models, harnesses and people involved.
       </PageHeader>
@@ -367,8 +367,8 @@ export default function Streams() {
             <StatCard label="Contributors" value={totals.people} icon={Users} accent="#1D76DB" />
           </section>
 
-          {/* Controls */}
-          <div className="mb-6 flex flex-wrap items-center gap-3">
+          {/* Controls — sticky so search/filter/view stay reachable while scrolling */}
+          <div className="sticky top-0 z-20 mb-6 -mx-4 flex flex-wrap items-center gap-3 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
             <div className="relative min-w-[180px] flex-1">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input placeholder="Search streams…" value={q} onChange={(e) => setQ(e.target.value)} className="pl-9" />

--- a/web/src/pages/Streams.tsx
+++ b/web/src/pages/Streams.tsx
@@ -285,7 +285,7 @@ function Segmented({ children }: { children: React.ReactNode }) {
 
 function SegButton({ active, onClick, title, children }: { active: boolean; onClick: () => void; title?: string; children: React.ReactNode }) {
   return (
-    <button type="button" onClick={onClick} title={title} className={cn("inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors", active ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}>
+    <button type="button" onClick={onClick} title={title} aria-pressed={active} className={cn("inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors", active ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground")}>
       {children}
     </button>
   );
@@ -357,7 +357,7 @@ export default function Streams() {
       ) : (
         <>
           {/* Stats */}
-          <section className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-7">
+          <section className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-7">
             <StatCard label="Streams" value={totals.count} icon={Network} accent="#2E4057" />
             <StatCard label="Awaiting direction" value={totals.decisions} icon={UserCheck} accent="#D97706" />
             <StatCard label="In progress" value={totals.inProgress} icon={Loader2} accent="#0EA5E9" />
@@ -368,7 +368,7 @@ export default function Streams() {
           </section>
 
           {/* Controls — sticky so search/filter/view stay reachable while scrolling */}
-          <div className="sticky top-0 z-20 mb-6 -mx-4 flex flex-wrap items-center gap-3 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
+          <div className="sticky top-16 z-20 mb-6 -mx-4 flex flex-wrap items-center gap-3 border-b border-border/70 bg-background/85 px-4 py-3 backdrop-blur md:-mx-6 md:px-6">
             <div className="relative min-w-[180px] flex-1">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input placeholder="Search streams…" value={q} onChange={(e) => setQ(e.target.value)} className="pl-9" />


### PR DESCRIPTION
Reworks the **Findings** and **Streams** screens toward a `/live`-style application feel — full viewport width, denser layout, less scrolling, and a better way to surface the data as it grows.

### Findings — full rebuild into an app shell
- **Sticky command bar** with live vitals: findings / domains / total sources / % high-confidence
- **Left facet rail**: domain + confidence filters with live counts, plus a domain-coverage distribution bar (click a facet to filter, click again to clear)
- **Sort**: Recent / Sources / Confidence
- **View toggle**: card grid *or* a compact, scannable **list** mode built for large result sets (domain, confidence, agent, source count, date as columns)
- Full-bleed width; results area stands on its own so the page scrolls far less

### Streams
- Full-bleed width, **sticky** search/filter/view controls, denser 4-up card grid on 2xl screens

### Shared
- Adds a reusable `.full-bleed` utility. Safe: the layout's `main` clips `overflow-x`, so 100vw never introduces a horizontal scrollbar.

`cd web && npm run build` passes (only the pre-existing large-chunk warning). First cut — happy to iterate on density/spacing once you see it live. Doesn't yet touch the finding/stream *detail* pages or add an ELI5 toggle; those are natural follow-ups.