### PR TITLE
feat(server): orchestrated review dispatch — the server hands reviewers their next PR (ADR-0019)

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -297,6 +297,27 @@ What changes when it's on:
   `resume`), `stop` (finish the current task, then exit), `abort` (abandon
   current work — released `abandoned` — and exit). Command semantics and the
   admin API are in [`server/README.md`](../server/README.md).
+- **Reviews too ([ADR-0019](adr/0019-orchestrated-review-dispatch.md))** —
+  an enrolled `review_work.sh` asks the same endpoint with `kind: "review"`
+  instead of walking the open-PR list. The server picks the oldest open PR
+  that needs a review by that identity — not draft, not
+  `review: human-only`/`do-not-automate`, not authored by the reviewer, not
+  already reviewed at its current head SHA (a commented-only review doesn't
+  count), under the review-round cap, and verified still open against live
+  GitHub — and takes a review lease (default 1 hour). **No labels are
+  involved**: the lease alone stops two enrolled reviewers doubling up, so
+  there is nothing to revert if the reviewer dies — the lease lapses and the
+  PR is claimable again. The runner reviews exactly that PR through its
+  normal per-PR flow (method-vs-standard kind, round cap, merge check — all
+  unchanged) and releases `done` on any posted verdict (PASS *or* NEEDS_WORK
+  — the review happened) or `abandoned` on failure/interrupt or a local
+  skip; an abandoned PR cools down (default 15 min) before re-dispatch, so a
+  skip can never loop. Each identity enrolls its **own** fleet token (the
+  stored token file is keyed by host + handle), so the reviewer running
+  under `REVIEW_GITHUB_TOKEN` never reuses the work identity's token and
+  author ≠ reviewer is enforced against the account that actually posts the
+  review. Empty queue or server trouble → the pass falls through to today's
+  PR-list walk unchanged.
 
 GitHub remains the durable source of truth throughout: the server arbitrates
 *who claims*, but every durable fact lands on GitHub as the same labels and

--- a/docs/adr/0019-orchestrated-review-dispatch.md
+++ b/docs/adr/0019-orchestrated-review-dispatch.md
@@ -1,0 +1,127 @@
+# ADR-0019: The fleet server dispatches PR reviews to enrolled reviewers (kind: review)
+
+- **Status:** proposed (ratified on merge by the human maintainer, who directed this design
+  on 2026-07-06 as a follow-up to ADR-0017/0018; agents do not self-ratify pipeline changes)
+- **Date:** 2026-07-06
+- **Deciders:** @adam91holt (human maintainer); drafted by an agent (Claude Fable 5) acting
+  on his direct instructions
+- **Relates to:** ADR-0017 (pull-claim orchestration — this extends its pattern from issues
+  to PR reviews), ADR-0018 (mirror-backed runner reads — same rate-limit motive), ADR-0015
+  (autopilot alternates review and work), ADR-0013 (review-round cap), #398
+
+## Context
+
+Every `review_work.sh` pass **walks the open-PR list client-side**: a paginated pulls read,
+then per-PR metadata reads just to decide *skip* — draft? `review: human-only`?
+author == reviewer? already reviewed at this head revision? parked at the round cap? Most
+of that burn discovers nothing to do, and (ADR-0018) it comes out of the one shared
+rate-limit budget per contributor identity. Concurrency is handled by a client-side claim
+dance — a `review: claimed` label honoured for a TTL plus a pending-status settle window
+with a randomised sleep — which mostly works, but costs GitHub writes per claim and still
+lets two reviewers race into the settle window on the same PR.
+
+ADR-0017 already solved exactly this shape of problem for *issue* claims: the fleet server
+picks the next eligible candidate from its webhook-fed mirror and takes an atomic Redis
+lease. Reviews are the same race with one welcome simplification: **a review holds no
+GitHub state while in progress** — no status label, no assignee — so the server has nothing
+to write on claim and nothing to revert on expiry.
+
+## Decision
+
+1. **Same pull-claim, second kind.** `POST /api/v1/work/claim` gains
+   `kind: "work" | "review"` (default `work`; every response echoes the kind it executed,
+   so a runner can detect an older server that silently dropped the field). For
+   `kind: review` the server picks the **oldest** eligible open PR from the mirror and
+   returns it; the enrolled runner reviews exactly that PR through its existing per-PR
+   flow. Eligibility replicates `review_work.sh`'s own selection rules server-side: open,
+   not draft, labels exclude `review: human-only` and `do-not-automate`, author ≠ the
+   claiming handle (the different-identity rule), under the review-round cap
+   (`MAX_REVIEW_ROUNDS` — the same env var the shell reads, so operator overrides can't
+   diverge the two; dismissed rounds don't count, matching the shell's GraphQL
+   `states:CHANGES_REQUESTED`), and **not already reviewed at the current head SHA** — an
+   approving, changes-requesting, or dismissed review carrying `commitId == headSha` means
+   either waiting-on-rework or already passed, so the PR is skipped until the author
+   pushes; new commits make it eligible again. A **commented-only** review at head does
+   *not* count as reviewed: it sets no merge-check status, so the shell's walk would still
+   review the PR. Because the mirror can miss a close, the winning candidate is verified
+   **still open against live GitHub** (one read per claim) before it is handed out —
+   a merged PR must never cost an agent-hour review; the read also self-heals the doc.
+2. **The lease is the whole claim.** `lease:review:<pr>` is taken with Redis `SET NX EX`
+   (`REVIEW_LEASE_TTL_SECONDS`, default 3600) — **no GitHub writes on claim, none on
+   release, none on expiry**, because reviews hold no labels. Leases renew on authed
+   telemetry heartbeats like work leases (the claimed-label mirror guard applies only to
+   kind `work`); an expired review lease just marks the assignment `lease-expired` and the
+   PR drops back into the review queue. Release outcomes: `done` on **any posted verdict**
+   — PASS and NEEDS_WORK both mean the review happened — `abandoned` on
+   failure/usage-limit/interrupt *or a local skip* (the runner's live checks disagreed with
+   the mirror). An abandoned PR **cools down** (`REVIEW_ABANDON_COOLDOWN_SECONDS`, default
+   900) before it can be dispatched again: without that, a PR every runner locally skips
+   would sit at the head of the deterministic oldest-first queue and burn one claim per
+   runner per pass, forever. The walk can still reach a cooling-down PR.
+3. **The mirror learns review state lazily.** `pull_request_review` webhooks append
+   `{reviewer, state, commitId, at}` to the PR doc (capped at the last 30) and
+   `pull_request` synchronize events update `headSha` — but the REST pulls list doesn't
+   carry reviews, so the interval sync can't backfill them. When dispatch evaluates a
+   candidate with no review data for its current head, it fetches
+   `GET /pulls/:n/reviews` **once** and stamps `reviewsFetchedFor: headSha`; the fetch is
+   bounded to the first 10 candidates per claim, so a cold mirror costs a bounded, one-time
+   read per PR revision instead of every pass forever.
+4. **One assignments collection, tagged by kind.** Review claims reuse the `assignments`
+   audit trail with `kind: "review"` (existing docs read as `kind: "work"`); for review
+   rows `issueNumber` holds the **PR number**. The active-claims view carries `kind` so the
+   dashboard badges reviews distinctly.
+5. **The runner stays the reviewer; the walk stays the fallback.** The server only picks
+   *which* PR — everything about *how* it is reviewed is unchanged: the method-vs-standard
+   review kind, prior-round context, the round cap and parking (#287/ADR-0013), the merge
+   check, NEEDS_WORK routing. The runner also keeps its client-side claim dance and
+   per-PR guards, because the lease arbitrates **only among enrolled reviewers** — a
+   non-enrolled reviewer on the label/status path can still race, and the existing dance
+   remains the cross-population defence. On claim failure for any reason — queue empty,
+   server down, timeout — `review_work.sh` falls through to today's PR-list walk
+   byte-for-byte (the ADR-0016/#398 fail-open invariant).
+6. **Review claims authenticate as the identity that posts the review.** The stored fleet
+   token file is keyed by **host + handle** (`~/.forgood/fleet-token-<host>-<handle>`;
+   a legacy host-only token is adopted and migrated once when the handle's re-enroll
+   409s), and `review_work.sh` drops any inherited `FLEET_TOKEN` when
+   `REVIEW_GITHUB_TOKEN` is set — so on the documented autopilot setup (work identity
+   enrolled at startup, reviews under a distinct token) the reviewer enrolls **its own**
+   handle rather than silently reusing the work identity's token, which would make the
+   server enforce author ≠ handle against the wrong account. Defence in depth: the claim
+   response carries `handle`, and the runner abandons the claim (falling back to the walk)
+   if it doesn't match the identity it posts reviews as.
+
+Alternatives considered: leasing via the existing `review: claimed` label writes routed
+through the server (rejected — keeps the GitHub write cost and the settle-window race this
+removes); backfilling all review state on interval sync (rejected — a per-PR REST read per
+sync cycle is the exact rate-limit burn ADR-0018 exists to kill; lazy fetch pays it once
+per revision, only for candidates); a separate reviews collection (rejected — one
+assignments audit trail with a `kind` tag keeps the admin surfaces and sweeper singular).
+
+## Consequences
+
+- Among enrolled reviewers, duplicate reviews of one PR become impossible, and a pass that
+  finds nothing to review costs **zero GitHub calls** — selection moves to the mirror.
+- No labels means the failure path is trivial: a crashed reviewer's lease lapses and the
+  PR is claimable again in ≤ TTL, with nothing on GitHub to clean up.
+- The mirror grows review state (`headSha`, `reviews`, `reviewsFetchedFor`) — one more
+  shape kept convergent between webhook reduce and sync, covered by tests.
+- A stale mirror can hand out a PR that was just reviewed or just pushed to; the runner's
+  existing per-PR checks read live GitHub before spending model tokens (including a
+  PR-state guard, so a merged/closed PR is never reviewed), so staleness wastes an
+  attempt, never produces a wrong verdict (the ADR-0018 posture: the mirror *selects*,
+  GitHub *decides*). The abandon cooldown bounds how often one stale PR can waste
+  attempts.
+- The mirror's skip rules are an **approximation** of the shell's status-check rules, and
+  it fails toward *not dispatching*: a PR whose review-entry array sits at its storage cap
+  (30) has an unknowable round count and is skipped (the walk still reaches it), and any
+  residual divergence resolves through the walk rather than a dispatch loop.
+- Honest limit: as with work claims, arbitration covers only the enrolled population —
+  mixed fleets still rely on the client-side claim dance, which is why it stays.
+
+## What would change this decision
+
+Evidence the fallback walk is being hit persistently (the server failing as a review
+dispatcher in practice); review-state drift the lazy fetch + webhooks fail to converge
+(would force sync-side backfill despite its cost); the enrolled share of reviewers
+approaching 100% (would let the client-side claim dance retire); or push assignment
+arriving for work claims (reviews would follow the same shape).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,5 +55,6 @@ routine fixes, copy changes, or web styling.
 | [0016](0016-fleet-telemetry-defaults-and-merge-heal.md) | Fleet telemetry counters on by default (logs opt-in at every client) + deterministic index-cascade merge-healing in the runners | Proposed |
 | [0017](0017-server-orchestrated-pull-claim.md) | The fleet server arbitrates work claims for enrolled agents (pull-claim v1) | Proposed |
 | [0018](0018-mirror-backed-runner-reads.md) | Runner queue reads come from the fleet server's mirror, not GitHub | Proposed |
+| [0019](0019-orchestrated-review-dispatch.md) | The fleet server dispatches PR reviews to enrolled reviewers (kind: review) | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -51,11 +51,29 @@ rule() { printf '%s────────────────────�
 # live here so start_work.sh (which has no telemetry helpers) can claim,
 # renew and release too.
 # Where the auto-enrolled token lives (0600, owner-only). One file per
-# server host so pointing FLEET_SERVER elsewhere never replays a token minted
-# for a different server.
+# server host AND per identity: the server binds every token to one handle,
+# and two identities routinely share a box (autopilot's WORK login + the
+# distinct REVIEW_GITHUB_TOKEN reviewer). A host-only file made the reviewer
+# silently reuse the work identity's token, so the server's author != handle
+# review rule was enforced against the wrong account (ADR-0019).
+fleet_token_host() { printf '%s' "${FLEET_SERVER:-}" | sed 's|^[a-z]*://||; s|[/:].*$||'; }
+
 fleet_token_file() {
-  local host; host="$(printf '%s' "${FLEET_SERVER:-}" | sed 's|^[a-z]*://||; s|[/:].*$||')"
-  printf '%s' "${FLEET_TOKEN_FILE:-$HOME/.forgood/fleet-token-${host:-default}}"
+  local host ident
+  host="$(fleet_token_host)"
+  ident="${ME:-${FLEET_HANDLE:-}}"
+  if [ -n "$ident" ]; then
+    printf '%s' "${FLEET_TOKEN_FILE:-$HOME/.forgood/fleet-token-${host:-default}-${ident}}"
+  else
+    printf '%s' "${FLEET_TOKEN_FILE:-$HOME/.forgood/fleet-token-${host:-default}}"
+  fi
+}
+
+# The pre-identity-keyed path — read once as a migration fallback when this
+# identity's enrollment 409s (its token was minted before per-identity files).
+fleet_legacy_token_file() {
+  local host; host="$(fleet_token_host)"
+  printf '%s/.forgood/fleet-token-%s' "$HOME" "${host:-default}"
 }
 
 # fleet_ensure_token — resolve FLEET_TOKEN: env var > stored file > TOFU
@@ -84,6 +102,25 @@ fleet_ensure_token() {
       + (if $m != "" then {model: $m[0:128]} else {} end)')" 2>/dev/null)" || return 1
   token="$(printf '%s' "$resp" | jq -r 'select(.ok == true) | .token // empty' 2>/dev/null || true)"
   if [ -z "$token" ]; then
+    # 409 "handle already enrolled" + a legacy host-only token file on disk:
+    # this identity enrolled before token files were keyed by handle — adopt
+    # its stored token once, migrating it to the per-identity path. Skipped
+    # when FLEET_TOKEN_FILE pins an explicit path (operator override), and
+    # harmless if the legacy file actually belongs to a DIFFERENT identity:
+    # the server still authenticates it as its bound handle, and the claim
+    # response's `handle` field exposes the mismatch to the runner.
+    if [ -z "${FLEET_TOKEN_FILE:-}" ] && printf '%s' "$resp" | grep -qi 'already enrolled'; then
+      local legacy; legacy="$(fleet_legacy_token_file)"
+      if [ "$legacy" != "$f" ] && [ -f "$legacy" ] && [ ! -L "$legacy" ] && [ -O "$legacy" ]; then
+        token="$(head -c 256 "$legacy" 2>/dev/null | tr -d '[:space:]')"
+        if [ -n "$token" ]; then
+          ( umask 077; mkdir -p "$(dirname "$f")" && printf '%s' "$token" > "$f" ) || true
+          FLEET_TOKEN="$token"; export FLEET_TOKEN
+          warn "Adopted the legacy host-keyed fleet token for @${ME:-${FLEET_HANDLE:-?}} (migrated to $f)."
+          return 0
+        fi
+      fi
+    fi
     warn "fleet enrollment failed for @${ME:-${FLEET_HANDLE:-?}}: $(printf '%s' "$resp" | jq -r '.error // "server unreachable"' 2>/dev/null || echo 'server unreachable') — using the label-claim path."
     return 1
   fi
@@ -155,6 +192,78 @@ fleet_release() {
   body="$(jq -cn --arg issue "${1:-}" --arg outcome "${2:-}" --arg pr "${3:-}" '
       {issue: ($issue | tonumber), outcome: $outcome}
     + (if $pr != "" then {prNumber: ($pr | tonumber)} else {} end)' 2>/dev/null)" || return 0
+  curl -sS -m 5 -X POST "$FLEET_SERVER/api/v1/work/release" \
+    -H 'content-type: application/json' \
+    -H "authorization: Bearer $FLEET_TOKEN" \
+    -d "$body" >/dev/null 2>&1 || true
+  return 0
+}
+
+# ---- fleet server review-claim helpers (orchestrated review dispatch) ----
+# Same opt-in gate as the work-claim helpers above (FLEET_SERVER + FLEET_TOKEN
+# + FLEET_CLAIM=1 — fleet_claim_enabled): reviews reuse the /work/claim and
+# /work/release endpoints with kind:"review", so review_work.sh can take ONE
+# server-arbitrated PR instead of walking the whole open-PR list. A review
+# claim holds NO labels and writes nothing to GitHub — the server-side lease
+# alone stops two enrolled reviewers colliding on one PR.
+
+# fleet_claim_review — ask the server for the next PR needing adversarial
+# review. On success prints {pr, headSha, author, title, leaseTtlSeconds,
+# handle} (jq-shaped from the claim response; `handle` is the registry
+# identity the claim was made FOR — the caller must check it against the
+# identity that will post the review) and returns 0. Queue empty, non-200,
+# bad JSON or timeout → returns 1 (the caller falls back to its own
+# client-side PR walk, unchanged). A pre-ADR-0019 server strips the unknown
+# `kind` field and executes a WORK claim — see the skew guard inside.
+fleet_claim_review() {
+  fleet_claim_enabled || return 1
+  local agent_id="" body resp
+  if [ -n "${FLEET_AGENT_ID_FILE:-}" ]; then
+    agent_id="$(cat "$FLEET_AGENT_ID_FILE" 2>/dev/null || true)"
+    # claimRequestSchema wants a UUID — never let a stale/garbled stash 400 the claim.
+    printf '%s' "$agent_id" | grep -qiE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' || agent_id=""
+  fi
+  body="$(jq -cn --arg harness "${AGENT:-}" --arg model "${MODEL:-}" --arg agentId "$agent_id" '
+      {kind: "review"}
+    + (if $harness != "" then {harness: $harness[0:32]} else {} end)
+    + (if $model   != "" then {model: $model[0:128]} else {} end)
+    + (if $agentId != "" then {agentId: $agentId} else {} end)' 2>/dev/null)" || return 1
+  resp="$(curl -sS -m 5 -X POST "$FLEET_SERVER/api/v1/work/claim" \
+    -H 'content-type: application/json' \
+    -H "authorization: Bearer $FLEET_TOKEN" \
+    -d "$body" 2>/dev/null)" || return 1
+  if ! printf '%s' "$resp" | jq -e '.ok == true and .review != null' >/dev/null 2>&1; then
+    # DEPLOY-SKEW GUARD: a pre-ADR-0019 server's claim schema silently strips
+    # the unknown `kind` field (non-strict zod object) and executes a WORK
+    # claim — labelling "status: claimed" + assigning the handle on a REAL
+    # issue — while answering {ok:true, issue:{...}}. Detect that shape and
+    # release the accidental claim, or the issue strands claimed-by-nobody
+    # until the server's lease TTL sweeps it, once per review pass.
+    local oops
+    oops="$(printf '%s' "$resp" | jq -r 'select(.ok == true) | .issue.number // empty' 2>/dev/null || true)"
+    if [ -n "$oops" ]; then
+      warn "Fleet server predates kind:review (deploy skew) — releasing the accidental work claim on #$oops."
+      fleet_release "$oops" abandoned
+    fi
+    return 1
+  fi
+  printf '%s' "$resp" | jq -c '{pr: .review.pr, headSha: .review.headSha, author: .review.author, title: .review.title, leaseTtlSeconds: .leaseTtlSeconds, handle: .handle}'
+}
+
+# fleet_release_review <pr> <done|abandoned> — finish a fleet-claimed review.
+# done = a verdict was actually posted (PASS and NEEDS_WORK both count — the
+# review HAPPENED); abandoned = it didn't (reviewer failure / usage limit /
+# interrupt / local skip), so the PR goes straight back into the review
+# queue. No label ops either way (review claims never held any). The
+# release request's `issue` field carries the PR number (the server's
+# release schema reuses it for kind:"review"). Best-effort: failures are
+# swallowed — the lease TTL and the server-side sweeper backstop a lost
+# release.
+fleet_release_review() {
+  fleet_claim_enabled || return 0
+  local body
+  body="$(jq -cn --arg pr "${1:-}" --arg outcome "${2:-}" \
+      '{kind: "review", issue: ($pr | tonumber), outcome: $outcome}' 2>/dev/null)" || return 0
   curl -sS -m 5 -X POST "$FLEET_SERVER/api/v1/work/release" \
     -H 'content-type: application/json' \
     -H "authorization: Bearer $FLEET_TOKEN" \

--- a/scripts/review_work.sh
+++ b/scripts/review_work.sh
@@ -18,6 +18,13 @@
 # rework up. A PR already marked NEEDS_WORK at its current revision is skipped
 # until the author pushes rework (FORCE=1 to re-review anyway).
 #
+# FLEET-FIRST (ADR-0019): when fleet claiming is enabled (FLEET_SERVER +
+# FLEET_TOKEN + FLEET_CLAIM=1, see scripts/fg-common.sh), each pass first asks
+# the fleet server for ONE arbitrated PR (claim kind: "review") instead of
+# walking the open-PR list — the server-side lease stops enrolled reviewers
+# colliding, with no labels involved. Claim rc 1 (queue empty / server down /
+# not enrolled) falls straight through to the existing walk, unchanged.
+#
 # A PR labelled "review: human-only" is excluded from this loop entirely —
 # pipeline/governance changes are reviewed and merged by a HUMAN maintainer,
 # never by agent runners. The label is applied by a maintainer, not by agents.
@@ -78,19 +85,36 @@ HUMAN_ONLY_LABEL="review: human-only"  # PRs carrying this are reviewed by a hum
 REVIEW_CLAIM_TTL="${REVIEW_CLAIM_TTL:-1800}"  # secs a review claim is honoured before it's treated as stale
 MAX_REVIEW_ROUNDS="${MAX_REVIEW_ROUNDS:-10}"  # change-requesting rounds before the PR is parked for a human (#287)
 DID_REVIEW=0   # set once review_one claims a PR and spends real work on it; skips leave it 0
+VERDICT_POSTED=0  # set by review_one once a verdict (PASS or NEEDS_WORK) is posted — the fleet release maps it to done/abandoned
+FLEET_REVIEW_PR=""  # PR held under a fleet review lease; cleanup abandons it so an interrupt never strands the lease for its full TTL
 
 # Release any claim we hold, then clean up the worktree. cleanup runs on ANY
 # exit via the EXIT trap; the INT/TERM handlers must call `exit` themselves,
 # otherwise bash runs the handler and then RESUMES the loop — which is exactly
 # why Ctrl-C used to do nothing here. exit re-triggers the EXIT trap, so cleanup
 # still runs exactly once.
-cleanup() { [ -n "${CLAIMED_PR:-}" ] && release_pr "$CLAIMED_PR" || true; remove_worktree || true; }
+cleanup() {
+  [ -n "${FLEET_REVIEW_PR:-}" ] && fleet_release_review "$FLEET_REVIEW_PR" abandoned || true
+  [ -n "${CLAIMED_PR:-}" ] && release_pr "$CLAIMED_PR" || true
+  remove_worktree || true
+}
 trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
 # Use a distinct reviewer identity if provided (recommended).
-if [ -n "${REVIEW_GITHUB_TOKEN:-}" ]; then export GH_TOKEN="$REVIEW_GITHUB_TOKEN"; fi
+if [ -n "${REVIEW_GITHUB_TOKEN:-}" ]; then
+  export GH_TOKEN="$REVIEW_GITHUB_TOKEN"
+  # Never authenticate fleet review claims with an INHERITED work-identity
+  # token: autopilot enrolls its WORK gh login and exports that FLEET_TOKEN,
+  # so keeping it here would make the server enforce its author != handle
+  # rule against the wrong identity (ADR-0019) — every PR authored by the
+  # work handle would be withheld from dispatch, and PRs authored by THIS
+  # reviewer would be dispatched only for review_one to hard-refuse them.
+  # Dropping it makes fleet_ensure_token load/enroll this reviewer identity's
+  # OWN token (the token file is keyed by host+handle in fg-common.sh).
+  unset FLEET_TOKEN FLEET_AGENT_ID_FILE
+fi
 
 # ---- concurrency: claim a PR before reviewing so parallel runners don't
 # collide on the same PR (or all pile onto the front of the list). A visible
@@ -381,16 +405,31 @@ set_check() {  # $1 sha, $2 state(success|failure), $3 desc, $4 url
 
 review_one() {  # $1 = PR number
   local pr="$1"
-  local sha author url title labels
+  local sha author url title labels state merged
   local meta
   meta="$(gh api "repos/$OWNER/$NAME/pulls/$pr" \
-    --jq '{sha:.head.sha, author:.user.login, url:.html_url, title:.title, labels:(.labels // [] | map(.name) | join(","))}' 2>/dev/null)" || return 1
+    --jq '{sha:.head.sha, author:.user.login, url:.html_url, title:.title, state:.state, merged:.merged, labels:(.labels // [] | map(.name) | join(","))}' 2>/dev/null)" || return 1
   sha="$(printf '%s' "$meta" | jq -r .sha)"
   author="$(printf '%s' "$meta" | jq -r .author)"
   url="$(printf '%s' "$meta" | jq -r .url)"
   title="$(printf '%s' "$meta" | jq -r .title)"
+  state="$(printf '%s' "$meta" | jq -r .state)"
+  merged="$(printf '%s' "$meta" | jq -r .merged)"
   labels="$(printf '%s' "$meta" | jq -r .labels)"
   rule; info "${c_bold}PR #$pr${c_reset} — $title ${c_dim}(by @$author)${c_reset}"
+
+  # STATE GUARD: never review a PR that is no longer open. The old walk was
+  # naturally immune (open_prs_needing_review lists live open PRs), but a
+  # fleet-dispatched PR comes from the server's MIRROR, which can be stale
+  # (lost `closed` webhook inside the sync interval) — and PR=<n> or a
+  # mid-pass merge can race the walk too. Without this, a full agent review
+  # lands on a merged PR and a NEEDS_WORK verdict would flip its already-DONE
+  # linked issue back to changes-requested. Skipping (rc 0, DID_REVIEW stays
+  # 0) releases a fleet lease as `abandoned` and preserves the walk's pacing.
+  if [ "$state" != open ]; then
+    log "#$pr is already $([ "$merged" = true ] && echo merged || echo closed) — nothing to review. Skipping."
+    return 0
+  fi
 
   # HUMAN-ONLY: pipeline/governance PRs are reviewed by a human maintainer, not
   # by this loop (also guards the PR=<n> single-PR path).
@@ -544,6 +583,9 @@ review_one() {  # $1 = PR number
 
   rm -f "$tmp"
   local body_flag=(--body-file "$body_file")
+  # A verdict is posted by whichever branch runs below — PASS and NEEDS_WORK
+  # both mean the review HAPPENED, so a fleet review lease releases as "done".
+  VERDICT_POSTED=1
 
   if [ "$verdict" = PASS ]; then
     ok "Verdict: PASS"
@@ -647,6 +689,54 @@ main() {
   fi
   local done=0
   while :; do
+    # FLEET-FIRST (ADR-0019): ask the fleet server for ONE arbitrated PR
+    # before walking the list. The server applies this loop's skip rules
+    # against its mirror (draft, human-only, author != reviewer, already
+    # reviewed at the current head) and its lease stops two enrolled
+    # reviewers colliding on one PR — no labels involved. Hard no-op unless
+    # fleet claiming is enabled (fg-common.sh); claim rc 1 (queue empty /
+    # server down / disabled) falls straight through to the walk, unchanged.
+    # PR=<n> and DRY_RUN keep the old paths (a dry run must not take leases).
+    local fclaim fpr fhandle frc
+    if [ -z "$ONLY_PR" ] && [ "$DRY_RUN" = 0 ] && fclaim="$(fleet_claim_review)"; then
+      fpr="$(printf '%s' "$fclaim" | jq -r '.pr // empty' 2>/dev/null || true)"
+      # IDENTITY GUARD: the server enforced author != <the token's handle>,
+      # but the review below is POSTED as @$ME. If the fleet token belongs to
+      # a different identity (e.g. an inherited work-identity token from a
+      # pre-identity-keyed setup), that rule was checked against the wrong
+      # account — abandon the claim and fall through to the walk, whose own
+      # author check ($ME) is authoritative.
+      fhandle="$(printf '%s' "$fclaim" | jq -r '.handle // empty' 2>/dev/null || true)"
+      if [ -n "$fpr" ] && [ -n "$fhandle" ] && [ "$fhandle" != "$ME" ]; then
+        warn "Fleet review claim was made for @$fhandle but reviews here post as @$ME — the fleet token belongs to a different identity."
+        warn "Re-enroll this reviewer (its token file is keyed by host+handle) or unset FLEET_TOKEN. Abandoning the claim and using the walk."
+        fleet_release_review "$fpr" abandoned
+        fpr=""
+      fi
+      if [ -n "$fpr" ]; then
+        info "Fleet server dispatched PR #$fpr for review (lease $(printf '%s' "$fclaim" | jq -r '.leaseTtlSeconds // "?"')s) — reviewing exactly that PR."
+        DID_REVIEW=0; VERDICT_POSTED=0; FLEET_REVIEW_PR="$fpr"
+        set +e; review_one "$fpr"; frc=$?; set -e
+        # done = a verdict was actually posted (PASS and NEEDS_WORK both mean
+        # the review happened); anything else — reviewer failure, usage
+        # limit, interrupt, or a local skip the mirror hadn't caught up
+        # with — abandons the lease so the PR returns to the review queue.
+        if [ "$VERDICT_POSTED" = 1 ]; then
+          fleet_release_review "$fpr" done
+        else
+          fleet_release_review "$fpr" abandoned
+        fi
+        FLEET_REVIEW_PR=""
+        was_interrupted "$frc" && { rule; warn "Interrupted — stopping."; exit 130; }
+        [ "$DID_REVIEW" = 1 ] && done=$((done+1))
+        [ "$MAX" -gt 0 ] && [ "$done" -ge "$MAX" ] && { rule; ok "Reached MAX=$MAX. Stopping."; exit 0; }
+        # A review that actually ran → straight back for the next claim. A
+        # local skip (stale mirror) falls through to the walk instead, so a
+        # pass keeps its old pacing rather than hot-looping claim → skip →
+        # claim on the same PR until the mirror catches up.
+        [ "$DID_REVIEW" = 1 ] && continue
+      fi
+    fi
     local prs
     if [ -n "$ONLY_PR" ]; then prs="$ONLY_PR"; else prs="$(open_prs_needing_review 2>/dev/null | shuffle_lines || true)"; fi
     if [ -z "$prs" ]; then

--- a/scripts/test-fg-common-fleet.sh
+++ b/scripts/test-fg-common-fleet.sh
@@ -9,6 +9,11 @@
 #   - fleet_release: sends done-with-prNumber vs abandoned payloads and
 #     swallows server failures
 #   - fleet_renew: fire-and-forget, always returns 0
+#   - fleet_claim_review: claims with kind:"review", emits {pr, headSha,
+#     author, title, leaseTtlSeconds}, and returns 1 on empty-queue /
+#     non-JSON / server down (the PR-walk fallback contract, ADR-0019)
+#   - fleet_release_review: sends kind:"review" done/abandoned payloads
+#     (issue = the PR number) and swallows server failures
 #   - fleet_pop_commands: drains the stash once, and REFUSES a stash file we
 #     don't own (the control hop is unauthenticated — a foreign /tmp file
 #     must never drive stop/pause)
@@ -65,6 +70,19 @@ class Handler(BaseHTTPRequestHandler):
             return
         if mode == "empty":
             payload = {"ok": True, "issue": None}
+        elif mode == "review":
+            payload = {
+                "ok": True,
+                "review": {"pr": 456, "title": "stub PR", "author": "someauthor",
+                           "headSha": "0123456789abcdef0123456789abcdef01234567",
+                           "htmlUrl": "https://github.com/example/repo/pull/456",
+                           "baseRef": "main", "headRef": "research/stub"},
+                "assignmentId": "rev123",
+                "leaseTtlSeconds": 3600,
+                "handle": "review-bot",
+            }
+        elif mode == "review-empty":
+            payload = {"ok": True, "review": None}
         elif mode == "garbage":
             self.send_response(200); self.end_headers()
             self.wfile.write(b"this is not json"); return
@@ -162,6 +180,71 @@ printf '%s' "$req" | jq -e '.body | fromjson | .issue == 123' >/dev/null || fail
 ( FLEET_SERVER="http://127.0.0.1:9" fleet_renew 123 ) || fail "renew must swallow server failures"
 pass "fleet_renew is fire-and-forget"
 
+# --- fleet_claim_review (kind: "review", ADR-0019) ------------------------------
+# Disabled → documented no-op return codes (same contract as the work helpers).
+( FLEET_CLAIM=0 fleet_claim_review ) && fail "fleet_claim_review must return 1 when disabled"
+( FLEET_CLAIM=0 fleet_release_review 1 done ) || fail "fleet_release_review must return 0 when disabled"
+pass "disabled review helpers no-op with the right return codes"
+
+printf 'review' > "$MODE_FILE"
+resp="$(AGENT=claude MODEL=test-model fleet_claim_review)" \
+  || fail "fleet_claim_review should succeed against the stub"
+[ "$(printf '%s' "$resp" | jq -r '.pr')" = "456" ] \
+  || fail "fleet_claim_review must emit .pr (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.handle')" = "review-bot" ] \
+  || fail "fleet_claim_review must emit .handle — the caller checks it against the posting identity (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.headSha')" = "0123456789abcdef0123456789abcdef01234567" ] \
+  || fail "fleet_claim_review must emit .headSha (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.author')" = "someauthor" ] \
+  || fail "fleet_claim_review must emit .author (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.title')" = "stub PR" ] \
+  || fail "fleet_claim_review must emit .title (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.leaseTtlSeconds')" = "3600" ] \
+  || fail "fleet_claim_review must pass leaseTtlSeconds through (got: $resp)"
+req="$(tail -1 "$LOG_FILE")"
+[ "$(printf '%s' "$req" | jq -r .path)" = "/api/v1/work/claim" ] || fail "review claim path"
+printf '%s' "$req" | jq -e '.auth == "Bearer fgt_0123456789abcdef0123456789abcdef"' >/dev/null \
+  || fail "review claim must send the bearer token"
+printf '%s' "$req" | jq -e '.body | fromjson | .kind == "review" and .harness == "claude" and .model == "test-model" and (has("stages") | not)' >/dev/null \
+  || fail "review claim body must carry kind:review + harness/model, no stages (got: $req)"
+pass "fleet_claim_review emits {pr, headSha, author, title, leaseTtlSeconds} and sends kind:review"
+
+# Fallback contract: empty review queue / garbage / server down → rc 1 (PR walk).
+printf 'review-empty' > "$MODE_FILE"
+fleet_claim_review && fail "empty review queue must return 1 (PR-walk fallback)"
+printf 'garbage' > "$MODE_FILE"
+fleet_claim_review && fail "non-JSON review claim response must return 1"
+printf 'review' > "$MODE_FILE"
+( FLEET_SERVER="http://127.0.0.1:9" fleet_claim_review ) && fail "server down must return 1"
+pass "fleet_claim_review returns 1 on empty/garbage/down (PR-walk fallback contract)"
+
+# DEPLOY-SKEW GUARD: a pre-ADR-0019 server strips the unknown `kind` and
+# executes a WORK claim ({ok:true, issue:{...}}, labels already written on a
+# real issue). fleet_claim_review must release that accidental claim
+# (abandoned → the server reverts the labels) and still return 1.
+printf 'claim' > "$MODE_FILE"
+fleet_claim_review && fail "a work-shaped claim response must return 1 (old server)"
+req="$(tail -1 "$LOG_FILE")"
+[ "$(printf '%s' "$req" | jq -r .path)" = "/api/v1/work/release" ] \
+  || fail "skew guard must release the accidental work claim (last request: $req)"
+printf '%s' "$req" | jq -e '.body | fromjson | .issue == 123 and .outcome == "abandoned"' >/dev/null \
+  || fail "skew release must abandon the claimed issue so its labels revert (got: $req)"
+pass "old-server skew: accidental work claim is released abandoned, rc 1 (walk fallback)"
+
+# --- fleet_release_review payloads ----------------------------------------------
+fleet_release_review 456 done || fail "fleet_release_review done must return 0"
+req="$(tail -1 "$LOG_FILE")"
+[ "$(printf '%s' "$req" | jq -r .path)" = "/api/v1/work/release" ] || fail "review release path"
+printf '%s' "$req" | jq -e '.body | fromjson | .kind == "review" and .issue == 456 and .outcome == "done"' >/dev/null \
+  || fail "review release done payload — issue carries the PR number (got: $req)"
+fleet_release_review 456 abandoned || fail "fleet_release_review abandoned must return 0"
+req="$(tail -1 "$LOG_FILE")"
+printf '%s' "$req" | jq -e '.body | fromjson | .kind == "review" and .issue == 456 and .outcome == "abandoned"' >/dev/null \
+  || fail "review release abandoned payload (got: $req)"
+( FLEET_SERVER="http://127.0.0.1:9" fleet_release_review 456 done ) || fail "review release must swallow server failures"
+printf 'claim' > "$MODE_FILE"
+pass "fleet_release_review sends kind:review done/abandoned payloads and swallows failures"
+
 # --- fleet_pop_commands: drain-once + ownership guard --------------------------
 FLEET_CMDS_FILE="$TMP/cmds"
 printf 'pause\nresume\n' > "$FLEET_CMDS_FILE"
@@ -226,5 +309,45 @@ fleet_claim_enabled && fail "409 enrollment must disable fleet claiming (label-p
 rm -f "$FLEET_TOKEN_FILE"
 printf 'claim' > "$MODE_FILE"
 pass "symlinked token file refused; enroll 409 falls back to the label path"
+
+# --- per-identity token files: two identities, one box (ADR-0019) --------------
+# The stored token is keyed by host AND handle: autopilot's WORK login and the
+# distinct REVIEW_GITHUB_TOKEN reviewer must never share a bearer token, or the
+# server's author != handle review rule is enforced against the wrong account.
+unset FLEET_TOKEN FLEET_TOKEN_FILE
+HOME_SAVE="$HOME"; export HOME="$TMP/home"; mkdir -p "$HOME"
+ME="worker-id"
+fleet_claim_enabled || fail "worker identity must auto-enroll"
+worker_file="$(fleet_token_file)"
+case "$worker_file" in
+  *"-worker-id") : ;;
+  *) fail "token file must be keyed by identity (got $worker_file)" ;;
+esac
+[ -f "$worker_file" ] || fail "worker token must be stored at its per-identity path"
+unset FLEET_TOKEN
+ME="reviewer-id"
+reviewer_file="$(fleet_token_file)"
+[ "$reviewer_file" != "$worker_file" ] || fail "distinct identities must not share a token file"
+fleet_claim_enabled || fail "reviewer identity must enroll its OWN token"
+[ -f "$reviewer_file" ] || fail "reviewer token must be stored at its own per-identity path"
+pass "two identities on one host get two token files (no cross-identity reuse)"
+
+# Migration: an identity enrolled before per-identity keying 409s on
+# re-enroll — its legacy host-only token is adopted once and migrated.
+unset FLEET_TOKEN
+ME="legacy-id"
+rm -f "$(fleet_token_file)"
+legacy_file="$(fleet_legacy_token_file)"
+mkdir -p "$(dirname "$legacy_file")"
+( umask 077; printf 'fgt_legacy0123456789abcdef01234567' > "$legacy_file" )
+printf 'enroll409' > "$MODE_FILE"
+fleet_claim_enabled || fail "enroll 409 with a legacy host-only token on disk must adopt it"
+[ "$FLEET_TOKEN" = "fgt_legacy0123456789abcdef01234567" ] \
+  || fail "adopted token must come from the legacy file (got ${FLEET_TOKEN:-unset})"
+[ -f "$(fleet_token_file)" ] || fail "legacy token must be migrated to the per-identity path"
+printf 'claim' > "$MODE_FILE"
+export HOME="$HOME_SAVE"
+unset ME FLEET_TOKEN
+pass "legacy host-only token adopted + migrated on enroll 409 (single-identity continuity)"
 
 echo "ALL FLEET CLIENT TESTS PASSED"

--- a/server/README.md
+++ b/server/README.md
@@ -241,6 +241,28 @@ curl -s -X POST $URL/api/v1/work/claim -H "$TOK" -H "$JSON" -d '{"stages":["rese
 
 curl -s -X POST $URL/api/v1/work/renew   -H "$TOK" -H "$JSON" -d '{"issue":123}'
 curl -s -X POST $URL/api/v1/work/release -H "$TOK" -H "$JSON" -d '{"issue":123,"outcome":"done","prNumber":456}'
+
+# Review claim (ADR-0019): the oldest open PR needing a review by this identity —
+# not draft/human-only/do-not-automate, not self-authored, not already reviewed at
+# its current head SHA (a commented-only review doesn't count), under the round cap
+# (MAX_REVIEW_ROUNDS, same env the shell reads), not cooling down after an abandoned
+# claim, and verified still open against live GitHub. No labels move on claim: the
+# Redis lease alone (REVIEW_LEASE_TTL_SECONDS, default 3600) arbitrates among
+# enrolled reviewers. Every claim response echoes the `kind` it executed.
+# 200 {ok:true, kind:"review", review:{pr,title,author,headSha,htmlUrl,baseRef,headRef}, assignmentId, leaseTtlSeconds, handle}
+#     {ok:true, kind:"review", review:null} = nothing to review · 429 + retryAfterSeconds = GitHub rate-limited
+# NOTE: enroll each identity separately — the runner's stored token file is keyed by
+# host + handle, and `handle` in the response is who the claim was made FOR; a
+# reviewer must claim with ITS OWN token or the author-≠-reviewer rule is enforced
+# against the wrong account.
+curl -s -X POST $URL/api/v1/work/claim -H "$TOK" -H "$JSON" -d '{"kind":"review"}'
+
+# Release a review: `issue` carries the PR number. "done" on ANY posted verdict —
+# PASS or NEEDS_WORK, the review happened — "abandoned" on failure/interrupt/local
+# skip. No label writes either way (reviews hold none); an unreleased claim just
+# lapses at TTL. An abandoned PR cools down (REVIEW_ABANDON_COOLDOWN_SECONDS,
+# default 900) before it can be dispatched again.
+curl -s -X POST $URL/api/v1/work/release -H "$TOK" -H "$JSON" -d '{"kind":"review","issue":456,"outcome":"done"}'
 ```
 
 `release` with `"outcome":"done"` frees the lease and leaves labels to the normal

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -96,6 +96,19 @@ export const config = {
   maxActiveClaims: num(process.env.MAX_ACTIVE_CLAIMS, 3),
 
   leaseTtlSeconds: num(process.env.LEASE_TTL_SECONDS, 1800),
+  // Review-claim leases (kind: "review" dispatch — ADR-0019). Longer than the
+  // work lease: one adversarial review round routinely takes an hour.
+  reviewLeaseTtlSeconds: num(process.env.REVIEW_LEASE_TTL_SECONDS, 3600),
+  // A review claim the runner released `abandoned` (it skipped the PR locally
+  // — already passed, author==reviewer, parked, crash) cools down for this
+  // long before claimNextReview may serve that PR again. Without it, a PR the
+  // mirror deems eligible but every runner skips sits at the head of the
+  // oldest-first queue and burns one claim per runner per pass, forever.
+  reviewAbandonCooldownSeconds: num(process.env.REVIEW_ABANDON_COOLDOWN_SECONDS, 900),
+  // Review-round cap before a PR is a human maintainer's (#287). Same env var
+  // the shell reads (review_work.sh MAX_REVIEW_ROUNDS) so an operator
+  // override can't diverge the server's cap from the runners'.
+  maxReviewRounds: num(process.env.MAX_REVIEW_ROUNDS, 10),
   // One-shot fleet drain commands (stop/abort) expire after this long, so a
   // handle minted (or a runner restarted) weeks after a drain is never killed
   // by a months-old command. pause/resume represent STATE and persist.

--- a/server/src/github/gh-api.ts
+++ b/server/src/github/gh-api.ts
@@ -46,12 +46,23 @@ export interface GhPull {
   labels: GhLabel[];
   user: GhUser | null;
   html_url: string;
-  head: { ref: string; repo: { full_name: string } | null };
+  head: { ref: string; sha: string; repo: { full_name: string } | null };
   base: { ref: string };
   merged?: boolean;
   merged_at?: string | null;
   created_at: string;
   updated_at: string;
+}
+
+/** Raw REST pull-request review item (subset of
+ *  `GET /repos/{repo}/pulls/{n}/reviews`). REST reports `state` in UPPER
+ *  CASE ("APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED",
+ *  "PENDING"); webhook payloads use lower case — callers normalise. */
+export interface GhReview {
+  user: GhUser | null;
+  state: string;
+  commit_id: string;
+  submitted_at?: string | null;
 }
 
 export interface ListIssuesOpts {
@@ -232,12 +243,34 @@ export class GitHubApi {
     );
   }
 
+  /** `GET /repos/{repo}/pulls/{n}/reviews` — a PR's submitted reviews, oldest
+   *  first. Used by review dispatch's lazy review-state fetch (the pulls LIST
+   *  endpoint doesn't carry reviews, so the mirror fetches them on demand,
+   *  once per head SHA). */
+  async listPullReviews(pr: number, opts: { maxPages?: number; perPage?: number } = {}): Promise<GhReview[]> {
+    const q = new URLSearchParams();
+    q.set("per_page", String(opts.perPage ?? 100));
+    return this.listPaginated<GhReview>(
+      `${this.repoUrl(`/pulls/${pr}/reviews`)}?${q.toString()}`,
+      opts.maxPages ?? this.cfg.maxSyncPages,
+    );
+  }
+
   /** `GET /repos/{repo}/issues/{n}` — one issue, live. Used where GitHub (the
    *  durable truth) must be consulted rather than the possibly-stale mirror,
    *  e.g. before reverting claim labels. */
   async getIssue(issue: number): Promise<GhIssue> {
     const res = await this.request("GET", this.repoUrl(`/issues/${issue}`));
     return (await res.json()) as GhIssue;
+  }
+
+  /** `GET /repos/{repo}/pulls/{n}` — one pull request, live. Review dispatch
+   *  verifies a lease-winning candidate is still OPEN before handing it out:
+   *  a lost `pull_request closed` webhook inside the sync interval would
+   *  otherwise dispatch a merged/closed PR for a full (wasted) agent review. */
+  async getPull(pr: number): Promise<GhPull> {
+    const res = await this.request("GET", this.repoUrl(`/pulls/${pr}`));
+    return (await res.json()) as GhPull;
   }
 
   /** `POST /repos/{repo}/issues/{n}/labels` body `{labels}`. */

--- a/server/src/github/reduce.ts
+++ b/server/src/github/reduce.ts
@@ -23,7 +23,15 @@
 import type { EventKind } from "../protocol.js";
 import type { Orchestrator } from "../orchestrator/stores.js";
 import type { GhIssue, GhPull, GhUser } from "./gh-api.js";
-import { issueDocFromRaw, pullDocFromRaw, type IssueDoc, type PullDoc } from "./sync.js";
+import {
+  issueDocFromRaw,
+  mergeReviewEntriesInto,
+  pullDocFromRaw,
+  pullDocUpdate,
+  type IssueDoc,
+  type PullDoc,
+  type PullReviewEntry,
+} from "./sync.js";
 
 /** A verified webhook delivery, as handed over by routes/webhooks.ts. */
 export interface WebhookDelivery {
@@ -60,7 +68,7 @@ interface WebhookPayload {
   issue?: (GhIssue & { pull_request?: unknown }) | null;
   pull_request?: GhPull | null;
   sender?: GhUser | null;
-  review?: { state?: unknown } | null;
+  review?: { state?: unknown; commit_id?: unknown; submitted_at?: unknown; user?: GhUser | null } | null;
   check_suite?: { conclusion?: unknown; head_branch?: unknown } | null;
   ref?: unknown;
   commits?: unknown;
@@ -98,9 +106,44 @@ async function upsertIssue(orch: Orchestrator, raw: GhIssue | null | undefined):
 
 async function upsertPull(orch: Orchestrator, raw: GhPull | null | undefined): Promise<void> {
   if (!raw || !Number.isInteger(raw.number)) return;
-  await orch.db
-    .collection<PullDoc>("pulls")
-    .replaceOne({ _id: raw.number }, pullDocFromRaw(raw, new Date().toISOString()), { upsert: true });
+  // $set (via the shared pullDocUpdate), NOT replace: the doc's accumulated
+  // `reviews`/`reviewsFetchedFor` must survive every pull_request refresh.
+  const { filter, update } = pullDocUpdate(pullDocFromRaw(raw, new Date().toISOString()));
+  await orch.db.collection<PullDoc>("pulls").updateOne(filter, update, { upsert: true });
+}
+
+const REVIEW_STATES: ReadonlySet<PullReviewEntry["state"]> = new Set([
+  "approved",
+  "changes_requested",
+  "commented",
+  "dismissed",
+]);
+
+/** payload.review → mirror review entry, or null when a field the entry
+ *  needs is missing/unrecognised (partial payloads must never poison the
+ *  doc). Webhook review states are lower case already; lowercase anyway so
+ *  a REST-shaped fixture converges too. */
+function reviewEntryFromPayload(p: WebhookPayload): PullReviewEntry | null {
+  const review = p.review;
+  const reviewer = typeof review?.user?.login === "string" ? review.user.login : null;
+  const state = typeof review?.state === "string" ? review.state.toLowerCase() : "";
+  const commitId = typeof review?.commit_id === "string" ? review.commit_id : null;
+  if (!reviewer || !commitId || !REVIEW_STATES.has(state as PullReviewEntry["state"])) return null;
+  return {
+    reviewer,
+    state: state as PullReviewEntry["state"],
+    commitId,
+    at: typeof review?.submitted_at === "string" ? review.submitted_at : new Date().toISOString(),
+  };
+}
+
+/** Append one review entry to the PR's mirror doc (dedupe + cap via the
+ *  shared CAS merge — a plain findOne→$set here raced both a concurrent
+ *  delivery of another review and dispatch's lazy REST fetch, silently
+ *  dropping entries). No-op when the doc doesn't exist yet — the same
+ *  delivery's upsertPull runs first, so it always does. */
+async function appendPullReview(orch: Orchestrator, pr: number, entry: PullReviewEntry): Promise<void> {
+  await mergeReviewEntriesInto(orch.db.collection<PullDoc>("pulls"), pr, [entry]);
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +174,14 @@ export async function reduceWebhook(orch: Orchestrator, delivery: WebhookDeliver
       return reducePullRequest(orch, action, p, sender);
     case "pull_request_review": {
       await upsertPull(orch, p.pull_request);
+      // Persist the review itself (reviewer/state/commitId) into the pulls
+      // doc — review dispatch reads these to skip PRs already reviewed at
+      // their current head. Dismissals arrive here too (action "dismissed",
+      // review.state "dismissed") and append as their own entry.
+      if (p.pull_request && Number.isInteger(p.pull_request.number)) {
+        const entry = reviewEntryFromPayload(p);
+        if (entry) await appendPullReview(orch, p.pull_request.number, entry);
+      }
       if (action !== "submitted" || !p.pull_request || !Number.isInteger(p.pull_request.number)) return null;
       const state = typeof p.review?.state === "string" ? p.review.state : "";
       const verb =

--- a/server/src/github/sync.ts
+++ b/server/src/github/sync.ts
@@ -54,6 +54,24 @@ export interface IssueDoc {
   syncedAt: string;
 }
 
+/** One submitted review on a PR, as the mirror stores it. `commitId` is the
+ *  head SHA the review was submitted against — review dispatch compares it
+ *  with the PR's CURRENT `headSha` to decide "already reviewed at this
+ *  revision". `state` is the review's CURRENT state, not event history: a
+ *  dismissal supersedes the entry it dismisses (same reviewer+commitId), so
+ *  round counting over these entries matches the shell's GraphQL
+ *  `reviews(states:CHANGES_REQUESTED)` count, which also excludes DISMISSED
+ *  (review_work.sh review_rounds()). */
+export interface PullReviewEntry {
+  reviewer: string;
+  state: "approved" | "changes_requested" | "commented" | "dismissed";
+  commitId: string;
+  at: string;
+}
+
+/** The mirror keeps only the LAST this-many review entries per PR. */
+export const PULL_REVIEWS_CAP = 30;
+
 /** Mirror doc for a pull request (`pulls` collection, `_id` = number). */
 export interface PullDoc {
   _id: number;
@@ -65,6 +83,7 @@ export interface PullDoc {
   user: string | null;
   htmlUrl: string;
   headRef: string;
+  headSha: string;
   headRepoFullName: string | null;
   baseRef: string;
   merged: boolean;
@@ -72,6 +91,79 @@ export interface PullDoc {
   createdAt: string;
   updatedAt: string;
   syncedAt: string;
+  /** Submitted reviews, capped at the last PULL_REVIEWS_CAP. Fed by
+   *  pull_request_review webhooks + review dispatch's lazy fetch; sync never
+   *  backfills these (the REST pulls list doesn't carry them) and never
+   *  clobbers them (pull upserts $set the listed fields only). */
+  reviews?: PullReviewEntry[];
+  /** The head SHA the reviews were last fetched for via
+   *  `GET /pulls/{n}/reviews` — review dispatch fetches at most once per
+   *  head revision. */
+  reviewsFetchedFor?: string;
+}
+
+/** Fold `incoming` review entries into `existing`: dedupe by
+ *  reviewer+commitId keeping the LATEST entry (ties go to `incoming`, so a
+ *  dismissal — same reviewer+commitId, same `submitted_at` as the review it
+ *  dismisses — SUPERSEDES the changes_requested entry instead of coexisting
+ *  with it), order by `at` ascending, cap at the last PULL_REVIEWS_CAP.
+ *  Shared by the webhook reducer and review dispatch's lazy fetch so both
+ *  persist one shape. State is deliberately NOT part of the key: an entry is
+ *  "this reviewer's current standing at this commit", which is what both the
+ *  reviewed-at-head skip and the round count need. */
+export function mergeReviewEntries(
+  existing: PullReviewEntry[] | undefined,
+  incoming: PullReviewEntry[],
+): PullReviewEntry[] {
+  const byKey = new Map<string, PullReviewEntry>();
+  for (const entry of [...(existing ?? []), ...incoming]) {
+    const key = `${entry.reviewer}\u0000${entry.commitId}`;
+    const prior = byKey.get(key);
+    if (!prior || prior.at <= entry.at) byKey.set(key, entry);
+  }
+  return [...byKey.values()]
+    .sort((a, b) => (a.at < b.at ? -1 : a.at > b.at ? 1 : 0))
+    .slice(-PULL_REVIEWS_CAP);
+}
+
+/**
+ * Merge `incoming` review entries into the PR doc's CURRENT `reviews` array
+ * ATOMICALLY (guarded compare-and-set, bounded retries) and return the
+ * merged array, or null when the doc doesn't exist / stays contended.
+ *
+ * Both review-entry writers — the webhook reducer's append and review
+ * dispatch's lazy REST fetch — MUST go through this: a plain
+ * read → mergeReviewEntries → `$set` clobbers whatever the other writer
+ * persisted between the read and the write. Concretely, the lazy fetch used
+ * to erase a review a `pull_request_review` webhook appended while the REST
+ * response was in flight — and because it also stamped
+ * `reviewsFetchedFor: headSha`, nothing ever re-fetched at that head, so the
+ * just-reviewed PR looked unreviewed until the next push. The CAS re-reads
+ * and re-merges on conflict, so concurrent appends always survive.
+ */
+export async function mergeReviewEntriesInto(
+  pulls: Collection<PullDoc>,
+  pr: number,
+  incoming: PullReviewEntry[],
+  extraSet: Partial<Pick<PullDoc, "reviewsFetchedFor">> = {},
+): Promise<PullReviewEntry[] | null> {
+  const MAX_ATTEMPTS = 5;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const doc = await pulls.findOne({ _id: pr }, { projection: { reviews: 1 } });
+    if (!doc) return null; // no mirror doc — nothing to merge into
+    const merged = mergeReviewEntries(doc.reviews, incoming);
+    // The guard matches only while `reviews` still equals what we read
+    // (exact array equality via $eq; `$exists: false` when it was absent).
+    // A rival write in between → matchedCount 0 → re-read and re-merge.
+    const guard: Parameters<typeof pulls.updateOne>[0] =
+      doc.reviews === undefined
+        ? { _id: pr, reviews: { $exists: false } }
+        : { _id: pr, reviews: { $eq: doc.reviews } };
+    const res = await pulls.updateOne(guard, { $set: { reviews: merged, ...extraSet } });
+    if (res.matchedCount === 1) return merged;
+  }
+  console.error(`sync: review-entry merge for PR #${pr} stayed contended after 5 attempts`);
+  return null;
 }
 
 interface SyncStateDoc {
@@ -113,6 +205,7 @@ export function pullDocFromRaw(raw: GhPull, syncedAt: string): PullDoc {
     user: raw.user?.login ?? null,
     htmlUrl: raw.html_url,
     headRef: raw.head?.ref ?? "",
+    headSha: raw.head?.sha ?? "",
     headRepoFullName: raw.head?.repo?.full_name ?? null,
     baseRef: raw.base?.ref ?? "",
     merged: Boolean(raw.merged ?? raw.merged_at != null),
@@ -147,10 +240,19 @@ async function upsertIssues(orch: Orchestrator, docs: IssueDoc[]): Promise<numbe
   return docs.length;
 }
 
+/** Split a PullDoc into filter + $set fields. Pull upserts $set (NOT
+ *  replace) so `reviews`/`reviewsFetchedFor` — which only webhooks and the
+ *  lazy review fetch write — survive every sync/webhook refresh. Exported so
+ *  the webhook reducer's pull upsert stays convergent with sync's. */
+export function pullDocUpdate(doc: PullDoc): { filter: { _id: number }; update: { $set: Omit<PullDoc, "_id"> } } {
+  const { _id, ...fields } = doc;
+  return { filter: { _id }, update: { $set: fields } };
+}
+
 async function upsertPulls(orch: Orchestrator, docs: PullDoc[]): Promise<number> {
   if (docs.length === 0) return 0;
   await pullsCol(orch).bulkWrite(
-    docs.map((doc) => ({ replaceOne: { filter: { _id: doc._id }, replacement: doc, upsert: true } })),
+    docs.map((doc) => ({ updateOne: { ...pullDocUpdate(doc), upsert: true } })),
     { ordered: false },
   );
   return docs.length;
@@ -208,6 +310,7 @@ async function routeAndUpsert(
           $setOnInsert: {
             draft: false,
             headRef: "",
+            headSha: "",
             headRepoFullName: null,
             baseRef: "",
             merged: false,

--- a/server/src/orchestrator/dispatch.ts
+++ b/server/src/orchestrator/dispatch.ts
@@ -54,10 +54,11 @@ import { ObjectId } from "mongodb";
 import type { Collection } from "mongodb";
 import { config } from "../config.js";
 import { GitHubApiError } from "../github/gh-api.js";
-import type { ClaimedIssue } from "../protocol.js";
+import { mergeReviewEntriesInto, PULL_REVIEWS_CAP, type PullDoc, type PullReviewEntry } from "../github/sync.js";
+import type { ClaimedIssue, ClaimedReview } from "../protocol.js";
 import type { FleetStore } from "../state.js";
 import type { AgentTier } from "./auth.js";
-import { leaseKey, type Orchestrator } from "./stores.js";
+import { leaseKey, reviewCooldownKey, reviewLeaseKey, type Orchestrator } from "./stores.js";
 
 const AVAILABLE_LABEL = "status: available";
 const CLAIMED_LABEL = "status: claimed";
@@ -68,6 +69,30 @@ const STREAM_PREFIX = "stream:";
 /** The stages dispatch may ever serve — discover is excluded by construction
  *  (ADR-0014 capability floor; frame_work.sh owns discover roots). */
 const DISPATCHABLE_STAGES = ["research", "ideate", "build"] as const;
+
+// Review dispatch (kind: "review", ADR-0019) — the skip rules replicate
+// scripts/review_work.sh; citations name the shell symbol first (grep for
+// it) with the line number of THIS branch's file as a secondary hint.
+/** review_work.sh HUMAN_ONLY_LABEL (L84): PRs a human maintainer reviews and
+ *  merges — never this loop (also skipped in review_one's human-only case,
+ *  L434–439). */
+const HUMAN_ONLY_LABEL = "review: human-only";
+/** review_work.sh REVIEW_CLAIMING_LABEL (L83): a walk-based reviewer is
+ *  holding this PR (label-path claim, claim_pr(), L136–170). Dispatch skips
+ *  it rather than double-reviewing; the walk's own TTL/stale-takeover
+ *  (review_claim_age(), L124–145) frees a crashed walker's label, after
+ *  which the PR becomes dispatchable again. */
+const REVIEW_CLAIMED_LABEL = "review: claimed";
+// The review-round cap is config.maxReviewRounds (env MAX_REVIEW_ROUNDS —
+// the SAME env var the shell reads at review_work.sh L86, so an operator
+// override can't diverge the two); the cap check itself is in
+// claimNextReview, mirroring review_one's round-cap block (L456–470, #287).
+/** Lazy review-state fetch budget: at most this many candidates get a
+ *  `GET /pulls/{n}/reviews` per claim call (spec "Mirror gains review
+ *  state"). Candidates beyond the budget whose review state is unknown are
+ *  skipped this pass — the fetches they got persist, so the next claim
+ *  starts further down the list. */
+const REVIEW_FETCH_BUDGET = 10;
 
 /** Mirror `issues` doc (see the data model in stores.ts / the spec). */
 interface IssueDoc {
@@ -91,6 +116,12 @@ interface IssueDoc {
  *  request — not in the spec's minimum shape, but public and useful. */
 interface AssignmentDoc {
   _id: ObjectId;
+  /** What was claimed. Docs from before review dispatch carry no field —
+   *  absent = "work" (read via kindOf below). */
+  kind?: "work" | "review";
+  /** For kind "work" the issue number; for kind "review" the PR NUMBER
+   *  (GitHub numbers issues and PRs from one sequence, so the two kinds can
+   *  never collide on a number). */
   issueNumber: number;
   handle: string;
   tier: AgentTier;
@@ -135,7 +166,18 @@ export type ClaimResult =
   /** Orchestration up but no githubToken — the route answers 503. */
   | { status: "disabled"; reason: string };
 
+/** claimNextReview's result — shaped like ClaimResult with `review` in place
+ *  of `issue` (the route maps the statuses identically). */
+export type ClaimReviewResult =
+  | { status: "claimed"; review: ClaimedReview; assignmentId: string; leaseTtlSeconds: number }
+  | { status: "capped" }
+  | { status: "empty" }
+  | { status: "rate-limited"; retryAfterSeconds: number }
+  | { status: "disabled"; reason: string };
+
 export type ReleaseOutcome = "done" | "abandoned" | "lease-expired" | "admin-released";
+
+export type AssignmentKind = "work" | "review";
 
 const nowIso = () => new Date().toISOString();
 
@@ -143,8 +185,32 @@ function issuesCol(orch: Orchestrator): Collection<IssueDoc> {
   return orch.db.collection<IssueDoc>("issues");
 }
 
+function pullsCol(orch: Orchestrator): Collection<PullDoc> {
+  return orch.db.collection<PullDoc>("pulls");
+}
+
 function assignmentsCol(orch: Orchestrator): Collection<AssignmentDoc> {
   return orch.db.collection<AssignmentDoc>("assignments");
+}
+
+/** An assignment's kind — docs from before review dispatch default "work". */
+function kindOf(doc: Pick<AssignmentDoc, "kind">): AssignmentKind {
+  return doc.kind ?? "work";
+}
+
+/** Mongo filter clause matching assignments of `kind` (absent = work). */
+function kindFilter(kind: AssignmentKind): Record<string, unknown> {
+  return kind === "review" ? { kind: "review" } : { kind: { $ne: "review" } };
+}
+
+/** The Redis lease key an assignment doc arbitrates on. */
+function assignmentLeaseKey(doc: Pick<AssignmentDoc, "kind" | "issueNumber">): string {
+  return kindOf(doc) === "review" ? reviewLeaseKey(doc.issueNumber) : leaseKey(doc.issueNumber);
+}
+
+/** The lease TTL for an assignment kind. */
+function kindLeaseTtl(kind: AssignmentKind): number {
+  return kind === "review" ? config.reviewLeaseTtlSeconds : config.leaseTtlSeconds;
 }
 
 /** First "stage: <s>" label value, or null (fg-common.sh `label_field`). */
@@ -265,8 +331,8 @@ function toClaimedIssue(doc: IssueDoc): ClaimedIssue {
 const RELEASE_LEASE_LUA =
   'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end';
 
-async function delLeaseIfOwned(orch: Orchestrator, issue: number, assignmentId: string): Promise<void> {
-  await orch.redis.eval(RELEASE_LEASE_LUA, 1, leaseKey(issue), assignmentId);
+async function delLeaseIfOwned(orch: Orchestrator, key: string, assignmentId: string): Promise<void> {
+  await orch.redis.eval(RELEASE_LEASE_LUA, 1, key, assignmentId);
 }
 
 /** Claim the next eligible issue for this agent (see module doc for the
@@ -320,7 +386,7 @@ export async function claimNext(
         // 404: the live issue is no longer "status: available" — a rival
         // claimed it or the mirror is stale. Nothing was written; free the
         // lease, refresh the mirror doc best-effort, next candidate.
-        await delLeaseIfOwned(orch, n, idStr).catch(() => undefined);
+        await delLeaseIfOwned(orch, leaseKey(n), idStr).catch(() => undefined);
         continue;
       }
       step = 1; // available removed — from here, undo means re-adding it
@@ -352,7 +418,7 @@ export async function claimNext(
       };
       if (err instanceof GitHubApiError && err.isRateLimit) {
         await undoPartialWrites();
-        await delLeaseIfOwned(orch, n, idStr).catch(() => undefined);
+        await delLeaseIfOwned(orch, leaseKey(n), idStr).catch(() => undefined);
         return { status: "rate-limited", retryAfterSeconds: err.retryAfterSeconds ?? 60 };
       }
       if (err instanceof GitHubApiError && err.status === 403) {
@@ -363,17 +429,17 @@ export async function claimNext(
         // than burning one failing GitHub write per candidate across the
         // whole queue.
         await undoPartialWrites();
-        await delLeaseIfOwned(orch, n, idStr).catch(() => undefined);
+        await delLeaseIfOwned(orch, leaseKey(n), idStr).catch(() => undefined);
         return { status: "disabled", reason: "github token lacks write access" };
       }
       if (err instanceof GitHubApiError && err.status >= 400 && err.status < 500) {
         // Per-issue 4xx: undo, free the lease, try the next candidate.
         await undoPartialWrites();
-        await delLeaseIfOwned(orch, n, idStr).catch(() => undefined);
+        await delLeaseIfOwned(orch, leaseKey(n), idStr).catch(() => undefined);
         continue;
       }
       await undoPartialWrites();
-      await delLeaseIfOwned(orch, n, idStr).catch(() => undefined);
+      await delLeaseIfOwned(orch, leaseKey(n), idStr).catch(() => undefined);
       throw err; // 5xx / network — surface to the route; lease is freed
     }
 
@@ -410,7 +476,7 @@ export async function claimNext(
     } catch (err) {
       await assignmentsCol(orch).deleteOne({ _id: assignmentId }).catch(() => undefined);
       await revertClaimLabels(orch, n, ctx.handle).catch(() => undefined);
-      await delLeaseIfOwned(orch, n, idStr).catch(() => undefined);
+      await delLeaseIfOwned(orch, leaseKey(n), idStr).catch(() => undefined);
       throw err; // the route answers 5xx honestly — the claim did NOT happen
     }
 
@@ -431,6 +497,248 @@ export async function claimNext(
   return { status: "empty" };
 }
 
+/** REST review states (UPPER CASE) → mirror entry states. "PENDING" is an
+ *  unsubmitted draft, not review state — it maps to nothing and is dropped. */
+const REST_REVIEW_STATES: Record<string, PullReviewEntry["state"]> = {
+  APPROVED: "approved",
+  CHANGES_REQUESTED: "changes_requested",
+  COMMENTED: "commented",
+  DISMISSED: "dismissed",
+};
+
+function toClaimedReview(doc: PullDoc): ClaimedReview {
+  return {
+    pr: doc.number,
+    title: doc.title,
+    author: doc.user,
+    headSha: doc.headSha,
+    htmlUrl: doc.htmlUrl,
+    baseRef: doc.baseRef,
+    headRef: doc.headRef,
+  };
+}
+
+/**
+ * Claim the next open PR needing an adversarial review (kind: "review",
+ * ADR-0019) — claimNext's shape, minus the GitHub label writes: the Redis
+ * lease `lease:review:<pr>` is the ONLY claim artifact (reviews hold no
+ * labels), so a claim costs zero GitHub writes and at most a few lazy
+ * review-state READS plus one liveness read for the winning candidate.
+ *
+ * Candidate selection approximates review_work.sh's skip rules over the
+ * mirror (shell symbols + this branch's line numbers cited inline): open,
+ * non-draft PRs (open_prs_needing_review(), L389–392) without
+ * "review: human-only" (the jq filter at L391 + review_one's case at
+ * L434–439), "do-not-automate", or a walk-based reviewer's "review: claimed"
+ * (claim_pr(), L136–170); never authored by the claiming handle (the
+ * INTEGRITY check, L441–447); not already reviewed at the current head
+ * (the check_state block, L448–455 — see the honest-divergence note at the
+ * skip below); under the review-round cap (L456–470, #287); and not inside
+ * the post-abandon cooldown (no shell equivalent — it stops a PR every
+ * runner locally skips from pinning the head of this deterministic queue).
+ * Oldest createdAt first, PR number as the deterministic tie-break. The
+ * winning candidate is verified still open against LIVE GitHub before it is
+ * handed out — a stale mirror (lost `closed` webhook) must not cost a full
+ * agent review of a merged PR.
+ */
+export async function claimNextReview(
+  orch: Orchestrator,
+  store: FleetStore,
+  ctx: ClaimContext,
+): Promise<ClaimReviewResult> {
+  const gh = orch.gh;
+  if (!gh) return { status: "disabled", reason: "no github token" };
+
+  // Same anti-grief bound as claimNext, over BOTH kinds: one handle holds at
+  // most maxActiveClaims live assignments, work and reviews combined.
+  const activeCount = await assignmentsCol(orch).countDocuments({ handle: ctx.handle, active: true });
+  if (activeCount >= config.maxActiveClaims) return { status: "capped" };
+
+  const open = await pullsCol(orch).find({ state: "open" }).toArray();
+  const candidates = open
+    .filter(
+      (p) =>
+        !p.draft &&
+        !(p.labels ?? []).includes(HUMAN_ONLY_LABEL) &&
+        !(p.labels ?? []).includes(DO_NOT_AUTOMATE_LABEL) &&
+        !(p.labels ?? []).includes(REVIEW_CLAIMED_LABEL) &&
+        p.user !== ctx.handle,
+    )
+    .sort((a, b) => {
+      if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+      return a.number - b.number;
+    });
+
+  // Post-abandon cooldowns, one MGET for the whole candidate page: a PR whose
+  // last claim was released `abandoned` (the runner skipped it locally —
+  // already passed at head, author == the runner's gh identity, parked) is
+  // parked out of dispatch for reviewAbandonCooldownSeconds. Without this,
+  // the oldest such PR is re-served to every runner on every pass: claim →
+  // local skip → abandon → re-claim, burning a claim + an assignment doc per
+  // runner per pass while never converging.
+  const cooldowns =
+    candidates.length > 0
+      ? await orch.redis.mget(candidates.map((c) => reviewCooldownKey(c.number)))
+      : [];
+
+  const ttl = config.reviewLeaseTtlSeconds;
+  let fetchBudget = REVIEW_FETCH_BUDGET;
+
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i];
+    if (!candidate) continue; // noUncheckedIndexedAccess appeasement — i is in range
+    const n = candidate.number;
+    if (cooldowns[i] !== null && cooldowns[i] !== undefined) continue; // cooling down after an abandoned claim
+
+    // A partially-upserted doc (sync's /issues fallback path) carries no
+    // head SHA yet — "reviewed at this revision" can't be evaluated and the
+    // runner can't check the head out. Skip; the next full sync repairs it.
+    const headSha = candidate.headSha;
+    if (!headSha) continue;
+
+    // Lazy review-state fetch: the REST pulls list never carries reviews, so
+    // a doc with NO data for its current head gets one GET /pulls/:n/reviews,
+    // persisted with reviewsFetchedFor = headSha (fetch once per revision).
+    // Bounded to REVIEW_FETCH_BUDGET candidates per claim call.
+    let reviews = candidate.reviews ?? [];
+    const hasDataForHead =
+      candidate.reviewsFetchedFor === headSha || reviews.some((r) => r.commitId === headSha);
+    if (!hasDataForHead) {
+      if (fetchBudget <= 0) continue; // state unknown, budget spent — next claim resumes here
+      fetchBudget--;
+      let fetched;
+      try {
+        fetched = await gh.listPullReviews(n);
+      } catch (err) {
+        if (err instanceof GitHubApiError && err.isRateLimit) {
+          return { status: "rate-limited", retryAfterSeconds: err.retryAfterSeconds ?? 60 };
+        }
+        // A read failure on ONE candidate (PR deleted → 404, transient 5xx)
+        // must not fail the whole claim: skip it without persisting
+        // reviewsFetchedFor, so a later pass retries the fetch.
+        console.error(`dispatch: review-state fetch failed for PR #${n}:`, err);
+        continue;
+      }
+      const entries: PullReviewEntry[] = [];
+      for (const r of fetched) {
+        const state = REST_REVIEW_STATES[(r.state ?? "").toUpperCase()];
+        if (!state || !r.user?.login || !r.commit_id) continue;
+        entries.push({ reviewer: r.user.login, state, commitId: r.commit_id, at: r.submitted_at ?? nowIso() });
+      }
+      // Guarded CAS merge (shared with the webhook reducer): a plain $set of
+      // a locally-merged array would erase a review a pull_request_review
+      // webhook appended between the REST response and this write — and with
+      // reviewsFetchedFor stamped, nothing would re-fetch at this head, so
+      // the just-reviewed PR would be re-dispatched until the next push.
+      const merged = await mergeReviewEntriesInto(pullsCol(orch), n, entries, {
+        reviewsFetchedFor: headSha,
+      });
+      if (merged === null) continue; // doc vanished / hyper-contended — retry next claim
+      reviews = merged;
+    }
+
+    // Reviewed at this revision? The shell keys this off the per-commit
+    // "for-good/adversarial-review" STATUS (check_state block, review_one
+    // L448–455): skip on success (passed) or failure (waiting on rework) —
+    // the mirror approximates that with review objects. "commented" is
+    // deliberately NOT treated as reviewed: an inline-comment review sets no
+    // commit status, so the shell's check_state stays "none" and the walk
+    // WOULD review the PR — a drive-by comment must not starve it from
+    // dispatch. "approved" ≈ status success, "changes_requested" ≈ status
+    // failure, and "dismissed" keeps the skip because a dismissal does not
+    // clear the failure status at that SHA. A NEW head (rework pushed)
+    // carries no matching commitId, so the PR becomes eligible again.
+    if (reviews.some((r) => r.commitId === headSha && r.state !== "commented")) continue;
+
+    // Review-round cap (review_one's round-cap block, L456–470, #287):
+    // at/over config.maxReviewRounds change-requesting rounds the PR is a
+    // human maintainer's — never dispatch an (N+1)th agent round. Dismissed
+    // rounds don't count (mergeReviewEntries supersedes a CR entry with its
+    // dismissal), matching the shell's GraphQL states:CHANGES_REQUESTED
+    // count. When the entry array sits AT its storage cap the true count is
+    // unknowable from the mirror (older CR entries may have been evicted) —
+    // fail toward parking, exactly like review_rounds() echoing the cap on a
+    // gh error: skip the candidate and leave it to the walk.
+    if (reviews.length >= PULL_REVIEWS_CAP) continue;
+    if (reviews.filter((r) => r.state === "changes_requested").length >= config.maxReviewRounds) continue;
+
+    const assignmentId = new ObjectId();
+    const idStr = assignmentId.toHexString();
+
+    // The atomic lease IS the claim — no GitHub writes follow it.
+    const took = await orch.redis.set(reviewLeaseKey(n), idStr, "EX", ttl, "NX");
+    if (took !== "OK") continue; // another enrolled reviewer holds it — next candidate
+
+    // LIVENESS: verify the winner is still open before handing it out. The
+    // mirror can miss a close (lost webhook + claim inside the sync
+    // interval); the old walk listed live open PRs so it never dispatched a
+    // merged PR — one live read per CLAIM (not per candidate) keeps that
+    // property and self-heals the stale doc. Fail-open on non-rate-limit
+    // read errors: proceeding is exactly the pre-guard behaviour, and the
+    // runner's own state guard (review_one) still catches it.
+    try {
+      const live = await gh.getPull(n);
+      if (live.state !== "open") {
+        await pullsCol(orch).updateOne(
+          { _id: n },
+          {
+            $set: {
+              state: live.state,
+              merged: Boolean(live.merged ?? live.merged_at != null),
+              mergedAt: live.merged_at ?? null,
+              updatedAt: live.updated_at ?? nowIso(),
+            },
+          },
+        );
+        await delLeaseIfOwned(orch, reviewLeaseKey(n), idStr).catch(() => undefined);
+        continue;
+      }
+    } catch (err) {
+      if (err instanceof GitHubApiError && err.isRateLimit) {
+        await delLeaseIfOwned(orch, reviewLeaseKey(n), idStr).catch(() => undefined);
+        return { status: "rate-limited", retryAfterSeconds: err.retryAfterSeconds ?? 60 };
+      }
+      console.error(`dispatch: liveness check failed for PR #${n} (dispatching anyway):`, err);
+    }
+
+    const now = nowIso();
+    const assignment: AssignmentDoc = {
+      _id: assignmentId,
+      kind: "review",
+      issueNumber: n, // the PR number — see AssignmentDoc.issueNumber
+      handle: ctx.handle,
+      tier: ctx.tier,
+      ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
+      ...(ctx.harness ? { harness: ctx.harness } : {}),
+      ...(ctx.model ? { model: ctx.model } : {}),
+      claimedAt: now,
+      renewedAt: now,
+      active: true,
+    };
+    try {
+      await assignmentsCol(orch).insertOne(assignment);
+    } catch (err) {
+      await delLeaseIfOwned(orch, reviewLeaseKey(n), idStr).catch(() => undefined);
+      throw err; // the route answers 5xx honestly — the claim did NOT happen
+    }
+
+    store.addEvent("claim", `@${ctx.handle} claimed the review of PR #${n} — ${candidate.title}`, {
+      handle: ctx.handle,
+      ...(ctx.harness ? { harness: ctx.harness } : {}),
+      ref: `#${n}`,
+    });
+
+    return {
+      status: "claimed",
+      review: toClaimedReview(candidate),
+      assignmentId: idStr,
+      leaseTtlSeconds: ttl,
+    };
+  }
+
+  return { status: "empty" };
+}
+
 /** Compare-and-EXPIRE: extend the lease only while it still belongs to this
  *  assignment — never extend a rival's lease or a sweeper's takeover
  *  sentinel. Atomic, so there is no GET→EXPIRE gap to race through. */
@@ -439,46 +747,50 @@ const RENEW_LEASE_LUA =
 
 async function expireLeaseIfOwned(
   orch: Orchestrator,
-  issue: number,
+  key: string,
   owner: string,
+  ttlSeconds: number,
 ): Promise<boolean> {
   const extended = (await orch.redis.eval(
     RENEW_LEASE_LUA,
     1,
-    leaseKey(issue),
+    key,
     owner,
-    String(config.leaseTtlSeconds),
+    String(ttlSeconds),
   )) as number;
   return extended === 1;
 }
 
-/** Extend the lease for this handle's active assignment on the issue.
- *  Returns false when there is no such active assignment — 404. */
-export async function renewLease(orch: Orchestrator, handle: string, issue: number): Promise<boolean> {
+/** Extend the lease for this handle's active assignment on the issue (or,
+ *  for a kind:"review" assignment, the PR — one number space, so the doc
+ *  found by number decides which lease key/TTL applies). Returns the granted
+ *  TTL in seconds, or null when there is no such active assignment — 404. */
+export async function renewLease(orch: Orchestrator, handle: string, issue: number): Promise<number | null> {
   const assignments = assignmentsCol(orch);
   const doc = await assignments.findOne({ issueNumber: issue, handle, active: true });
-  if (!doc) return false;
+  if (!doc) return null;
 
-  const key = leaseKey(issue);
+  const key = assignmentLeaseKey(doc);
+  const ttl = kindLeaseTtl(kindOf(doc));
   const idStr = doc._id.toHexString();
-  const extended = await expireLeaseIfOwned(orch, issue, idStr);
+  const extended = await expireLeaseIfOwned(orch, key, idStr, ttl);
   if (!extended) {
     // The lease key expired but the sweeper hasn't released the claim yet —
     // re-take it for this assignment. NX so neither a rival's re-claim nor a
     // sweeper's takeover sentinel (sweep:<id>, set atomically in place of a
     // bare exists() check) is ever stolen: exactly one of {renew, sweep} wins.
-    const retaken = await orch.redis.set(key, idStr, "EX", config.leaseTtlSeconds, "NX");
-    if (retaken !== "OK") return false;
+    const retaken = await orch.redis.set(key, idStr, "EX", ttl, "NX");
+    if (retaken !== "OK") return null;
     // If the sweeper released the assignment between our findOne and the
     // re-take, don't resurrect an orphan lease.
     const stillActive = await assignments.findOne({ _id: doc._id, active: true });
     if (!stillActive) {
-      await delLeaseIfOwned(orch, issue, idStr);
-      return false;
+      await delLeaseIfOwned(orch, key, idStr);
+      return null;
     }
   }
   await assignments.updateOne({ _id: doc._id }, { $set: { renewedAt: nowIso() } });
-  return true;
+  return ttl;
 }
 
 type RevertResult = "reverted" | "skipped" | "failed";
@@ -561,9 +873,25 @@ async function finishAssignment(
     },
   );
   if (res.matchedCount === 0) return { finished: false, reverted: false };
-  await delLeaseIfOwned(orch, assignment.issueNumber, opts.leaseValue ?? assignment._id.toHexString());
+  await delLeaseIfOwned(orch, assignmentLeaseKey(assignment), opts.leaseValue ?? assignment._id.toHexString());
+  // An ABANDONED review means the runner claimed the PR and then skipped it
+  // locally (already passed at head, author == its posting identity, parked
+  // for a human, crash) — mirror state the server couldn't see. Re-serving
+  // the PR immediately would hand the deterministic oldest-first queue's
+  // head to every runner in a claim → skip → abandon loop, so park it out of
+  // dispatch for a cooldown instead (the walk can still reach it).
+  // Lease-expired releases deliberately DON'T cool down: the lease TTL
+  // itself already spaced that claim out, and a crashed reviewer's PR should
+  // re-queue promptly (ADR-0019 "back in the review queue").
+  if (kindOf(assignment) === "review" && outcome === "abandoned") {
+    await orch.redis
+      .set(reviewCooldownKey(assignment.issueNumber), assignment.handle, "EX", config.reviewAbandonCooldownSeconds)
+      .catch(() => undefined);
+  }
   let reverted = false;
-  if (opts.revert) {
+  // Label reverts are a kind:"work" concept only — review claims hold no
+  // labels (nothing was written on claim, so there is nothing to revert).
+  if (opts.revert && kindOf(assignment) === "work") {
     const result = await revertClaimLabels(orch, assignment.issueNumber, assignment.handle);
     reverted = result === "reverted";
     if (result === "failed") {
@@ -581,7 +909,10 @@ async function finishAssignment(
  * `lease-expired` / `admin-released` (with revertLabels): add
  * "status: available", remove "status: claimed", remove assignee, DEL lease,
  * mark inactive. `handle` is required for agent-initiated releases (must
- * match the assignment); admin release passes `handle: undefined`.
+ * match the assignment); admin release passes `handle: undefined` (and no
+ * `kind`, matching either — the number space is shared, so the doc found by
+ * number is unambiguous). Kind "review" releases (`issue` = the PR number)
+ * never touch labels for ANY outcome — review claims hold none.
  * Returns false when no matching active assignment exists — 404.
  */
 export async function releaseAssignment(
@@ -590,6 +921,8 @@ export async function releaseAssignment(
   opts: {
     issue: number;
     outcome: ReleaseOutcome;
+    /** Which kind the caller believes it is releasing; omitted = any. */
+    kind?: AssignmentKind;
     handle?: string;
     prNumber?: number;
     /** Admin-release only; agent "abandoned" always reverts. */
@@ -600,6 +933,7 @@ export async function releaseAssignment(
     issueNumber: opts.issue,
     active: true,
     ...(opts.handle ? { handle: opts.handle } : {}),
+    ...(opts.kind ? kindFilter(opts.kind) : {}),
   });
   if (!doc) return false;
 
@@ -615,9 +949,13 @@ export async function releaseAssignment(
   if (!finished) return false;
 
   const text =
-    opts.outcome === "done"
-      ? `@${doc.handle} finished #${opts.issue}${opts.prNumber ? ` → PR #${opts.prNumber}` : ""}`
-      : `@${doc.handle}'s claim on #${opts.issue} released (${opts.outcome})`;
+    kindOf(doc) === "review"
+      ? opts.outcome === "done"
+        ? `@${doc.handle} finished reviewing PR #${opts.issue}`
+        : `@${doc.handle}'s review claim on PR #${opts.issue} released (${opts.outcome})`
+      : opts.outcome === "done"
+        ? `@${doc.handle} finished #${opts.issue}${opts.prNumber ? ` → PR #${opts.prNumber}` : ""}`
+        : `@${doc.handle}'s claim on #${opts.issue} released (${opts.outcome})`;
   store.addEvent("claim", text, { handle: doc.handle, ref: `#${opts.issue}` });
   return true;
 }
@@ -634,22 +972,34 @@ export async function renewLeasesForHandle(orch: Orchestrator, handle: string): 
   try {
     const active = await assignmentsCol(orch).find({ handle, active: true }).toArray();
     for (const doc of active) {
-      const issue = await issuesCol(orch).findOne(
-        { _id: doc.issueNumber },
-        { projection: { labels: 1, assignees: 1 } },
-      );
-      // The assignee check only applies when the claim actually set one —
-      // auto-enrolled outside contributors can't be assignees on GitHub
-      // (assigneeSet:false), so for them "still claimed" is label-only.
-      const expectAssignee = doc.assigneeSet !== false;
-      if (
-        !issue ||
-        !(issue.labels ?? []).includes(CLAIMED_LABEL) ||
-        (expectAssignee && !(issue.assignees ?? []).includes(doc.handle))
-      ) {
-        continue; // no longer claimed by this handle — let the lease lapse
+      // The claimed-label mirror guard applies ONLY to kind "work" — a review
+      // claim writes no labels/assignees anywhere, so there is no mirror
+      // state to cross-check; an active review assignment renews while the
+      // agent heartbeats (compare-and-EXPIRE on lease:review:<n>, so a lapsed
+      // lease is still never resurrected).
+      if (kindOf(doc) === "work") {
+        const issue = await issuesCol(orch).findOne(
+          { _id: doc.issueNumber },
+          { projection: { labels: 1, assignees: 1 } },
+        );
+        // The assignee check only applies when the claim actually set one —
+        // auto-enrolled outside contributors can't be assignees on GitHub
+        // (assigneeSet:false), so for them "still claimed" is label-only.
+        const expectAssignee = doc.assigneeSet !== false;
+        if (
+          !issue ||
+          !(issue.labels ?? []).includes(CLAIMED_LABEL) ||
+          (expectAssignee && !(issue.assignees ?? []).includes(doc.handle))
+        ) {
+          continue; // no longer claimed by this handle — let the lease lapse
+        }
       }
-      const extended = await expireLeaseIfOwned(orch, doc.issueNumber, doc._id.toHexString());
+      const extended = await expireLeaseIfOwned(
+        orch,
+        assignmentLeaseKey(doc),
+        doc._id.toHexString(),
+        kindLeaseTtl(kindOf(doc)),
+      );
       if (extended) {
         await assignmentsCol(orch).updateOne({ _id: doc._id }, { $set: { renewedAt: nowIso() } });
       }
@@ -684,27 +1034,32 @@ export async function sweepExpiredLeases(orch: Orchestrator, store: FleetStore):
       try {
         const sentinel = `sweep:${doc._id.toHexString()}`;
         const took = await orch.redis.set(
-          leaseKey(doc.issueNumber),
+          assignmentLeaseKey(doc),
           sentinel,
           "EX",
           SWEEP_SENTINEL_TTL_SECONDS,
           "NX",
         );
         if (took !== "OK") continue; // a lease exists (live, or just re-taken by renew)
+        // Kind "review": no label revert (review claims hold no labels) —
+        // the PR simply becomes claimable again once the lease is gone.
+        const isReview = kindOf(doc) === "review";
         const { finished, reverted } = await finishAssignment(orch, doc, "lease-expired", {
-          revert: true,
+          revert: !isReview,
           leaseValue: sentinel,
         });
         if (!finished) {
-          await delLeaseIfOwned(orch, doc.issueNumber, sentinel).catch(() => undefined);
+          await delLeaseIfOwned(orch, assignmentLeaseKey(doc), sentinel).catch(() => undefined);
           continue;
         }
         expired++;
         store.addEvent(
           "claim",
-          reverted
-            ? `lease expired — #${doc.issueNumber} is back in the queue (was @${doc.handle})`
-            : `lease expired — released @${doc.handle}'s claim on #${doc.issueNumber} (labels left as-is)`,
+          isReview
+            ? `review lease expired — PR #${doc.issueNumber} back in the review queue (was @${doc.handle})`
+            : reverted
+              ? `lease expired — #${doc.issueNumber} is back in the queue (was @${doc.handle})`
+              : `lease expired — released @${doc.handle}'s claim on #${doc.issueNumber} (labels left as-is)`,
           { handle: doc.handle, ref: `#${doc.issueNumber}` },
         );
       } catch (err) {

--- a/server/src/orchestrator/stores.ts
+++ b/server/src/orchestrator/stores.ts
@@ -30,6 +30,23 @@ export function leaseKey(issue: number): string {
   return `lease:issue:${issue}`;
 }
 
+/** Redis key for a PR's review-claim lease (`SET NX EX
+ *  reviewLeaseTtlSeconds`). Distinct namespace from `lease:issue:` so a work
+ *  claim and a review claim can never collide on a number. */
+export function reviewLeaseKey(pr: number): string {
+  return `lease:review:${pr}`;
+}
+
+/** Redis key parking a PR out of review dispatch after an ABANDONED review
+ *  release (`SET EX reviewAbandonCooldownSeconds`). A runner that claims a
+ *  PR and then skips it locally (already passed at head, author == its gh
+ *  identity, parked for a human) releases `abandoned`; without a cooldown
+ *  the deterministic oldest-first queue re-serves that same PR to every
+ *  runner on every pass. */
+export function reviewCooldownKey(pr: number): string {
+  return `cooldown:review:${pr}`;
+}
+
 /** Redis key holding one handle's current command (JSON, or unset). */
 export function commandKey(handle: string): string {
   return `cmd:${handle}`;

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -273,6 +273,10 @@ export const enrollRequestSchema = z.object({
 export type EnrollRequest = z.infer<typeof enrollRequestSchema>;
 
 export const claimRequestSchema = z.object({
+  /** What to claim: "work" = the next available issue (the default, and the
+   *  only kind before ADR-0019); "review" = the next open PR needing an
+   *  adversarial review. `stages` only applies to kind "work". */
+  kind: z.enum(["work", "review"]).default("work"),
   stages: z.array(z.enum(["research", "ideate", "build"])).optional(), // default: all three
   harness: z.string().max(32).optional(),
   model: z.string().max(128).optional(),
@@ -281,6 +285,9 @@ export const claimRequestSchema = z.object({
 export type ClaimRequest = z.infer<typeof claimRequestSchema>;
 
 export const releaseRequestSchema = z.object({
+  /** For kind "review", `issue` carries the PR number (one GitHub number
+   *  space — a number is never both an issue and a PR). */
+  kind: z.enum(["work", "review"]).default("work"),
   issue: z.number().int().positive(),
   outcome: z.enum(["done", "abandoned"]),
   prNumber: z.number().int().positive().optional(),
@@ -290,6 +297,13 @@ export type ReleaseRequest = z.infer<typeof releaseRequestSchema>;
 export interface ClaimedIssue {
   number: number; title: string; labels: string[]; body: string; htmlUrl: string;
   stage: string | null; stream: string | null;
+}
+
+/** What a kind:"review" claim hands the runner — enough to fetch the PR head
+ *  and run the existing per-PR review flow without any GitHub list calls. */
+export interface ClaimedReview {
+  pr: number; title: string; author: string | null; headSha: string; htmlUrl: string;
+  baseRef: string; headRef: string;
 }
 // Server->agent WS message (agents only, not watchers):
 //   { type: "command", command: FleetCommand }

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -14,10 +14,13 @@
  *    `gh` login, which may differ for bot-handle tokens);
  *    {ok:true, issue:null} when the queue is empty; 503 when no github
  *    token; 429 {ok:false, retryAfterSeconds} on GitHub rate-limit.
+ *    kind:"review" (ADR-0019) answers {ok:true, review: ClaimedReview, ...}
+ *    / {ok:true, review:null} instead, same statuses otherwise.
  *  - POST /api/v1/work/renew   — body {issue}. 404 when this handle has no
- *    active assignment on the issue.
+ *    active assignment on the issue (for reviews, `issue` = the PR number).
  *  - POST /api/v1/work/release — body releaseRequestSchema. done = mark
  *    inactive + DEL lease, labels untouched; abandoned = revert labels too.
+ *    kind:"review" releases never touch labels for either outcome.
  *
  * index.ts registers this only when orchestration is connected (otherwise
  * the paths answer 503 "orchestration disabled").
@@ -28,7 +31,14 @@ import { config } from "../config.js";
 import { GitHubApiError } from "../github/gh-api.js";
 import { IpRateLimiter } from "../guards.js";
 import { bearerToken, enrollAgent, verifyAgentToken, type AgentIdentity } from "../orchestrator/auth.js";
-import { claimNext, releaseAssignment, renewLease, type ClaimResult } from "../orchestrator/dispatch.js";
+import {
+  claimNext,
+  claimNextReview,
+  releaseAssignment,
+  renewLease,
+  type ClaimResult,
+  type ClaimReviewResult,
+} from "../orchestrator/dispatch.js";
 import type { Orchestrator } from "../orchestrator/stores.js";
 import { claimRequestSchema, enrollRequestSchema, releaseRequestSchema } from "../protocol.js";
 import type { FleetStore } from "../state.js";
@@ -103,16 +113,20 @@ export function registerDispatchRoutes(
     if (!parsed.success) {
       return reply.code(400).send({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" });
     }
-    let result: ClaimResult;
+    const ctx = {
+      handle: identity.handle,
+      tier: identity.tier,
+      ...(parsed.data.stages ? { stages: parsed.data.stages } : {}),
+      ...(parsed.data.harness ? { harness: parsed.data.harness } : {}),
+      ...(parsed.data.model ? { model: parsed.data.model } : {}),
+      ...(parsed.data.agentId ? { agentId: parsed.data.agentId } : {}),
+    };
+    let result: ClaimResult | ClaimReviewResult;
     try {
-      result = await claimNext(orch, store, {
-        handle: identity.handle,
-        tier: identity.tier,
-        ...(parsed.data.stages ? { stages: parsed.data.stages } : {}),
-        ...(parsed.data.harness ? { harness: parsed.data.harness } : {}),
-        ...(parsed.data.model ? { model: parsed.data.model } : {}),
-        ...(parsed.data.agentId ? { agentId: parsed.data.agentId } : {}),
-      });
+      result =
+        parsed.data.kind === "review"
+          ? await claimNextReview(orch, store, ctx)
+          : await claimNext(orch, store, ctx);
     } catch (err) {
       // Never serialize upstream error messages to the client — they embed
       // the GitHub API path and upstream error text. Log server-side only.
@@ -122,21 +136,28 @@ export function registerDispatchRoutes(
       }
       return reply.code(500).send({ ok: false, error: "internal error" });
     }
+    // kind:"review" responses carry `review` where work carries `issue` —
+    // same statuses, so a runner's queue-empty/error handling is one path.
+    // Every response ECHOES the kind it executed, so a runner can detect a
+    // server that silently dropped an unknown kind (deploy skew — the
+    // pre-ADR-0019 schema stripped `kind` and ran a WORK claim).
+    const emptyPayload = parsed.data.kind === "review" ? { review: null } : { issue: null };
     switch (result.status) {
       case "claimed":
         return {
           ok: true,
-          issue: result.issue,
+          kind: parsed.data.kind,
+          ...("review" in result ? { review: result.review } : { issue: result.issue }),
           assignmentId: result.assignmentId,
           leaseTtlSeconds: result.leaseTtlSeconds,
           handle: identity.handle,
         };
       case "empty":
-        return { ok: true, issue: null };
+        return { ok: true, kind: parsed.data.kind, ...emptyPayload };
       case "capped":
-        // Shaped like empty (issue:null) so every runner just falls into its
-        // queue-empty path; the reason lets an operator see why.
-        return { ok: true, issue: null, reason: "active-claim-cap" };
+        // Shaped like empty (issue:null / review:null) so every runner just
+        // falls into its queue-empty path; the reason lets an operator see why.
+        return { ok: true, kind: parsed.data.kind, ...emptyPayload, reason: "active-claim-cap" };
       case "rate-limited":
         return reply.code(429).send({
           ok: false,
@@ -156,11 +177,13 @@ export function registerDispatchRoutes(
     if (!parsed.success) {
       return reply.code(400).send({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" });
     }
-    const renewed = await renewLease(orch, identity.handle, parsed.data.issue);
-    if (!renewed) {
+    // renewLease answers the GRANTED TTL (review leases run longer than work
+    // leases), or null when this handle holds nothing active on the number.
+    const grantedTtl = await renewLease(orch, identity.handle, parsed.data.issue);
+    if (grantedTtl === null) {
       return reply.code(404).send({ ok: false, error: "no active assignment for this handle+issue" });
     }
-    return { ok: true, leaseTtlSeconds: config.leaseTtlSeconds };
+    return { ok: true, leaseTtlSeconds: grantedTtl };
   });
 
   app.post("/api/v1/work/release", async (req, reply) => {
@@ -174,6 +197,7 @@ export function registerDispatchRoutes(
     const released = await releaseAssignment(orch, store, {
       issue: parsed.data.issue,
       outcome: parsed.data.outcome,
+      kind: parsed.data.kind,
       handle: identity.handle,
       ...(parsed.data.prNumber ? { prNumber: parsed.data.prNumber } : {}),
     });

--- a/server/src/routes/queue.ts
+++ b/server/src/routes/queue.ts
@@ -76,15 +76,17 @@ export function registerQueueRoutes(
   });
 
   // Who is working on what, right now — the dashboard's "active claims"
-  // panel. Active assignments joined with the mirror's issue titles and the
-  // LIVE Redis lease TTL (a lease near zero with an active doc = a worker
-  // gone quiet; the sweeper will reap it). All public data: the same
-  // labels/assignees GitHub shows, plus timing.
+  // panel. Active assignments joined with the mirror's issue titles (PR
+  // titles for kind:"review" rows) and the LIVE Redis lease TTL (a lease
+  // near zero with an active doc = a worker gone quiet; the sweeper will
+  // reap it). All public data: the same labels/assignees GitHub shows, plus
+  // timing.
   app.get("/api/v1/work/active", async (req, reply) => {
     if (!limiter.allow(req.ip)) return reply.code(429).send({ ok: false, error: "slow down" });
     const active = await orch.db
       .collection<{
         _id: unknown;
+        kind?: "work" | "review";
         issueNumber: number;
         handle: string;
         harness?: string;
@@ -95,25 +97,41 @@ export function registerQueueRoutes(
       }>("assignments")
       .find(
         { active: true },
-        { projection: { issueNumber: 1, handle: 1, harness: 1, model: 1, tier: 1, claimedAt: 1, renewedAt: 1 } },
+        { projection: { kind: 1, issueNumber: 1, handle: 1, harness: 1, model: 1, tier: 1, claimedAt: 1, renewedAt: 1 } },
       )
       .sort({ claimedAt: 1 })
       .toArray();
+    // Review assignments' issueNumber is a PR number — titles come from the
+    // pulls mirror; work titles from issues. One number space, so two maps.
+    const workNumbers = active.filter((a) => a.kind !== "review").map((a) => a.issueNumber);
+    const reviewNumbers = active.filter((a) => a.kind === "review").map((a) => a.issueNumber);
     const titles = new Map<number, { title?: string; labels?: string[] }>(
       (
         await orch.db
           .collection<{ _id: number; title?: string; labels?: string[] }>("issues")
-          .find({ _id: { $in: active.map((a) => a.issueNumber) } }, { projection: { title: 1, labels: 1 } })
+          .find({ _id: { $in: workNumbers } }, { projection: { title: 1, labels: 1 } })
           .toArray()
       ).map((i) => [i._id, i]),
     );
+    const prTitles = new Map<number, { title?: string }>(
+      (
+        await orch.db
+          .collection<{ _id: number; title?: string }>("pulls")
+          .find({ _id: { $in: reviewNumbers } }, { projection: { title: 1 } })
+          .toArray()
+      ).map((p) => [p._id, p]),
+    );
     const work = await Promise.all(
       active.map(async (a) => {
-        const ttl = await orch.redis.ttl(`lease:issue:${a.issueNumber}`).catch(() => -2);
-        const issue = titles.get(a.issueNumber);
-        const stage = (issue?.labels ?? []).find((l) => l.startsWith("stage: "))?.slice(7) ?? null;
+        const kind = a.kind ?? "work";
+        const key = kind === "review" ? `lease:review:${a.issueNumber}` : `lease:issue:${a.issueNumber}`;
+        const ttl = await orch.redis.ttl(key).catch(() => -2);
+        const issue = kind === "review" ? prTitles.get(a.issueNumber) : titles.get(a.issueNumber);
+        const labels = kind === "review" ? [] : ((titles.get(a.issueNumber)?.labels ?? []) as string[]);
+        const stage = labels.find((l) => l.startsWith("stage: "))?.slice(7) ?? null;
         return {
           issue: a.issueNumber,
+          kind,
           title: issue?.title ?? null,
           stage,
           handle: a.handle,

--- a/server/test/dispatch.test.mjs
+++ b/server/test/dispatch.test.mjs
@@ -13,7 +13,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { dockerAvailable, startRedis, startMongo } from "./helpers/containers.mjs";
-import { startMockGitHub, makeIssue } from "./helpers/mock-github.mjs";
+import { startMockGitHub, makeIssue, makePull, makeReview } from "./helpers/mock-github.mjs";
 
 // Must be set BEFORE dist/config.js is imported (config reads env at import
 // time) — hence the dynamic imports inside the test body.
@@ -45,6 +45,46 @@ function mirrorIssue({
     createdAt,
     updatedAt: createdAt,
     syncedAt: createdAt,
+  };
+}
+
+/** Mirror `pulls`-doc shape from the same friendly spec that seeds the mock
+ *  (see mirrorIssue). `reviews`/`reviewsFetchedFor` are the MIRROR fields;
+ *  `restReviews` (makeReview output) seeds the mock's reviews endpoint. */
+function mirrorPull({
+  number,
+  title = `PR #${number}`,
+  state = "open",
+  draft = false,
+  labels = [],
+  user = "octocat",
+  headRef = `branch-${number}`,
+  headSha = `sha-${number}-1`,
+  baseRef = "main",
+  createdAt = "2026-01-01T00:00:00Z",
+  reviews,
+  reviewsFetchedFor,
+}) {
+  return {
+    _id: number,
+    number,
+    title,
+    state,
+    draft,
+    labels,
+    user,
+    htmlUrl: `https://github.com/example/repo/pull/${number}`,
+    headRef,
+    headSha,
+    headRepoFullName: "example/repo",
+    baseRef,
+    merged: false,
+    mergedAt: null,
+    createdAt,
+    updatedAt: createdAt,
+    syncedAt: createdAt,
+    ...(reviews ? { reviews } : {}),
+    ...(reviewsFetchedFor ? { reviewsFetchedFor } : {}),
   };
 }
 
@@ -86,7 +126,7 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
 
   try {
     const { config } = await import("../dist/config.js");
-    const { connectOrchestrator, leaseKey } = await import("../dist/orchestrator/stores.js");
+    const { connectOrchestrator, leaseKey, reviewLeaseKey, reviewCooldownKey } = await import("../dist/orchestrator/stores.js");
     const dispatch = await import("../dist/orchestrator/dispatch.js");
     const { FleetStore } = await import("../dist/state.js");
 
@@ -517,12 +557,12 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
 
       // Age the lease so a successful renew is observable.
       await o.redis.expire(leaseKey(61), 5);
-      assert.equal(await dispatch.renewLease(o, "alice", 61), true);
+      assert.equal(await dispatch.renewLease(o, "alice", 61), config.leaseTtlSeconds, "renew answers the granted TTL");
       const ttl = await o.redis.ttl(leaseKey(61));
       assert.ok(ttl > config.leaseTtlSeconds - 60, `TTL refreshed (got ${ttl})`);
 
-      assert.equal(await dispatch.renewLease(o, "bob", 61), false, "not bob's assignment");
-      assert.equal(await dispatch.renewLease(o, "alice", 999), false, "no such assignment");
+      assert.equal(await dispatch.renewLease(o, "bob", 61), null, "not bob's assignment");
+      assert.equal(await dispatch.renewLease(o, "alice", 999), null, "no such assignment");
     });
 
     await t.test("renewLeasesForHandle refreshes heartbeating agents, never throws", async () => {
@@ -543,14 +583,14 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
 
       // Key expired, assignment still active → re-take succeeds.
       await o.redis.del(leaseKey(112));
-      assert.equal(await dispatch.renewLease(o, "alice", 112), true, "expired key is re-taken");
+      assert.equal(await dispatch.renewLease(o, "alice", 112), config.leaseTtlSeconds, "expired key is re-taken");
       assert.equal(await o.redis.get(leaseKey(112)), claimed.assignmentId, "re-taken for THIS assignment");
       const ttl = await o.redis.ttl(leaseKey(112));
       assert.ok(ttl > config.leaseTtlSeconds - 60, `re-take carries a fresh TTL (got ${ttl})`);
 
       // A rival's lease is never stolen or extended.
       await o.redis.set(leaseKey(112), "rival-assignment-id", "EX", 30);
-      assert.equal(await dispatch.renewLease(o, "alice", 112), false, "rival's lease is untouchable");
+      assert.equal(await dispatch.renewLease(o, "alice", 112), null, "rival's lease is untouchable");
       assert.equal(await o.redis.get(leaseKey(112)), "rival-assignment-id");
       const rivalTtl = await o.redis.ttl(leaseKey(112));
       assert.ok(rivalTtl <= 30, "rival's TTL not extended by our renew");
@@ -559,7 +599,7 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       // renew must answer false so the agent re-claims instead of silently
       // working a claim the sweeper is releasing.
       await o.redis.set(leaseKey(112), `sweep:${claimed.assignmentId}`, "EX", 30);
-      assert.equal(await dispatch.renewLease(o, "alice", 112), false, "sweep sentinel wins the takeover race");
+      assert.equal(await dispatch.renewLease(o, "alice", 112), null, "sweep sentinel wins the takeover race");
       assert.equal(await o.redis.get(leaseKey(112)), `sweep:${claimed.assignmentId}`, "sentinel untouched");
     });
 
@@ -808,6 +848,467 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       assert.equal(assignment.outcome, "admin-released");
     });
 
+    // ---------------------------------------------------- review dispatch
+
+    /** Reset stores + mock and seed PULL fixtures from one spec list.
+     *  `restReviews` (makeReview output) seeds the mock's reviews endpoint;
+     *  `reviews`/`reviewsFetchedFor` seed the MIRROR doc. */
+    async function seedPulls(specs) {
+      await o.redis.flushdb();
+      await o.db.collection("issues").deleteMany({});
+      await o.db.collection("assignments").deleteMany({});
+      await o.db.collection("pulls").deleteMany({});
+      mock.reset();
+      mock.assignableUsers = null;
+      mock.seed({
+        pulls: specs.map(({ restReviews, reviews, reviewsFetchedFor, ...s }) =>
+          makePull({ ...s, reviews: restReviews ?? [] })),
+      });
+      if (specs.length) await o.db.collection("pulls").insertMany(specs.map(mirrorPull));
+    }
+
+    const reviewsFetches = (pr) =>
+      mock.requests.filter((r) => r.method === "GET" && r.path.endsWith(`/pulls/${pr}/reviews`)).length;
+
+    await t.test("claimNextReview: eligibility replicates review_work.sh, claim is lease-only", async () => {
+      const at = (d) => `2026-06-0${d}T00:00:00Z`;
+      await seedPulls([
+        // All of these predate #208 — each would be claimed first if eligible.
+        { number: 201, user: "alice", createdAt: at(1) }, // author == reviewer
+        { number: 202, labels: ["review: human-only"], createdAt: at(1) },
+        { number: 203, draft: true, createdAt: at(1) },
+        { number: 204, createdAt: at(1), reviews: [
+          { reviewer: "bob", state: "approved", commitId: "sha-204-1", at: at(2) },
+        ] }, // approved at current head
+        { number: 205, createdAt: at(1), reviews: [
+          { reviewer: "bob", state: "changes_requested", commitId: "sha-205-1", at: at(2) },
+        ] }, // waiting on rework at current head
+        { number: 206, labels: ["do-not-automate"], createdAt: at(1) },
+        { number: 207, labels: ["review: claimed"], createdAt: at(1) }, // a walk-based reviewer holds it
+        { number: 208, title: "research: finding X", createdAt: at(3), reviewsFetchedFor: "sha-208-1" },
+      ]);
+      const store = new FleetStore();
+
+      const result = await dispatch.claimNextReview(o, store, {
+        handle: "alice",
+        tier: "standard",
+        harness: "claude",
+        model: "claude-fable-5",
+      });
+      assert.equal(result.status, "claimed");
+      assert.deepEqual(result.review, {
+        pr: 208,
+        title: "research: finding X",
+        author: "octocat",
+        headSha: "sha-208-1",
+        htmlUrl: "https://github.com/example/repo/pull/208",
+        baseRef: "main",
+        headRef: "branch-208",
+      });
+      assert.equal(result.leaseTtlSeconds, config.reviewLeaseTtlSeconds);
+
+      // The lease IS the claim: zero GitHub writes, and no review fetches
+      // were needed (204/205 carry data at head; the rest never got that far).
+      assert.equal(mock.calls.length, 0, "review claims never write labels/assignees");
+      assert.equal(await o.redis.get(reviewLeaseKey(208)), result.assignmentId);
+      const ttl = await o.redis.ttl(reviewLeaseKey(208));
+      assert.ok(ttl > 0 && ttl <= config.reviewLeaseTtlSeconds);
+
+      const assignment = await activeAssignment(208);
+      assert.ok(assignment);
+      assert.equal(assignment.kind, "review");
+      assert.equal(assignment.handle, "alice");
+
+      const event = store.recentEvents().find((e) => e.kind === "claim");
+      assert.ok(event, "claim event emitted");
+      assert.ok(event.text.includes("review of PR #208"), event.text);
+
+      // Everything else stays excluded: the queue is now empty for bob too
+      // (208 is leased; 201 is bob-eligible by authorship? no — 201's author
+      // is alice, so for BOB it becomes eligible: prove author-exclusion is
+      // per-claimant by bob claiming 201).
+      const bob = await dispatch.claimNextReview(o, new FleetStore(), { handle: "bob", tier: "standard" });
+      assert.equal(bob.status, "claimed");
+      assert.equal(bob.review.pr, 201, "author exclusion applies per claiming handle");
+
+      const carol = await dispatch.claimNextReview(o, new FleetStore(), { handle: "carol", tier: "standard" });
+      assert.equal(carol.status, "empty", "human-only/draft/reviewed-at-head/do-not-automate/walk-claimed all excluded");
+    });
+
+    await t.test("claimNextReview: rework (new head) makes a changes-requested PR eligible again", async () => {
+      // Reviewed at the OLD head, then the author pushed sha-210-2: the
+      // mirror's reviewsFetchedFor still points at the old head, so dispatch
+      // re-fetches once and finds no review at the CURRENT head.
+      await seedPulls([
+        {
+          number: 210,
+          headSha: "sha-210-2",
+          createdAt: "2026-06-01T00:00:00Z",
+          reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-210-1", at: "2026-06-02T00:00:00Z" }],
+          reviewsFetchedFor: "sha-210-1",
+          restReviews: [makeReview({ reviewer: "bob", state: "CHANGES_REQUESTED", commitId: "sha-210-1" })],
+        },
+      ]);
+      const result = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(result.status, "claimed");
+      assert.equal(result.review.pr, 210);
+      assert.equal(result.review.headSha, "sha-210-2");
+      assert.equal(reviewsFetches(210), 1, "the new head triggered exactly one re-fetch");
+      const doc = await o.db.collection("pulls").findOne({ _id: 210 });
+      assert.equal(doc.reviewsFetchedFor, "sha-210-2", "fetch marker moved to the new head");
+    });
+
+    await t.test("lazy review fetch: once per head, persisted, never re-fetched", async () => {
+      // The mirror doc has NO review data (fresh sync — the pulls list
+      // carries none), but GitHub knows the PR was approved at its head.
+      await seedPulls([
+        {
+          number: 220,
+          createdAt: "2026-06-01T00:00:00Z",
+          restReviews: [
+            makeReview({ reviewer: "bob", state: "APPROVED", commitId: "sha-220-1", submittedAt: "2026-06-02T00:00:00Z" }),
+            makeReview({ reviewer: "bob", state: "PENDING", commitId: "sha-220-1" }), // draft — dropped
+          ],
+        },
+      ]);
+
+      const first = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(first.status, "empty", "the fetch revealed an approval at head — not claimable");
+      assert.equal(reviewsFetches(220), 1);
+      const doc = await o.db.collection("pulls").findOne({ _id: 220 });
+      assert.equal(doc.reviewsFetchedFor, "sha-220-1");
+      assert.deepEqual(doc.reviews, [
+        { reviewer: "bob", state: "approved", commitId: "sha-220-1", at: "2026-06-02T00:00:00Z" },
+      ], "REST states normalised, PENDING dropped, persisted in mirror shape");
+
+      const second = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(second.status, "empty");
+      assert.equal(reviewsFetches(220), 1, "reviewsFetchedFor prevents a re-fetch at the same head");
+    });
+
+    await t.test("two concurrent review claims get distinct PRs", async () => {
+      await seedPulls([
+        { number: 231, createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-231-1" },
+        { number: 232, createdAt: "2026-06-02T00:00:00Z", reviewsFetchedFor: "sha-232-1" },
+      ]);
+      const results = await Promise.all(
+        ["alice", "bob"].map((handle) =>
+          dispatch.claimNextReview(o, new FleetStore(), { handle, tier: "standard" }),
+        ),
+      );
+      for (const r of results) assert.equal(r.status, "claimed");
+      assert.deepEqual(
+        results.map((r) => r.review.pr).sort((a, b) => a - b),
+        [231, 232],
+        "the Redis NX review lease arbitrates — no double-reviews",
+      );
+    });
+
+    await t.test("review release done/abandoned: assignment closed, ZERO GitHub writes", async () => {
+      await seedPulls([
+        { number: 241, createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-241-1" },
+        { number: 242, createdAt: "2026-06-02T00:00:00Z", reviewsFetchedFor: "sha-242-1" },
+      ]);
+      const store = new FleetStore();
+      const first = await dispatch.claimNextReview(o, store, { handle: "alice", tier: "standard" });
+      assert.equal(first.review.pr, 241);
+      const second = await dispatch.claimNextReview(o, store, { handle: "alice", tier: "standard" });
+      assert.equal(second.review.pr, 242);
+      mock.reset(); // count only post-claim GitHub traffic
+
+      // done — the review happened (PASS or NEEDS_WORK both count).
+      assert.equal(
+        await dispatch.releaseAssignment(o, store, { issue: 241, outcome: "done", kind: "review", handle: "alice" }),
+        true,
+      );
+      // abandoned — reviewer crashed/usage-limited; the PR just re-queues.
+      assert.equal(
+        await dispatch.releaseAssignment(o, store, { issue: 242, outcome: "abandoned", kind: "review", handle: "alice" }),
+        true,
+      );
+      assert.equal(mock.calls.length, 0, "neither outcome touches labels — review claims hold none");
+      assert.deepEqual(mock.requests, [], "no GitHub traffic at all (not even the revert's live read)");
+
+      for (const [pr, outcome] of [[241, "done"], [242, "abandoned"]]) {
+        const doc = await anyAssignment(pr);
+        assert.equal(doc.active, false);
+        assert.equal(doc.outcome, outcome);
+        assert.equal(await o.redis.exists(reviewLeaseKey(pr)), 0, `lease freed for PR #${pr}`);
+      }
+
+      assert.equal(
+        await dispatch.releaseAssignment(o, store, { issue: 241, outcome: "done", kind: "review", handle: "alice" }),
+        false,
+        "second release finds no active review assignment",
+      );
+      // A done-release alone does NOT mark the PR reviewed — the POSTED
+      // review does, arriving as a pull_request_review webhook. Simulate
+      // that for #241; #242 was abandoned (no review posted), so it — and
+      // only it — is claimable again once its abandon COOLDOWN lapses (an
+      // abandon usually means the runner skipped the PR locally, so serving
+      // it again immediately would just loop).
+      await o.db.collection("pulls").updateOne(
+        { _id: 241 },
+        { $set: { reviews: [{ reviewer: "alice", state: "approved", commitId: "sha-241-1", at: "2026-06-03T00:00:00Z" }] } },
+      );
+      const cooled = await dispatch.claimNextReview(o, new FleetStore(), { handle: "bob", tier: "standard" });
+      assert.equal(cooled.status, "empty", "an abandoned PR cools down before re-dispatch");
+      await o.redis.del(reviewCooldownKey(242)); // cooldown lapses, deterministically
+      const reclaim = await dispatch.claimNextReview(o, new FleetStore(), { handle: "bob", tier: "standard" });
+      assert.equal(reclaim.status, "claimed");
+      assert.equal(reclaim.review.pr, 242, "the abandoned PR re-queues after the cooldown; the reviewed one is skipped");
+    });
+
+    await t.test("sweeper: expired review lease → inactive, no label writes, review-queue event", async () => {
+      await seedPulls([{ number: 251, createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-251-1" }]);
+      const store = new FleetStore();
+      const claimed = await dispatch.claimNextReview(o, store, { handle: "alice", tier: "standard" });
+      assert.equal(claimed.status, "claimed");
+      mock.reset();
+
+      // Lease still alive → nothing happens.
+      assert.equal(await dispatch.sweepExpiredLeases(o, store), 0);
+      assert.ok(await activeAssignment(251));
+
+      await o.redis.del(reviewLeaseKey(251)); // TTL expiry, deterministically
+      assert.equal(await dispatch.sweepExpiredLeases(o, store), 1);
+
+      const assignment = await anyAssignment(251);
+      assert.equal(assignment.active, false);
+      assert.equal(assignment.outcome, "lease-expired");
+      assert.equal(assignment.revertPending, undefined, "no revert is ever pending for a review");
+      assert.equal(mock.calls.length, 0, "no label writes");
+      assert.deepEqual(mock.requests, [], "no GitHub reads either — nothing to revert");
+      const event = store
+        .recentEvents()
+        .find((e) => e.kind === "claim" && e.text.includes("review lease expired"));
+      assert.ok(event, "expiry surfaces on the fleet feed");
+      assert.ok(event.text.includes("PR #251"), event.text);
+      assert.equal(event.ref, "#251");
+
+      assert.equal(await dispatch.sweepExpiredLeases(o, store), 0, "idempotent");
+    });
+
+    await t.test("renewLeasesForHandle extends an active review lease (no claimed-label guard)", async () => {
+      await seedPulls([{ number: 261, createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-261-1" }]);
+      const claimed = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(claimed.status, "claimed");
+      // No `issues` mirror doc exists for #261 (it's a PR) — the kind:"work"
+      // claimed-label guard would let this lease lapse; review renewal must not.
+      await o.redis.expire(reviewLeaseKey(261), 5);
+      await dispatch.renewLeasesForHandle(o, "alice");
+      const ttl = await o.redis.ttl(reviewLeaseKey(261));
+      assert.ok(ttl > 5, `active review lease renewed by heartbeat hook (ttl=${ttl})`);
+      assert.ok(ttl <= config.reviewLeaseTtlSeconds, "renewed with the REVIEW TTL");
+
+      // Compare-and-EXPIRE only: an expired review lease is never resurrected.
+      await o.redis.del(reviewLeaseKey(261));
+      await dispatch.renewLeasesForHandle(o, "alice");
+      assert.equal(await o.redis.exists(reviewLeaseKey(261)), 0);
+
+      // renewLease (the /work/renew path) answers the review TTL by kind.
+      await dispatch.sweepExpiredLeases(o, new FleetStore()); // release the lapsed claim
+      const reclaimed = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(reclaimed.status, "claimed");
+      assert.equal(await dispatch.renewLease(o, "alice", 261), config.reviewLeaseTtlSeconds);
+    });
+
+    await t.test("abandoned review release parks the PR behind a dispatch cooldown", async () => {
+      // A PR the mirror deems eligible but every runner locally skips
+      // (already passed at head, author == the runner's posting identity,
+      // parked) is abandoned back to the FRONT of the oldest-first queue —
+      // without a cooldown it pins every enrolled reviewer's claim forever.
+      await seedPulls([
+        { number: 281, createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-281-1" },
+        { number: 282, createdAt: "2026-06-02T00:00:00Z", reviewsFetchedFor: "sha-282-1" },
+      ]);
+      const store = new FleetStore();
+      const first = await dispatch.claimNextReview(o, store, { handle: "alice", tier: "standard" });
+      assert.equal(first.review.pr, 281, "oldest first");
+      await dispatch.releaseAssignment(o, store, { issue: 281, outcome: "abandoned", kind: "review", handle: "alice" });
+
+      const ttl = await o.redis.ttl(reviewCooldownKey(281));
+      assert.ok(
+        ttl > 0 && ttl <= config.reviewAbandonCooldownSeconds,
+        `abandon sets cooldown:review:<pr> with the configured TTL (got ${ttl})`,
+      );
+
+      // The very next claim — from ANY handle — skips the cooled-down PR.
+      const second = await dispatch.claimNextReview(o, new FleetStore(), { handle: "bob", tier: "standard" });
+      assert.equal(second.review.pr, 282, "cooled-down PR is not re-served; the queue advances");
+      await dispatch.releaseAssignment(o, new FleetStore(), { issue: 282, outcome: "abandoned", kind: "review", handle: "bob" });
+      const drained = await dispatch.claimNextReview(o, new FleetStore(), { handle: "carol", tier: "standard" });
+      assert.equal(drained.status, "empty", "both abandoned PRs are cooling down");
+
+      // Cooldown lapses → dispatchable again.
+      await o.redis.del(reviewCooldownKey(281));
+      const again = await dispatch.claimNextReview(o, new FleetStore(), { handle: "carol", tier: "standard" });
+      assert.equal(again.review.pr, 281, "the PR returns to dispatch once the cooldown lapses");
+
+      // A lease EXPIRY (crashed reviewer) deliberately does NOT cool down:
+      // the PR should promptly re-queue (ADR-0019).
+      await o.redis.del(reviewLeaseKey(281));
+      await dispatch.sweepExpiredLeases(o, new FleetStore());
+      assert.equal(await o.redis.exists(reviewCooldownKey(281)), 0, "lease-expired sets no cooldown");
+      const requeued = await dispatch.claimNextReview(o, new FleetStore(), { handle: "dave", tier: "standard" });
+      assert.equal(requeued.review.pr, 281, "an expired lease re-queues immediately");
+    });
+
+    await t.test("lazy fetch persist survives a concurrent webhook review append (CAS)", async () => {
+      // The race: dispatch snapshots the doc, calls GET /pulls/:n/reviews,
+      // and a pull_request_review webhook lands BETWEEN the REST response
+      // and the persist. A plain $set of the locally-merged array erased the
+      // webhook's entry — and with reviewsFetchedFor stamped, nothing ever
+      // re-fetched at that head, so the just-reviewed PR was re-dispatched.
+      const { reduceWebhook } = await import("../dist/github/reduce.js");
+      await seedPulls([{ number: 291, createdAt: "2026-06-01T00:00:00Z" }]); // no review data → lazy fetch
+      const raw = makePull({ number: 291, headSha: "sha-291-1", createdAt: "2026-06-01T00:00:00Z" });
+
+      const orig = o.gh.listPullReviews.bind(o.gh);
+      o.gh.listPullReviews = async (...args) => {
+        const out = await orig(...args); // REST answers (empty list)…
+        await reduceWebhook(o, {
+          // …and the webhook for a review submitted at head reduces before
+          // dispatch persists its merge.
+          event: "pull_request_review",
+          action: "submitted",
+          payload: {
+            action: "submitted",
+            pull_request: raw,
+            review: { user: { login: "carol" }, state: "approved", commit_id: "sha-291-1", submitted_at: "2026-06-02T00:00:00Z" },
+            sender: { login: "carol" },
+          },
+        });
+        return out;
+      };
+      try {
+        const result = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+        assert.equal(result.status, "empty", "the merged state shows carol's review at head — not claimable");
+      } finally {
+        delete o.gh.listPullReviews;
+      }
+
+      const doc = await o.db.collection("pulls").findOne({ _id: 291 });
+      assert.deepEqual(
+        doc.reviews,
+        [{ reviewer: "carol", state: "approved", commitId: "sha-291-1", at: "2026-06-02T00:00:00Z" }],
+        "the concurrently-appended webhook entry SURVIVES the lazy-fetch persist",
+      );
+      assert.equal(doc.reviewsFetchedFor, "sha-291-1", "fetch marker still stamped");
+
+      const second = await dispatch.claimNextReview(o, new FleetStore(), { handle: "bob", tier: "standard" });
+      assert.equal(second.status, "empty", "second claim skips the reviewed PR");
+      assert.equal(reviewsFetches(291), 1, "…without re-fetching at the same head");
+    });
+
+    await t.test("a commented-only review at head does not block dispatch (shell parity)", async () => {
+      // review_work.sh keys reviewed-at-revision off the merge-check STATUS
+      // (check_state, success|failure) — an inline-comment review sets no
+      // status, so the walk reviews the PR. Dispatch must not starve it.
+      await seedPulls([
+        // Oldest: dismissed at head — stays skipped (a dismissal does not
+        // clear the shell's failure status at that SHA).
+        { number: 301, createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-301-1", reviews: [
+          { reviewer: "bob", state: "dismissed", commitId: "sha-301-1", at: "2026-06-02T00:00:00Z" },
+        ] },
+        // Commented at head — including by the PR AUTHOR — still needs review.
+        { number: 302, createdAt: "2026-06-02T00:00:00Z", reviewsFetchedFor: "sha-302-1", reviews: [
+          { reviewer: "bob", state: "commented", commitId: "sha-302-1", at: "2026-06-03T00:00:00Z" },
+          { reviewer: "octocat", state: "commented", commitId: "sha-302-1", at: "2026-06-04T00:00:00Z" },
+        ] },
+      ]);
+      const result = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(result.status, "claimed");
+      assert.equal(result.review.pr, 302, "commented-only head is claimable; dismissed-at-head is not");
+      const none = await dispatch.claimNextReview(o, new FleetStore(), { handle: "bob", tier: "standard" });
+      assert.equal(none.status, "empty", "the dismissed-at-head PR stays skipped");
+    });
+
+    await t.test("round cap: dismissals lower the count; an entry array at its cap is not trusted", async () => {
+      const { reduceWebhook } = await import("../dist/github/reduce.js");
+      // #311 sits AT the round cap (10 CR rounds at old heads, none at the
+      // current head) → not dispatched.
+      const crEntries = Array.from({ length: config.maxReviewRounds }, (_, i) => ({
+        reviewer: `rev-${i}`,
+        state: "changes_requested",
+        commitId: "sha-311-1",
+        at: `2026-06-0${(i % 8) + 1}T00:00:00Z`,
+      }));
+      await seedPulls([
+        { number: 311, headSha: "sha-311-2", createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-311-2", reviews: crEntries },
+      ]);
+      const capped = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(capped.status, "empty", "at the round cap the PR is a human's — never dispatched");
+
+      // A maintainer dismisses one stale changes-request (the #307 unwedge):
+      // the webhook's dismissal SUPERSEDES that CR entry, the count drops
+      // under the cap, and the PR becomes dispatchable at its new head —
+      // instead of the mirror counting dismissed rounds forever.
+      await reduceWebhook(o, {
+        event: "pull_request_review",
+        action: "dismissed",
+        payload: {
+          action: "dismissed",
+          pull_request: makePull({ number: 311, headSha: "sha-311-2", createdAt: "2026-06-01T00:00:00Z" }),
+          review: { user: { login: "rev-0" }, state: "dismissed", commit_id: "sha-311-1", submitted_at: "2026-06-01T00:00:00Z" },
+          sender: { login: "maintainer" },
+        },
+      });
+      const doc = await o.db.collection("pulls").findOne({ _id: 311 });
+      assert.equal(
+        doc.reviews.filter((r) => r.state === "changes_requested").length,
+        config.maxReviewRounds - 1,
+        "the dismissal replaced the CR entry rather than coexisting with it",
+      );
+      const freed = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(freed.status, "claimed");
+      assert.equal(freed.review.pr, 311, "dismissal releases the PR back to dispatch");
+      await dispatch.releaseAssignment(o, new FleetStore(), { issue: 311, outcome: "done", kind: "review", handle: "alice" });
+
+      // #312's entry array sits AT the storage cap (PULL_REVIEWS_CAP): older
+      // CR entries may have been evicted, so the mirror's CR count is a
+      // floor, not the truth. Fail toward parking (skip; the walk still
+      // reaches it) — matching review_rounds() echoing the cap on error.
+      const manyEntries = Array.from({ length: 30 }, (_, i) => ({
+        reviewer: `r-${i}`,
+        state: i < 8 ? "changes_requested" : "approved", // visible CRs UNDER the round cap
+        commitId: "sha-312-1",
+        at: `2026-06-${String((i % 27) + 1).padStart(2, "0")}T00:00:00Z`,
+      }));
+      await seedPulls([
+        { number: 312, headSha: "sha-312-2", createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-312-2", reviews: manyEntries },
+      ]);
+      const untrusted = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(untrusted.status, "empty", "a capped entry array is an unreliable rounds source — skipped");
+    });
+
+    await t.test("stale mirror: a merged PR is never dispatched; the live check heals the doc", async () => {
+      // The pull_request `closed` webhook was lost and a reviewer claims
+      // inside the sync interval: the mirror still says open. The old walk
+      // listed LIVE open PRs so this could never happen — the live check on
+      // the lease winner restores that property.
+      await seedPulls([
+        { number: 321, createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-321-1" },
+        { number: 322, createdAt: "2026-06-02T00:00:00Z", reviewsFetchedFor: "sha-322-1" },
+      ]);
+      // GitHub truth: #321 was merged by hand.
+      mock.addPull(makePull({
+        number: 321,
+        state: "closed",
+        merged: true,
+        mergedAt: "2026-06-03T00:00:00Z",
+        createdAt: "2026-06-01T00:00:00Z",
+      }));
+      const result = await dispatch.claimNextReview(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(result.status, "claimed");
+      assert.equal(result.review.pr, 322, "the merged PR is skipped, the next candidate serves");
+      assert.equal(await o.redis.exists(reviewLeaseKey(321)), 0, "the probe lease on the merged PR was freed");
+      const healed = await o.db.collection("pulls").findOne({ _id: 321 });
+      assert.equal(healed.state, "closed", "mirror self-healed from the live read");
+      assert.equal(healed.merged, true);
+      assert.equal(await anyAssignment(321), null, "no assignment recorded for the merged PR");
+    });
+
     // ------------------------------------------------------------- routes
 
     const Fastify = (await import("fastify")).default;
@@ -850,6 +1351,13 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
         { number: 81, title: "research: X", labels: ["status: available", "stage: research"], createdAt: "2026-05-01T00:00:00Z" },
         { number: 82, title: "research: Y", labels: ["status: available", "stage: ideate"], createdAt: "2026-05-02T00:00:00Z" },
       ]);
+      // A review claim shows up alongside work claims, badged by `kind` and
+      // titled from the PULLS mirror (its number is a PR number).
+      await o.db.collection("pulls").insertMany([
+        mirrorPull({ number: 89, title: "feat: Z", createdAt: "2026-05-03T00:00:00Z", reviewsFetchedFor: "sha-89-1" }),
+      ]);
+      mock.addPull(makePull({ number: 89, title: "feat: Z" }));
+
       const claimed = await dispatch.claimNext(o, new FleetStore(), {
         handle: "worker-one",
         tier: "standard",
@@ -857,6 +1365,12 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
         model: "gpt-x",
       });
       assert.equal(claimed.status, "claimed");
+      const reviewClaimed = await dispatch.claimNextReview(o, new FleetStore(), {
+        handle: "reviewer-two",
+        tier: "standard",
+        harness: "claude",
+      });
+      assert.equal(reviewClaimed.status, "claimed");
 
       const app = Fastify();
       apps.push(app);
@@ -864,8 +1378,8 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       const res = await app.inject({ method: "GET", url: "/api/v1/work/active" });
       assert.equal(res.statusCode, 200);
       const body = res.json();
-      assert.equal(body.count, 1);
-      const [row] = body.work;
+      assert.equal(body.count, 2);
+      const row = body.work.find((w) => w.kind === "work");
       assert.equal(row.issue, 81);
       assert.equal(row.title, "research: X");
       assert.equal(row.stage, "research");
@@ -873,9 +1387,24 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       assert.equal(row.harness, "codex");
       assert.equal(typeof row.claimedAt, "string");
       assert.ok(row.leaseSecondsLeft > 0, "live lease TTL surfaced");
+      const reviewRow = body.work.find((w) => w.kind === "review");
+      assert.ok(reviewRow, "review claims appear with kind: review");
+      assert.equal(reviewRow.issue, 89, "`issue` carries the PR number");
+      assert.equal(reviewRow.title, "feat: Z", "title joined from the pulls mirror");
+      assert.equal(reviewRow.stage, null);
+      assert.equal(reviewRow.handle, "reviewer-two");
+      assert.ok(reviewRow.leaseSecondsLeft > 0, "review lease TTL read from lease:review:<n>");
 
-      // Released work leaves the panel.
+      // Released claims leave the panel (each kind independently).
       await dispatch.releaseAssignment(o, new FleetStore(), { handle: "worker-one", issue: 81, outcome: "done" });
+      const afterWork = await app.inject({ method: "GET", url: "/api/v1/work/active" });
+      assert.equal(afterWork.json().count, 1);
+      await dispatch.releaseAssignment(o, new FleetStore(), {
+        handle: "reviewer-two",
+        issue: 89,
+        outcome: "done",
+        kind: "review",
+      });
       const after = await app.inject({ method: "GET", url: "/api/v1/work/active" });
       assert.equal(after.json().count, 0);
     });
@@ -1008,6 +1537,87 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       });
       assert.equal(emptyClaim.statusCode, 200);
       assert.equal(emptyClaim.json().issue, null, "empty queue is ok:true, issue:null");
+    });
+
+    await t.test("work routes, kind review: claim/renew/release round-trip", async () => {
+      const auth = await import("../dist/orchestrator/auth.js");
+      await seedPulls([
+        { number: 271, title: "research: Y", createdAt: "2026-06-01T00:00:00Z", reviewsFetchedFor: "sha-271-1" },
+      ]);
+      const app = Fastify();
+      apps.push(app);
+      registerDispatchRoutes(app, new FleetStore(), o);
+      const { token } = await auth.mintAgentToken(o, { handle: "reviewbot", tier: "standard" });
+      const authz = { authorization: `Bearer ${token}` };
+
+      const claim = await app.inject({
+        method: "POST",
+        url: "/api/v1/work/claim",
+        headers: authz,
+        payload: { kind: "review", harness: "claude" },
+      });
+      assert.equal(claim.statusCode, 200);
+      const claimBody = claim.json();
+      assert.equal(claimBody.ok, true);
+      assert.equal(claimBody.issue, undefined, "review claims carry `review`, not `issue`");
+      assert.deepEqual(claimBody.review, {
+        pr: 271,
+        title: "research: Y",
+        author: "octocat",
+        headSha: "sha-271-1",
+        htmlUrl: "https://github.com/example/repo/pull/271",
+        baseRef: "main",
+        headRef: "branch-271",
+      });
+      assert.ok(claimBody.assignmentId);
+      assert.equal(claimBody.leaseTtlSeconds, config.reviewLeaseTtlSeconds);
+      assert.equal(claimBody.handle, "reviewbot");
+
+      // Renew answers the REVIEW TTL (kind resolved from the assignment).
+      const renew = await app.inject({
+        method: "POST",
+        url: "/api/v1/work/renew",
+        headers: authz,
+        payload: { issue: 271 },
+      });
+      assert.equal(renew.statusCode, 200);
+      assert.equal(renew.json().leaseTtlSeconds, config.reviewLeaseTtlSeconds);
+
+      // Empty review queue answers review:null (the runner's fall-through).
+      const emptyClaim = await app.inject({
+        method: "POST",
+        url: "/api/v1/work/claim",
+        headers: authz,
+        payload: { kind: "review" },
+      });
+      assert.equal(emptyClaim.statusCode, 200);
+      assert.equal(emptyClaim.json().review, null, "empty review queue is ok:true, review:null");
+
+      // Releasing with the WRONG kind must not find the review assignment.
+      const wrongKind = await app.inject({
+        method: "POST",
+        url: "/api/v1/work/release",
+        headers: authz,
+        payload: { issue: 271, outcome: "done" }, // kind defaults to "work"
+      });
+      assert.equal(wrongKind.statusCode, 404, "a review assignment is not releasable as kind work");
+
+      const release = await app.inject({
+        method: "POST",
+        url: "/api/v1/work/release",
+        headers: authz,
+        payload: { kind: "review", issue: 271, outcome: "done" },
+      });
+      assert.equal(release.statusCode, 200);
+      assert.equal(await o.redis.exists(reviewLeaseKey(271)), 0);
+
+      const renewGone = await app.inject({
+        method: "POST",
+        url: "/api/v1/work/renew",
+        headers: authz,
+        payload: { issue: 271 },
+      });
+      assert.equal(renewGone.statusCode, 404, "released review can't be renewed");
     });
 
     await t.test("enroll route: TOFU mint once, 409 after, strict handle shape, config-off → 403", async () => {

--- a/server/test/helpers/mock-github.mjs
+++ b/server/test/helpers/mock-github.mjs
@@ -11,6 +11,9 @@
  *                                               the real /issues endpoint)
  *  - GET    /repos/:repo/issues/:n             (single live issue)
  *  - GET    /repos/:repo/pulls                 (paginated, state filter)
+ *  - GET    /repos/:repo/pulls/:n              (single live pull)
+ *  - GET    /repos/:repo/pulls/:n/reviews      (seeded via makePull's
+ *                                               `reviews` / makeReview)
  *  - POST   /repos/:repo/issues/:n/labels      body {labels:[...]} | [...]
  *  - DELETE /repos/:repo/issues/:n/labels/:name
  *  - POST   /repos/:repo/issues/:n/assignees   body {assignees:[...]} —
@@ -67,7 +70,8 @@ export function makeIssue({
   };
 }
 
-/** Build a GitHub-REST-shaped pull request from a friendly spec. */
+/** Build a GitHub-REST-shaped pull request from a friendly spec. `reviews`
+ *  (makeReview output) back the GET /pulls/:n/reviews endpoint. */
 export function makePull({
   number,
   title = `PR #${number}`,
@@ -76,12 +80,14 @@ export function makePull({
   labels = [],
   user = "octocat",
   headRef = `branch-${number}`,
+  headSha = `sha-${number}-1`,
   headRepoFullName = "example/repo",
   baseRef = "main",
   merged = false,
   mergedAt = null,
   createdAt = nowIso(),
   updatedAt = createdAt,
+  reviews = [],
 } = {}) {
   if (!Number.isInteger(number)) throw new Error("makePull: number is required");
   return {
@@ -92,12 +98,30 @@ export function makePull({
     labels: labels.map((l) => (typeof l === "string" ? { name: l } : l)),
     user: { login: user },
     html_url: `https://github.com/example/repo/pull/${number}`,
-    head: { ref: headRef, repo: { full_name: headRepoFullName } },
+    head: { ref: headRef, sha: headSha, repo: { full_name: headRepoFullName } },
     base: { ref: baseRef },
     merged,
     merged_at: mergedAt,
     created_at: createdAt,
     updated_at: updatedAt,
+    reviews,
+  };
+}
+
+/** Build a GitHub-REST-shaped submitted review (as `GET /pulls/:n/reviews`
+ *  returns them — state in UPPER CASE, unlike webhook payloads). */
+export function makeReview({
+  reviewer = "reviewer",
+  state = "APPROVED",
+  commitId,
+  submittedAt = nowIso(),
+} = {}) {
+  if (!commitId) throw new Error("makeReview: commitId is required");
+  return {
+    user: { login: reviewer },
+    state,
+    commit_id: commitId,
+    submitted_at: submittedAt,
   };
 }
 
@@ -258,6 +282,28 @@ class MockGitHub {
       if (state !== "all") items = items.filter((p) => p.state === state);
       items.sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at));
       this.paginate(parsed, items, send);
+      return;
+    }
+
+    const singlePull = /^\/repos\/[^/]+\/[^/]+\/pulls\/(\d+)$/.exec(path);
+    if (method === "GET" && singlePull) {
+      const pull = this.pulls.get(Number(singlePull[1]));
+      if (!pull) {
+        send(404, { message: "Not Found" });
+        return;
+      }
+      send(200, pull);
+      return;
+    }
+
+    const pullReviews = /^\/repos\/[^/]+\/[^/]+\/pulls\/(\d+)\/reviews$/.exec(path);
+    if (method === "GET" && pullReviews) {
+      const pull = this.pulls.get(Number(pullReviews[1]));
+      if (!pull) {
+        send(404, { message: "Not Found" });
+        return;
+      }
+      this.paginate(parsed, pull.reviews ?? [], send);
       return;
     }
 

--- a/server/test/webhooks.test.mjs
+++ b/server/test/webhooks.test.mjs
@@ -233,6 +233,7 @@ test("webhooks", { skip: docker ? false : "docker unavailable" }, async (t) => {
       user: "octocat",
       htmlUrl: raw.html_url,
       headRef: raw.head.ref,
+      headSha: raw.head.sha,
       headRepoFullName: "example/repo",
       baseRef: "main",
       merged: true,
@@ -302,6 +303,91 @@ test("webhooks", { skip: docker ? false : "docker unavailable" }, async (t) => {
     const event = store.recentEvents()[0];
     assert.equal(event.kind, "gh_activity");
     assert.ok(event.text.includes("requested changes"), event.text);
+  });
+
+  await t.test("pull_request_review persists reviewer/state/commitId; synchronize moves headSha", async () => {
+    const raw = makePull({ number: 209, headSha: "sha-209-1" });
+    let res = await post("pull_request_review", {
+      action: "submitted",
+      review: { state: "changes_requested", commit_id: "sha-209-1", submitted_at: "2026-07-01T00:00:00Z", user: { login: "dave" } },
+      pull_request: raw,
+      sender: { login: "dave" },
+    });
+    assert.equal(res.statusCode, 202);
+    let doc = await pulls().findOne({ _id: 209 });
+    assert.equal(doc.headSha, "sha-209-1", "pull_request payload's head.sha mirrored");
+    assert.deepEqual(doc.reviews, [
+      { reviewer: "dave", state: "changes_requested", commitId: "sha-209-1", at: "2026-07-01T00:00:00Z" },
+    ]);
+
+    // A second reviewer APPENDS; the same reviewer+commit dedupes
+    // keep-latest instead of growing the array.
+    res = await post("pull_request_review", {
+      action: "submitted",
+      review: { state: "approved", commit_id: "sha-209-1", submitted_at: "2026-07-02T00:00:00Z", user: { login: "erin" } },
+      pull_request: raw,
+      sender: { login: "erin" },
+    });
+    assert.equal(res.statusCode, 202);
+    res = await post("pull_request_review", {
+      action: "edited",
+      review: { state: "changes_requested", commit_id: "sha-209-1", submitted_at: "2026-07-03T00:00:00Z", user: { login: "dave" } },
+      pull_request: raw,
+      sender: { login: "dave" },
+    });
+    assert.equal(res.statusCode, 202);
+    doc = await pulls().findOne({ _id: 209 });
+    assert.deepEqual(
+      doc.reviews.map((r) => [r.reviewer, r.state, r.at]),
+      [
+        ["erin", "approved", "2026-07-02T00:00:00Z"],
+        ["dave", "changes_requested", "2026-07-03T00:00:00Z"],
+      ],
+      "dedupe by reviewer+commitId keeps the latest; distinct reviewers append",
+    );
+
+    // A DISMISSAL supersedes the entry it dismisses (same reviewer+commit,
+    // same submitted_at — the payload carries the original review's) instead
+    // of coexisting with it — so review dispatch's round count drops when a
+    // maintainer dismisses stale changes-requests, matching the shell's
+    // GraphQL states:CHANGES_REQUESTED count.
+    res = await post("pull_request_review", {
+      action: "dismissed",
+      review: { state: "dismissed", commit_id: "sha-209-1", submitted_at: "2026-07-03T00:00:00Z", user: { login: "dave" } },
+      pull_request: raw,
+      sender: { login: "maintainer" },
+    });
+    assert.equal(res.statusCode, 202);
+    doc = await pulls().findOne({ _id: 209 });
+    assert.deepEqual(
+      doc.reviews.map((r) => [r.reviewer, r.state]),
+      [
+        ["erin", "approved"],
+        ["dave", "dismissed"],
+      ],
+      "the dismissal REPLACED dave's changes_requested entry (no ghost CR round)",
+    );
+
+    // Rework pushed: pull_request synchronize moves the mirrored head and
+    // must NOT wipe the accumulated reviews ($set upsert, not replace).
+    const rebased = makePull({ number: 209, headSha: "sha-209-2" });
+    res = await post("pull_request", { action: "synchronize", pull_request: rebased, sender: { login: "octocat" } });
+    assert.equal(res.statusCode, 202);
+    doc = await pulls().findOne({ _id: 209 });
+    assert.equal(doc.headSha, "sha-209-2", "synchronize updated headSha");
+    assert.equal(doc.reviews.length, 2, "reviews survive the pull refresh");
+
+    // A payload without the fields an entry needs (the minimal fixtures
+    // elsewhere in this file) refreshes the mirror but appends nothing.
+    res = await post("pull_request_review", {
+      action: "submitted",
+      review: { state: "approved" },
+      pull_request: rebased,
+      sender: { login: "erin" },
+    });
+    assert.equal(res.statusCode, 202);
+    doc = await pulls().findOne({ _id: 209 });
+    assert.equal(doc.reviews.length, 2, "partial review payloads never poison the doc");
   });
 
   await t.test("unknown event: stored, 202, no feed", async () => {

--- a/web/src/components/live/ActiveWork.tsx
+++ b/web/src/components/live/ActiveWork.tsx
@@ -31,6 +31,7 @@ export function ActiveWorkFeed({ work }: { work: ActiveWorkItem[] }) {
       {work.map((w) => {
         const color = harnessColor(w.harness ?? "unknown", dark);
         const lease = leaseHealth(w.leaseSecondsLeft);
+        const isReview = w.kind === "review";
         return (
           <li key={`${w.issue}-${w.handle}-${w.claimedAt}`} className="flex items-center gap-2.5 py-2">
             <a href={`https://github.com/${w.handle}`} target="_blank" rel="noreferrer" className="shrink-0">
@@ -44,7 +45,7 @@ export function ActiveWorkFeed({ work }: { work: ActiveWorkItem[] }) {
                 <span className="shrink-0 font-medium">@{w.handle}</span>
                 <span className="shrink-0 text-muted-foreground">·</span>
                 <a
-                  href={`${REPO_URL}/issues/${w.issue}`}
+                  href={`${REPO_URL}/${isReview ? "pull" : "issues"}/${w.issue}`}
                   target="_blank"
                   rel="noreferrer"
                   className="shrink-0 font-mono text-foreground hover:underline"
@@ -54,6 +55,11 @@ export function ActiveWorkFeed({ work }: { work: ActiveWorkItem[] }) {
                 {w.title ? <span className="truncate text-foreground/60">{w.title}</span> : null}
               </div>
               <div className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground">
+                {isReview ? (
+                  <span className="rounded-full bg-violet-500/15 px-1.5 py-px font-medium text-violet-600 dark:text-violet-400">
+                    review
+                  </span>
+                ) : null}
                 {w.stage ? (
                   <span className="rounded-full bg-secondary/70 px-1.5 py-px font-medium">{w.stage}</span>
                 ) : null}

--- a/web/src/lib/live.ts
+++ b/web/src/lib/live.ts
@@ -105,7 +105,10 @@ export interface LogLine {
 /** One row of "who is working on what" — GET /api/v1/work/active (the
  *  orchestrator's live assignments joined with issue titles + lease TTLs). */
 export interface ActiveWorkItem {
+  /** For kind "review", `issue` carries the PR number. */
   issue: number;
+  /** Absent on rows from servers predating review dispatch = "work". */
+  kind?: "work" | "review";
   title: string | null;
   stage: string | null;
   handle: string;


### PR DESCRIPTION
Part of #398, implements ADR-0019 (included). Enrolled reviewers now claim their next PR from the orchestrator (kind: review) instead of walking the PR list — server-side eligibility from the mirror, review leases so two reviewers never duplicate work, abandon-cooldowns against starvation, total fallback to the walk. Built and adversarially reviewed by workflow (13 confirmed findings, all fixed); 136/136 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)