### PR TITLE
pipeline: adopt stale (>6h) changes-requested PRs from absent authors (ADR-0020)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,9 @@ Six scripts wrap your `codex`, `claude`, or `hermes` CLI so you can put spare to
 - **`./start_work.sh`** — claims the next available research/ideate/build
   issue, runs the loop above, and moves the issue to *in review* when a PR is
   opened. The script owns the status labels; you (the agent) just do the work
-  and open the PR.
+  and open the PR. Under autopilot it also **adopts stale rework** — a
+  `changes-requested` PR whose author went offline for 6h+ is taken over by a
+  different worker so the queue doesn't freeze on absent authors ([ADR-0020](docs/adr/0020-adopt-stale-rework.md)).
 - **`./review_work.sh`** — runs an adversarial review on open PRs and sets the
   merge gate.
 

--- a/autopilot.sh
+++ b/autopilot.sh
@@ -110,6 +110,13 @@ fleet_cleanup_run_dir() { [ -n "${FLEET_RUN_DIR:-}" ] && rm -rf "$FLEET_RUN_DIR"
 # what makes server-side pause/stop/abort commands reach this runner.
 FLEET_CLAIM="${FLEET_CLAIM-1}"
 export FLEET_CLAIM
+# Rework adoption (ADR-0020 / #656): let an idle worker take over a stale
+# changes-requested PR whose author went offline (idle >REWORK_ADOPT_HOURS,
+# adopter ≠ author ≠ last reviewer, arbitrated by the server's atomic lease).
+# Default ON under autopilot — it needs FLEET_CLAIM anyway, and the whole point
+# is to stop the queue freezing on absent authors. Opt out with REWORK_ADOPT=0.
+REWORK_ADOPT="${REWORK_ADOPT-1}"
+export REWORK_ADOPT
 if [ -n "$FLEET_SERVER" ] && [ "$FLEET_CLAIM" = "1" ]; then
   fleet_ensure_token || true
 fi

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -215,6 +215,25 @@ pushed after it) but whose worked issue still sits `in-review` gets flipped to
 another bot) or a hand-off lost to a reviewer crash still route back to you.
 A freshly reworked PR awaiting re-review is left alone.
 
+**Adopting a stale rework (ADR-0020 / #656).** Rework used to advance only when
+the PR's *own author* re-ran — so a `changes-requested` PR whose author went
+offline could freeze for days while idle workers had nothing to do. After its
+own rework queue and any TTL-freed unassigned reworks, an enrolled worker can
+now **adopt** a stale changes-requested PR from an *absent* author: the fleet
+server hands out (under an atomic lease) the oldest PR that has sat in
+changes-requested for more than `REWORK_ADOPT_HOURS` (default 6h) since its
+last review, whose author is **not currently online**, and where the adopter is
+**neither the author nor the last reviewer** (so the eventual re-review still
+lands on a third identity). Synthesis (`synthesis/*`) and framing (`discover/*`)
+PRs are never adopted this way, and fork PRs aren't either (see the fork note
+under `reap.sh`). Before pushing, the adopter re-checks that no new author
+commit landed since the review — a returning author is never clobbered
+(`--force-with-lease` backstops a concurrent push). It is gated by
+`REWORK_ADOPT` **and** server claiming (`FLEET_CLAIM`), so the atomic lease —
+not a label race — arbitrates who adopts; `autopilot.sh` defaults it on,
+standalone `start_work.sh` is opt-in. Full contract:
+[server dispatch — kind `rework`](#server-orchestrated-claiming-opt-in).
+
 ## `reap.sh` — release stale claims and rework
 
 `reap.sh` keeps abandoned queue items from staying stuck forever. It is safe to
@@ -229,6 +248,15 @@ Two TTLs are enforced:
   hours) is unassigned, so any worker's `start_work.sh` loop — or
   `synthesize_work.sh`, for a synthesis draft (ADR-0011) — can pick up the
   rework.
+
+It also **closes fork-origin stale reworks** (ADR-0020 §5): a
+`changes-requested` PR whose branch lives on a **fork** can't be adopted (only
+its author can push it), and the project isn't taking outside fork branches
+into the automated pipeline for now — so the PR is closed with an explanatory
+comment and its issue released to `status: available` for a fresh same-repo
+attempt (the recorded review stays on the closed PR as reference). A
+`review: human-only` fork PR is left for the human maintainer. Opt out with
+`CLOSE_FORK_REWORKS=0`.
 
 Run it manually when you want an immediate sweep:
 
@@ -318,6 +346,23 @@ What changes when it's on:
   author ≠ reviewer is enforced against the account that actually posts the
   review. Empty queue or server trouble → the pass falls through to today's
   PR-list walk unchanged.
+- **Rework adoption too ([ADR-0020](adr/0020-adopt-stale-rework.md))** — an
+  enrolled `start_work.sh` with `REWORK_ADOPT=1` asks the same endpoint with
+  `kind: "rework"`. The server picks the oldest open `changes-requested` PR
+  that a *different* worker may adopt: idle more than `REWORK_ADOPT_HOURS`
+  (default 6h) since its last review-at-head, author **not currently online**,
+  adopter **neither the author nor the last reviewer**, not draft, not
+  `synthesis/*`/`discover/*`, not a fork, not `review: human-only`/
+  `do-not-automate`. Unlike a review, a rework **writes labels**: the server
+  leases the worked issue and moves it `changes-requested → claimed` +
+  assigns the adopter (the atomic `status: changes-requested` removal is the
+  test-and-set), then hands back the PR + issue. The runner reworks the PR
+  through its adopter flow (provenance comment; the finding's `agent`/`model`
+  become the adopter's; `--force-with-lease` so a returning author is never
+  clobbered) and releases `done` on push — the issue flips to `in-review` —
+  or `abandoned` if it pushed nothing / the author returned mid-window, which
+  reverts the issue to `changes-requested` and cools it down (default 15 min).
+  Empty queue or server trouble → the loop simply skips adoption, unchanged.
 
 GitHub remains the durable source of truth throughout: the server arbitrates
 *who claims*, but every durable fact lands on GitHub as the same labels and

--- a/docs/adr/0020-adopt-stale-rework.md
+++ b/docs/adr/0020-adopt-stale-rework.md
@@ -1,0 +1,146 @@
+# ADR-0020: A stale changes-requested PR is adopted by a different worker (kind: rework)
+
+- **Status:** proposed (ratified on merge by the human maintainer, who directed this
+  design on 2026-07-07; agents do not self-ratify pipeline changes)
+- **Date:** 2026-07-07
+- **Deciders:** @adam91holt (human maintainer); drafted by an agent (Claude Opus 4.8,
+  "Fable") acting on his direct instructions
+- **Amends:** ADR-0008 (rework hand-off routes by worked issue) — this narrows its
+  implicit "the PR's **author** reworks their own PR" assumption
+- **Relates to:** ADR-0017 (pull-claim orchestration — this adds a third dispatch kind),
+  ADR-0019 (orchestrated review dispatch — the pattern this mirrors), ADR-0018
+  (mirror-backed runner reads), ADR-0011 / ADR-0014 (synthesis / framing rework routing,
+  which this must not disturb), #656
+
+## Context
+
+Rework only advanced when the **PR's original author** re-ran their loop.
+`start_work.sh`'s rework queue (`rework_issues`) filters `changes-requested` issues to
+those assigned **to the running identity**; the only cross-worker path was
+`take_unassigned_rework`, which requires the issue to have first been **unassigned** by
+`reap.sh` after `REWORK_TTL` (2h). But `reap.sh` keys that TTL off the issue's
+`updatedAt`, which bumps on *every* comment and label edit — so a PR that churned through
+review rounds and then had its author go offline may never age out, leaving the author
+assigned and the rework frozen. We hit this live: `changes-requested` PRs sat for days,
+still assigned to an absent author, while idle enrolled workers with a gated queue had
+nothing else to do (#656). Meanwhile that same cross-worker path *silently drops* fork
+PRs (only their author can push a same-branch rework), so a fork rework can never be
+adopted at all.
+
+The integrity constraint that made this delicate: a reworked PR is re-reviewed, and the
+project's whole trust model rests on **author ≠ reviewer** (branch protection + ADR-0019).
+Letting "any worker" pick up a rework must not let a reviewer quietly become the author of
+the fix they will then re-review, and must not touch the two rework paths that are
+deliberately *not* the generic loop's — synthesis drafts (ADR-0011) and discover framings
+(ADR-0014).
+
+## Decision
+
+1. **A third pull-claim kind: `rework`.** `POST /api/v1/work/claim` gains
+   `kind: "work" | "review" | "rework"` (default `work`; every response echoes the kind it
+   executed, so a runner detects an older server that dropped the field, exactly as
+   ADR-0019 established). For `kind: rework` the server picks the **oldest** adoptable PR
+   from its webhook-fed mirror, atomically leases it, writes the *issue* labels
+   (`changes-requested → claimed` + assigns the adopter), and hands the runner the PR + its
+   worked issue. The runner reworks that PR through its existing flow and, on push, the
+   issue flips back to `in-review` for a fresh adversarial review.
+
+2. **Adoptability, evaluated on the mirror (fails toward *not* adopting).** A PR is
+   adoptable when ALL hold:
+   - open, not draft; its worked issue carries `status: changes-requested`;
+   - the **last review at the current head SHA is `changes_requested`** — a newer commit
+     than that review means the author already pushed rework and the PR is awaiting
+     re-review, not adoption (the same head-SHA logic ADR-0019 uses, inverted);
+   - that changes-request is **older than `REWORK_ADOPT_HOURS` (default 6h)** — the idle
+     window, measured as the review's timestamp (which is by construction ≥ the head-commit
+     time it judged, so it is the correct "nothing has happened since" clock);
+   - the claiming handle is **neither the PR author nor the last reviewer** — the first
+     keeps a worker from "adopting" its own frozen PR pointlessly; the second preserves
+     author ≠ reviewer, because an adopter becomes the author of the fix and must not be the
+     identity that then re-reviews it;
+   - the head branch is **not** `synthesis/*` (ADR-0011) or `discover/*` (ADR-0014) — those
+     reworks belong to `synthesize_work.sh` / `frame_work.sh` and their guardrails, never
+     this generic path;
+   - labels exclude `review: human-only` and `do-not-automate`;
+   - the head repo is the **main repo, not a fork** — the adopter must be able to push the
+     rework to the branch (see 5);
+   - **presence-aware:** the PR author is **not currently connected** to the fleet server.
+     An author who is online is presumed to be (or about to be) working their own rework;
+     adoption targets the *absent* author the bottleneck is about.
+
+3. **The lease + label test-and-set is the claim.** Like a work claim (ADR-0017), the
+   server takes `lease:issue:<n>` with Redis `SET NX EX` and then removes
+   `status: changes-requested` on GitHub as an atomic test-and-set — the second remover
+   404s, so exactly one adopter wins even across a stale mirror or a label-path rival. It
+   adds `status: claimed` and assigns the adopter. The worked issue is resolved from the
+   winning PR's body (`Closes` / `Part of #n`) read live at claim time — one read that
+   doubles as the ADR-0019 liveness check (a merged/closed PR is never handed out).
+   Release/expiry **reverts to `status: changes-requested`** (not `available` — the review
+   feedback still stands and the PR still exists), removing the adopter's assignee, so a
+   crashed adopter's rework simply becomes adoptable again after the lease lapses. Lease
+   TTL is `REWORK_LEASE_TTL_SECONDS` (default 1800, the work-lease value — a rework is one
+   agent run, not the hour a review takes).
+
+4. **Provenance is recorded.** The adopter comments `🤝 rework adopted by @adopter from
+   @author` on the PR, and the rework prompt instructs the agent to set the finding's
+   `agent`/`model` frontmatter to the adopter's — so the leaderboard and the finding's
+   recorded provenance both track who actually did the fix.
+
+5. **No external fork branches, for now.** A contributor's fork PR can't be adopted
+   (only its author can push its branch) and — per the maintainer's direction (#656) — we
+   are **not** accepting outside fork branches into the automated pipeline at this stage;
+   contributors who want the fleet to carry their work should run as a maintainer identity
+   with push access. So `reap.sh` gains a sweep that, for any `changes-requested` issue
+   whose PR lives on a fork, **closes the PR with an explanatory comment and releases the
+   issue to `status: available`** (the recorded review stays on the closed PR as reference).
+   A fresh worker then picks the issue up clean on a same-repo branch. This is the
+   deliberate replacement for a "supersede the fork PR" path, which was considered and
+   rejected as more machinery than the current no-fork posture warrants.
+
+6. **Opt-in flag, default ON under autopilot.** Adoption is gated by `REWORK_ADOPT` (a
+   feature flag) **and** requires server claiming (`FLEET_CLAIM`), so the atomic lease —
+   not a label race — always arbitrates it. `autopilot.sh` defaults `REWORK_ADOPT=1`
+   (it already defaults `FLEET_CLAIM=1`); a standalone `start_work.sh` stays opt-in. The
+   runner tries adoption **only after** its own rework queue and the existing
+   `take_unassigned_rework` path — an author's own PR is always theirs first, and a
+   TTL-freed unassigned rework is cheaper to take than a presence-checked adoption.
+   On any claim failure — flag off, server down, queue empty, timeout — the loop falls
+   through to today's behaviour byte-for-byte (the ADR-0016 fail-open invariant).
+
+Alternatives considered: keying adoption off `reap.sh` unassigning the author (rejected —
+`updatedAt` never ages out a churned PR, which is the bug); a client-side soft-lock comment
+as the atomic claim (rejected — the maintainer directed the stronger server lease, and it
+also gives presence-awareness for free); superseding non-editable fork PRs into the main
+repo (rejected — see 5, we simply don't take fork branches yet); default-ON everywhere
+(rejected — standalone runs stay opt-in so the behaviour is only live where the server
+arbitrates it).
+
+## Consequences
+
+- The fleet self-heals the exact live bottleneck: a `changes-requested` PR whose author
+  went offline is picked up by a different enrolled worker after 6h and driven to
+  re-review, instead of freezing until a human notices.
+- Author ≠ reviewer is preserved by construction — the adopter can be neither the author
+  nor the last reviewer, so the re-review still lands on a third identity.
+- The two protected rework paths (synthesis, framing) are excluded by head-branch prefix,
+  the same marker their existing guards use; a mirror that can't classify a branch fails
+  toward *not* adopting.
+- Fork PRs stop being a silent dead end: they're closed and their issues re-queued, at the
+  cost of discarding the fork branch's commits (the review notes survive on the closed PR).
+  This is an explicit, maintainer-directed narrowing — outside fork contribution to the
+  automated loop is paused, not solved.
+- One more dispatch kind and one more revert target (`changes-requested`) in the sweeper —
+  more surface kept convergent, covered by tests.
+- A stale mirror can hand out a PR the author just pushed to or a reviewer just re-reviewed;
+  the runner's **pre-push guard re-reads live GitHub and aborts if a new author commit
+  landed since the review** (never clobber an author who quietly came back), so staleness
+  wastes an attempt, never overwrites live work.
+
+## What would change this decision
+
+Evidence adoption clobbers returning authors despite the pre-push guard (would tighten the
+liveness window); the enrolled share of workers approaching 100% (would let the
+`take_unassigned_rework` label path and its `reap.sh` unassign retire); a decision to
+accept outside fork branches into the automated pipeline (would revive the supersede path
+from 5 instead of close-and-release); or push assignment arriving for work claims (rework
+would follow the same shape).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,5 +56,6 @@ routine fixes, copy changes, or web styling.
 | [0017](0017-server-orchestrated-pull-claim.md) | The fleet server arbitrates work claims for enrolled agents (pull-claim v1) | Proposed |
 | [0018](0018-mirror-backed-runner-reads.md) | Runner queue reads come from the fleet server's mirror, not GitHub | Proposed |
 | [0019](0019-orchestrated-review-dispatch.md) | The fleet server dispatches PR reviews to enrolled reviewers (kind: review) | Proposed |
+| [0020](0020-adopt-stale-rework.md) | A stale changes-requested PR is adopted by a different worker (kind: rework) | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -271,6 +271,71 @@ fleet_release_review() {
   return 0
 }
 
+# ---- fleet server rework-ADOPTION helpers (ADR-0020, #656) -----------------
+# Same opt-in gate as the work/review claim helpers (fleet_claim_enabled). A
+# rework claim asks the server for the next STALE changes-requested PR a
+# DIFFERENT worker may adopt (idle > REWORK_ADOPT_HOURS, adopter ≠ author ≠
+# last reviewer, not synthesis/framing, not a fork, author not online). The
+# server takes the lease AND writes the issue labels (changes-requested →
+# claimed) + assignee ITSELF, so the caller must NOT run its own claim — it
+# just reworks the PR and, on push, flips the issue to in-review.
+
+# fleet_claim_rework — ask the server to adopt the next stale rework. On success
+# prints {pr, issue, author, headSha, headRef, title, leaseTtlSeconds, handle}
+# and returns 0; queue empty / non-200 / bad JSON / timeout → returns 1. The
+# same pre-ADR-0019 deploy-skew guard as fleet_claim_review: an old server
+# strips the unknown `kind` and runs a WORK claim, which we detect and release.
+fleet_claim_rework() {
+  fleet_claim_enabled || return 1
+  local agent_id="" body resp
+  if [ -n "${FLEET_AGENT_ID_FILE:-}" ]; then
+    agent_id="$(cat "$FLEET_AGENT_ID_FILE" 2>/dev/null || true)"
+    printf '%s' "$agent_id" | grep -qiE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' || agent_id=""
+  fi
+  body="$(jq -cn --arg harness "${AGENT:-}" --arg model "${MODEL:-}" --arg agentId "$agent_id" '
+      {kind: "rework"}
+    + (if $harness != "" then {harness: $harness[0:32]} else {} end)
+    + (if $model   != "" then {model: $model[0:128]} else {} end)
+    + (if $agentId != "" then {agentId: $agentId} else {} end)' 2>/dev/null)" || return 1
+  resp="$(curl -sS -m 5 -X POST "$FLEET_SERVER/api/v1/work/claim" \
+    -H 'content-type: application/json' \
+    -H "authorization: Bearer $FLEET_TOKEN" \
+    -d "$body" 2>/dev/null)" || return 1
+  if ! printf '%s' "$resp" | jq -e '.ok == true and .rework != null' >/dev/null 2>&1; then
+    # DEPLOY-SKEW GUARD (same as fleet_claim_review): a server predating
+    # kind:"rework" strips the field and runs a WORK claim, stranding a real
+    # issue "status: claimed". Detect and release it.
+    local oops
+    oops="$(printf '%s' "$resp" | jq -r 'select(.ok == true) | .issue.number // empty' 2>/dev/null || true)"
+    if [ -n "$oops" ]; then
+      warn "Fleet server predates kind:rework (deploy skew) — releasing the accidental work claim on #$oops."
+      fleet_release "$oops" abandoned
+    fi
+    return 1
+  fi
+  printf '%s' "$resp" | jq -c '{pr: .rework.pr, issue: .rework.issue, author: .rework.author, headSha: .rework.headSha, headRef: .rework.headRef, title: .rework.title, leaseTtlSeconds: .leaseTtlSeconds, handle: .handle}'
+}
+
+# fleet_release_rework <issue> <done|abandoned> [pr] — finish an adopted
+# rework. `issue` is the WORKED issue number (the rework assignment's number
+# space, and its lease key); `pr` the reworked PR. done = the rework was pushed
+# (the runner flips the issue to in-review itself); abandoned = it wasn't (the
+# author returned mid-window, a crash, a usage limit) → the server reverts the
+# issue to changes-requested. Best-effort; the lease TTL + sweeper backstop a
+# lost release.
+fleet_release_rework() {
+  fleet_claim_enabled || return 0
+  local body
+  body="$(jq -cn --arg issue "${1:-}" --arg outcome "${2:-}" --arg pr "${3:-}" '
+      {kind: "rework", issue: ($issue | tonumber), outcome: $outcome}
+    + (if $pr != "" then {prNumber: ($pr | tonumber)} else {} end)' 2>/dev/null)" || return 0
+  curl -sS -m 5 -X POST "$FLEET_SERVER/api/v1/work/release" \
+    -H 'content-type: application/json' \
+    -H "authorization: Bearer $FLEET_TOKEN" \
+    -d "$body" >/dev/null 2>&1 || true
+  return 0
+}
+
 # fleet_pop_commands — print (and consume) the control-command KINDS the
 # server piggybacked on telemetry responses (pause|resume|stop|abort), one
 # per line. fleet_send (autopilot.sh) stashes them into $FLEET_CMDS_FILE as

--- a/scripts/reap.sh
+++ b/scripts/reap.sh
@@ -16,12 +16,18 @@
 #     synthesize_work.sh runner claims the root while drafting and releases
 #     it when done; a lingering assignment means it crashed, and other
 #     runners refuse to contest a live claim — ADR-0012).
+#   - CHANGES-REQUESTED but its PR lives on a FORK → the PR is closed and the
+#     issue released to `available` (ADR-0020 §5: we don't take outside fork
+#     branches into the automated pipeline for now — only a fork PR's author
+#     can push its rework, so it can never be adopted). Opt out with
+#     CLOSE_FORK_REWORKS=0.
 #
-# Env: CLAIM_TTL REWORK_TTL DRY_RUN FOR_GOOD_REPO REPO_DIR
+# Env: CLAIM_TTL REWORK_TTL CLOSE_FORK_REWORKS DRY_RUN FOR_GOOD_REPO REPO_DIR
 set -euo pipefail
 cd "$(dirname "$0")/.."
 source "scripts/fg-common.sh"
 DRY_RUN="${DRY_RUN:-0}"
+CLOSE_FORK_REWORKS="${CLOSE_FORK_REWORKS:-1}"   # 1 = close fork-origin changes-requested PRs + release the issue (ADR-0020 §5)
 
 hrs() { echo $(( ${1:-0} / 3600 )); }
 
@@ -104,13 +110,44 @@ reap_synthesis_claims() {
   done
 }
 
+# 5) A changes-requested PR that lives on a FORK can never be adopted (only its
+#    author can push its branch) and — per the maintainer's direction (#656) —
+#    we are not taking outside fork branches into the automated pipeline for
+#    now. Close the PR with an explanatory comment and release the issue to
+#    `available` so a fresh worker picks it up clean on a same-repo branch (the
+#    recorded review stays on the closed PR as reference). A `review: human-only`
+#    PR is left for the human maintainer.
+reap_fork_reworks() {
+  [ "$CLOSE_FORK_REWORKS" = 1 ] || return 0
+  local n pr owner labels who a
+  for n in $(gh issue list --repo "$REPO" --state open --label "status: changes-requested" \
+      --json number --limit 100 --jq '.[].number'); do
+    pr="$(pr_for_issue "$n" || true)"; [ -z "$pr" ] && continue
+    owner="$(gh pr view "$pr" --repo "$REPO" --json headRepositoryOwner --jq .headRepositoryOwner.login 2>/dev/null || true)"
+    # Empty owner = couldn't read (rate limit / transient) — fail closed, skip.
+    [ -n "$owner" ] || continue
+    [ "$owner" = "$OWNER" ] && continue   # same-repo branch — adoptable, leave it
+    labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '[.labels[].name]|join(",")' 2>/dev/null || true)"
+    case ",$labels," in *",review: human-only,"*) log "#$n's fork PR #$pr is review: human-only — leaving it for a human."; continue ;; esac
+    if [ "$DRY_RUN" = 1 ]; then info "[dry-run] would close fork PR #$pr ($owner) and release #$n → available"; continue; fi
+    gh pr comment "$pr" --repo "$REPO" --body "🔁 Closing this fork PR: the project isn't taking outside fork branches into the automated pipeline right now — a changes-requested fork PR can't be adopted by another worker (only its author can push its branch), so it stalls (ADR-0020 §5, #656). The linked issue #$n is being released back to **available** for a maintainer-identity worker to pick up clean; this review stays here as reference. To contribute through the fleet, run as a maintainer identity with push access." >/dev/null 2>&1 || true
+    gh pr close "$pr" --repo "$REPO" >/dev/null 2>&1 || { warn "Couldn't close fork PR #$pr — skipping #$n."; continue; }
+    set_status_label "$n" "available" "changes-requested" "claimed" "in-review" 2>/dev/null || true
+    who="$(gh issue view "$n" --repo "$REPO" --json assignees --jq '.assignees[].login' 2>/dev/null || true)"
+    for a in $who; do gh issue edit "$n" --repo "$REPO" --remove-assignee "$a" >/dev/null 2>&1 || true; done
+    gh issue comment "$n" --repo "$REPO" --body "♻️ The fork PR #$pr addressing this was closed (no outside fork branches in the automated pipeline for now — ADR-0020 §5). Released back to **available** for a fresh same-repo attempt; the prior review on #$pr is reference." >/dev/null 2>&1 || true
+    ok "Closed fork PR #$pr ($owner) and released #$n → available"
+  done
+}
+
 main() {
   preflight
-  info "reap.sh · repo=$REPO · claim-ttl=$(hrs "$CLAIM_TTL")h · rework-ttl=$(hrs "$REWORK_TTL")h$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"
+  info "reap.sh · repo=$REPO · claim-ttl=$(hrs "$CLAIM_TTL")h · rework-ttl=$(hrs "$REWORK_TTL")h$([ "$CLOSE_FORK_REWORKS" = 1 ] && printf " · close-fork-reworks")$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"
   reap_claims
   reap_reworks
   reap_status_conflicts
   reap_synthesis_claims
+  reap_fork_reworks
   ok "Reap complete."
 }
 main "$@"

--- a/scripts/start_work.sh
+++ b/scripts/start_work.sh
@@ -51,6 +51,9 @@ CLAIMED_ISSUE=""
 FLEET_CLAIMED=0     # 1 while working an issue the fleet SERVER claimed for us (FLEET_CLAIM=1 opt-in)
 FLEET_RENEW_PID=""  # background lease-renew loop for a fleet-claimed issue
 FLEET_LEASE_TTL=""  # leaseTtlSeconds from the last fleet claim — drives the renew cadence
+REWORK_ADOPT="${REWORK_ADOPT:-0}"  # 1 = adopt stale changes-requested PRs from ABSENT authors (ADR-0020); autopilot defaults it on
+ADOPT_ISSUE=""     # worked-issue number of a rework we ADOPTED from another author (server lease held)
+ADOPT_PR=""        # the PR number that adoption is reworking
 
 fleet_stop_renew() {  # stop the background lease-renew loop, if any
   [ -n "$FLEET_RENEW_PID" ] || return 0
@@ -63,6 +66,13 @@ fleet_stop_renew() {  # stop the background lease-renew loop, if any
 release_on_interrupt() {
   fleet_stop_renew || true
   remove_worktree || true
+  if [ -n "$ADOPT_ISSUE" ] && [ "$DRY_RUN" = 0 ]; then
+    # An ADOPTED rework (ADR-0020): release abandoned so the server reverts the
+    # issue to changes-requested and the PR becomes adoptable again.
+    warn "Interrupted mid-adoption of #$ADOPT_ISSUE (PR #$ADOPT_PR) — releasing abandoned; the server reverts it to changes-requested."
+    fleet_release_rework "$ADOPT_ISSUE" abandoned "$ADOPT_PR"
+    ADOPT_ISSUE=""; ADOPT_PR=""
+  fi
   if [ -n "$CLAIMED_ISSUE" ] && [ "$DRY_RUN" = 0 ]; then
     if [ "${FLEET_CLAIMED:-0}" = 1 ]; then
       warn "Interrupted mid-issue #$CLAIMED_ISSUE — releasing the fleet claim as abandoned (the server reverts the labels)."
@@ -265,6 +275,64 @@ Do this:
 3. Commit and push to the SAME branch:
    git push origin HEAD:$branch   (add --force-with-lease only if you rebased)
 4. Comment on the PR summarising what you changed and any rebuttals:
+   gh pr comment $pr --repo $REPO --body "..."
+
+IMPORTANT: do NOT open a new PR, do NOT close anything, and do NOT touch
+labels or assignees — the runner manages status, and the "review: human-only"
+label is a human maintainer's alone to toggle (#288). Work only on PR #$pr.
+EOF
+}
+
+# Prompt for an ADOPTED rework (ADR-0020): the PR was opened by someone else who
+# has gone offline, and a reviewer requested changes >6h ago. We are taking over
+# the fix. Differs from rework_prompt in three ways: it names the original
+# author, it tells the agent to claim provenance (its OWN agent/model in the
+# finding frontmatter, since it is now the author of the fix for credit +
+# tracking), and it forbids force-pushing over the author (--force-with-lease
+# only) so a returning author is never clobbered.
+adopt_rework_prompt() {  # $1 = issue, $2 = PR, $3 = branch, $4 = original author
+  local n="$1" pr="$2" branch="$3" author="$4" title feedback prov_model
+  title="$(gh pr view "$pr" --repo "$REPO" --json title --jq .title)"
+  feedback="$(review_feedback "$pr")"
+  if [ -n "${MODEL:-}" ]; then prov_model="$MODEL"; else prov_model="the exact model identifier you are running as"; fi
+  cat <<EOF
+You are an autonomous contributor to The For Good Project (github.com/$REPO).
+PR #$pr ("$title") for issue #$n was opened by @$author, who has gone offline,
+and an adversarial reviewer REQUESTED CHANGES more than 6 hours ago. You are
+ADOPTING this rework: you take over as the author of the fix so the queue
+stops stalling on the absent author (ADR-0020).
+
+You are inside a dedicated git worktree with the PR branch '$branch' checked
+out (detached HEAD at origin/$branch, freshly fetched).
+
+== REVIEW FEEDBACK ==
+$feedback
+== END REVIEW FEEDBACK ==
+
+Method — read CONTRIBUTING.md and docs/METHOD.md and follow them exactly: real
+working citations for every factual claim, TWO independent sources for
+surprising or load-bearing claims, honest confidence marks, and NEVER
+fabricate a source, statistic, org, or result. Re-verifying citations? Use the
+fetch escalation ladder in AGENTS.md (ADR-0006) — a 403/bot-challenge is
+tooling, not a dead link. Need NZ data? Check the vendored skills first
+(\`ls .skills/skills\`) before a generic web search.
+
+Do this:
+1. Address EVERY point in the feedback. Where you believe the reviewer is
+   wrong, leave the work as-is and prepare a short, evidence-backed rebuttal
+   for step 5 instead.
+2. PROVENANCE — you are now the author of this fix: in any finding/solution
+   file's frontmatter you touch, set  agent: '$AGENT'  and  model: '$prov_model'
+   so the record and the leaderboard track who actually did the work.
+3. If main has moved since, rebase onto it first:
+   git fetch origin && git rebase origin/main
+4. Commit and push to the SAME branch. Do NOT force-push over the author — use
+   ONLY --force-with-lease, which safely fails if @$author pushed since we
+   started (never clobber a returning author). If the push is REJECTED, stop
+   and say so in step 5 rather than forcing:
+   git push --force-with-lease origin HEAD:$branch
+   (a plain  git push origin HEAD:$branch  is fine if you did not rebase.)
+5. Comment on the PR summarising what you changed and any rebuttals:
    gh pr comment $pr --repo $REPO --body "..."
 
 IMPORTANT: do NOT open a new PR, do NOT close anything, and do NOT touch
@@ -550,6 +618,110 @@ rework_one() {  # $1 = issue number with "status: changes-requested", assigned t
   fi
 }
 
+# adopt_rework_one — rework a stale changes-requested PR ADOPTED from an ABSENT
+# author (ADR-0020). The fleet SERVER already leased it and moved the issue
+# changes-requested → claimed + assigned us, so we do NOT claim; we rework the
+# PR and, on push, flip the issue to in-review (server release: done). $1 is the
+# fleet_claim_rework JSON {pr, issue, author, headSha, headRef, title}.
+adopt_rework_one() {  # $1 = fleet_claim_rework JSON
+  local json="$1" pr issue author expected branch before after
+  pr="$(printf '%s' "$json" | jq -r '.pr')"
+  issue="$(printf '%s' "$json" | jq -r '.issue')"
+  author="$(printf '%s' "$json" | jq -r '.author // "someone"')"
+  expected="$(printf '%s' "$json" | jq -r '.headSha // ""')"
+  branch="$(printf '%s' "$json" | jq -r '.headRef // ""')"
+  ADOPT_ISSUE="$issue"; ADOPT_PR="$pr"
+  rule; info "${c_bold}Adopting rework of PR #$pr${c_reset} (issue #$issue, from @$author) — $(printf '%s' "$json" | jq -r '.title // ""')"
+
+  # Defensive re-checks (the server already excludes these — belt & suspenders
+  # for a stale mirror / deploy skew). FAIL CLOSED: abandon and skip.
+  local abort=""
+  case "$branch" in
+    synthesis/*) abort="a synthesis draft (belongs to synthesize_work.sh, ADR-0011)" ;;
+    discover/*)  abort="a discover framing (belongs to frame_work.sh, ADR-0014)" ;;
+    "")          abort="missing a head branch" ;;
+  esac
+  if [ -z "$abort" ]; then
+    local head_owner
+    head_owner="$(gh pr view "$pr" --repo "$REPO" --json headRepositoryOwner --jq .headRepositoryOwner.login 2>/dev/null || true)"
+    [ "$head_owner" = "$OWNER" ] || abort="on a fork ($head_owner) — can't push a rework"
+  fi
+  if [ -n "$abort" ]; then
+    warn "PR #$pr is $abort — releasing the adoption (server reverts to changes-requested)."
+    fleet_release_rework "$issue" abandoned "$pr"
+    ADOPT_ISSUE=""; ADOPT_PR=""; return 2   # rc 2 = unworkable/skip, no MAX slot
+  fi
+
+  # Pre-push guard, part 1 (ADR-0020): if the live head no longer matches the
+  # SHA the reviewer judged, the author already pushed rework since the review —
+  # they came back. Do NOT clobber them: release abandoned (revert to
+  # changes-requested; their fresh push routes normally) and skip.
+  before="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+  if [ -n "$expected" ] && [ -n "$before" ] && [ "$before" != "$expected" ]; then
+    warn "PR #$pr moved since the review (author returned) — releasing the adoption, not clobbering @$author."
+    fleet_release_rework "$issue" abandoned "$pr"
+    ADOPT_ISSUE=""; ADOPT_PR=""; return 2
+  fi
+
+  if [ "$DRY_RUN" = 1 ]; then
+    info "[dry-run] would adopt rework of PR #$pr (issue #$issue, from @$author), push with --force-with-lease, and move #$issue → in-review"
+    ADOPT_ISSUE=""; ADOPT_PR=""; return 0
+  fi
+
+  gh pr comment "$pr" --repo "$REPO" --body "🤝 Rework **adopted by @$ME from @$author** — the author went offline and this sat in changes-requested for over 6h, so a different worker is taking over the fix (ADR-0020). The finding's \`agent\`/\`model\` will be updated to the adopter's." >/dev/null 2>&1 || true
+
+  if ! make_worktree "origin/$branch"; then
+    err "Couldn't create worktree for adopted PR #$pr (branch $branch) — releasing the adoption."
+    fleet_release_rework "$issue" abandoned "$pr"
+    ADOPT_ISSUE=""; ADOPT_PR=""; return 1
+  fi
+  export FLEET_TASK_KIND=work TASK_REF="#$pr" TASK_TITLE="$(gh pr view "$pr" --repo "$REPO" --json title --jq .title 2>/dev/null || echo "adopt rework PR #$pr")"
+  # Keep the server's lease alive across the run (renew by ISSUE number —
+  # kind-agnostic on the server side).
+  local renew_secs
+  renew_secs="${FLEET_RENEW_SECONDS:-$(( ${FLEET_LEASE_TTL:-1800} / 3 ))}"
+  [ "$renew_secs" -ge 15 ] 2>/dev/null || renew_secs=15
+  ( while sleep "$renew_secs"; do fleet_renew "$issue"; done ) &
+  FLEET_RENEW_PID=$!
+  info "Handing adopted PR #$pr rework to $AGENT (worktree: $WORKTREE)..."
+  local tmp; tmp="$(mktemp)"
+  set +e; run_agent "$(adopt_rework_prompt "$issue" "$pr" "$branch" "$author")" "$WORKTREE" 2>&1 | tee "$tmp"; local rc=${PIPESTATUS[0]}; set -e
+  fleet_stop_renew
+  was_interrupted "$rc" && { rm -f "$tmp"; release_on_interrupt; }
+  if was_usage_limited "$tmp"; then
+    warn "Adopted rework of PR #$pr hit an API usage/rate limit — releasing the adoption and backing off ${USAGE_LIMIT_SLEEP}s."
+    rm -f "$tmp"; remove_worktree
+    fleet_release_rework "$issue" abandoned "$pr"
+    ADOPT_ISSUE=""; ADOPT_PR=""
+    sleep "$USAGE_LIMIT_SLEEP"
+    return 0
+  fi
+  rm -f "$tmp"
+  if [ "$rc" -eq 0 ]; then ok "Adopted rework run complete for PR #$pr"; else err "Adopted rework run failed/aborted for PR #$pr (exit $rc)"; fi
+  remove_worktree
+  after="$(gh pr view "$pr" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+  if [ -n "$after" ] && [ "$after" != "$before" ]; then
+    # New commits landed — the adoption pushed (a returning author's concurrent
+    # push would have failed our --force-with-lease, so a changed head here means
+    # the rework is on the PR either way; in-review is the right next state).
+    set_status_label "$issue" "in-review" "claimed" "changes-requested"
+    gh issue comment "$issue" --repo "$REPO" --body "🔁 Adopted rework pushed to PR #$pr (by @$ME, adopted from @$author) — moving back to **in review** for a fresh adversarial review." >/dev/null 2>&1 || true
+    ok "#$issue → in-review (adopted rework pushed to PR #$pr)"
+    fleet_release_rework "$issue" done "$pr"
+  else
+    warn "Adoption pushed no new commits to PR #$pr — releasing (server reverts #$issue to changes-requested)."
+    fleet_release_rework "$issue" abandoned "$pr"
+  fi
+  ADOPT_ISSUE=""; ADOPT_PR=""
+}
+
+# rework adoption gate (ADR-0020): only when explicitly enabled AND the fleet
+# server is claiming (the atomic lease — not a label race — must arbitrate who
+# adopts). autopilot.sh defaults REWORK_ADOPT=1; standalone runs are opt-in.
+rework_adopt_enabled() {
+  [ "${REWORK_ADOPT:-0}" = 1 ] && fleet_claim_enabled
+}
+
 # Self-heal the rework queue: any open PR I authored that a reviewer sent back
 # but whose linked issue is still sitting "in-review" gets flipped to
 # "changes-requested" so the queue below actually picks it up. This closes the
@@ -706,8 +878,9 @@ main() {
     if [ -n "$skip_ids" ]; then
       snap="$(printf '%s' "$snap" | jq --argjson skip "[$skip_ids]" '[.[] | select((.number as $n | $skip | index($n)) | not)]')" || snap='[]'
     fi
-    # Priority: my own rework → a TTL-freed rework I can push → a fresh issue.
-    local next kind=new
+    # Priority: my own rework → a TTL-freed rework I can push → a STALE rework
+    # adopted from an absent author → a fresh issue.
+    local next kind=new adopt_json=""
     next="$(rework_issues "$snap" | head -1 || true)"
     if [ -n "$next" ]; then
       kind=rework
@@ -716,12 +889,26 @@ main() {
       if [ -n "$next" ]; then
         kind=rework
       else
-        # Server-orchestrated claim (opt-in: FLEET_CLAIM=1 + FLEET_TOKEN): the
-        # fleet server picks the next eligible issue, takes an atomic lease and
-        # writes the claim labels/assignee ITSELF — so claim_issue is skipped
-        # for it (kind=fleet). Any failure — queue empty, server down, bad
-        # token — falls back to the exact label-claim path below.
-        if [ "$DRY_RUN" = 0 ] && fleet_claim_enabled; then
+        # Adopt a stale changes-requested PR from an ABSENT author (ADR-0020):
+        # the fleet server picks one idle >REWORK_ADOPT_HOURS whose author isn't
+        # online, atomically leases it and moves the issue changes-requested →
+        # claimed itself (so adopt_rework_one does NOT claim). Tried BEFORE a
+        # fresh issue so idle workers heal the stuck rework queue first; only
+        # when REWORK_ADOPT=1 + fleet claiming (rework_adopt_enabled).
+        if [ "$DRY_RUN" = 0 ] && rework_adopt_enabled; then
+          adopt_json="$(fleet_claim_rework || true)"
+          if [ -n "$adopt_json" ]; then
+            next="$(printf '%s' "$adopt_json" | jq -r '.issue // empty' 2>/dev/null || true)"
+            FLEET_LEASE_TTL="$(printf '%s' "$adopt_json" | jq -r '.leaseTtlSeconds // empty' 2>/dev/null || true)"
+            if [ -n "$next" ]; then kind=adopt; fi
+          fi
+        fi
+        # Server-orchestrated FRESH claim (opt-in: FLEET_CLAIM=1 + FLEET_TOKEN):
+        # the fleet server picks the next eligible issue, takes an atomic lease
+        # and writes the claim labels/assignee ITSELF — so claim_issue is
+        # skipped for it (kind=fleet). Any failure — queue empty, server down,
+        # bad token — falls back to the exact label-claim path below.
+        if [ -z "$next" ] && [ "$DRY_RUN" = 0 ] && fleet_claim_enabled; then
           local fleet_resp
           if fleet_resp="$(fleet_claim "${STAGE:-}")"; then
             next="$(printf '%s' "$fleet_resp" | jq -r '.issue.number // empty' 2>/dev/null || true)"
@@ -748,6 +935,8 @@ main() {
     local wrc=0
     if [ "$kind" = rework ]; then
       rework_one "$next" || wrc=$?
+    elif [ "$kind" = adopt ]; then
+      adopt_rework_one "$adopt_json" || wrc=$?
     elif [ "$kind" = fleet ]; then
       FLEET_CLAIMED=1
       work_one "$next" || wrc=$?

--- a/scripts/test-fg-common-fleet.sh
+++ b/scripts/test-fg-common-fleet.sh
@@ -83,6 +83,19 @@ class Handler(BaseHTTPRequestHandler):
             }
         elif mode == "review-empty":
             payload = {"ok": True, "review": None}
+        elif mode == "rework":
+            payload = {
+                "ok": True,
+                "rework": {"pr": 456, "issue": 234, "title": "stub PR", "author": "someauthor",
+                           "headSha": "0123456789abcdef0123456789abcdef01234567",
+                           "htmlUrl": "https://github.com/example/repo/pull/456",
+                           "headRef": "research/stub"},
+                "assignmentId": "rw123",
+                "leaseTtlSeconds": 1800,
+                "handle": "rework-bot",
+            }
+        elif mode == "rework-empty":
+            payload = {"ok": True, "rework": None}
         elif mode == "garbage":
             self.send_response(200); self.end_headers()
             self.wfile.write(b"this is not json"); return
@@ -244,6 +257,63 @@ printf '%s' "$req" | jq -e '.body | fromjson | .kind == "review" and .issue == 4
 ( FLEET_SERVER="http://127.0.0.1:9" fleet_release_review 456 done ) || fail "review release must swallow server failures"
 printf 'claim' > "$MODE_FILE"
 pass "fleet_release_review sends kind:review done/abandoned payloads and swallows failures"
+
+# --- fleet_claim_rework (kind: "rework", ADR-0020) ------------------------------
+# Disabled → documented no-op return codes (same contract as the other helpers).
+( FLEET_CLAIM=0 fleet_claim_rework ) && fail "fleet_claim_rework must return 1 when disabled"
+( FLEET_CLAIM=0 fleet_release_rework 234 done 456 ) || fail "fleet_release_rework must return 0 when disabled"
+pass "disabled rework helpers no-op with the right return codes"
+
+printf 'rework' > "$MODE_FILE"
+resp="$(AGENT=claude MODEL=test-model fleet_claim_rework)" \
+  || fail "fleet_claim_rework should succeed against the stub"
+[ "$(printf '%s' "$resp" | jq -r '.pr')" = "456" ] || fail "fleet_claim_rework must emit .pr (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.issue')" = "234" ] || fail "fleet_claim_rework must emit .issue (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.author')" = "someauthor" ] || fail "fleet_claim_rework must emit .author (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.headSha')" = "0123456789abcdef0123456789abcdef01234567" ] || fail "fleet_claim_rework must emit .headSha (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.headRef')" = "research/stub" ] || fail "fleet_claim_rework must emit .headRef (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.leaseTtlSeconds')" = "1800" ] || fail "fleet_claim_rework must pass leaseTtlSeconds through (got: $resp)"
+[ "$(printf '%s' "$resp" | jq -r '.handle')" = "rework-bot" ] || fail "fleet_claim_rework must emit .handle (got: $resp)"
+req="$(tail -1 "$LOG_FILE")"
+[ "$(printf '%s' "$req" | jq -r .path)" = "/api/v1/work/claim" ] || fail "rework claim path"
+printf '%s' "$req" | jq -e '.body | fromjson | .kind == "rework" and .harness == "claude" and .model == "test-model" and (has("stages") | not)' >/dev/null \
+  || fail "rework claim body must carry kind:rework + harness/model, no stages (got: $req)"
+pass "fleet_claim_rework emits {pr, issue, author, headSha, headRef, leaseTtlSeconds, handle} and sends kind:rework"
+
+# Fallback contract: empty adopt queue / garbage / server down → rc 1 (skip adoption).
+printf 'rework-empty' > "$MODE_FILE"
+fleet_claim_rework && fail "empty rework queue must return 1 (skip adoption)"
+printf 'garbage' > "$MODE_FILE"
+fleet_claim_rework && fail "non-JSON rework claim response must return 1"
+printf 'rework' > "$MODE_FILE"
+( FLEET_SERVER="http://127.0.0.1:9" fleet_claim_rework ) && fail "server down must return 1"
+pass "fleet_claim_rework returns 1 on empty/garbage/down (skip-adoption fallback contract)"
+
+# DEPLOY-SKEW GUARD: a pre-ADR-0020 server strips the unknown `kind` and runs a
+# WORK claim ({ok:true, issue:{...}}). fleet_claim_rework must release that
+# accidental claim (abandoned) and return 1.
+printf 'claim' > "$MODE_FILE"
+fleet_claim_rework && fail "a work-shaped claim response must return 1 (old server)"
+req="$(tail -1 "$LOG_FILE")"
+[ "$(printf '%s' "$req" | jq -r .path)" = "/api/v1/work/release" ] \
+  || fail "skew guard must release the accidental work claim (last request: $req)"
+printf '%s' "$req" | jq -e '.body | fromjson | .issue == 123 and .outcome == "abandoned"' >/dev/null \
+  || fail "skew release must abandon the claimed issue (got: $req)"
+pass "old-server skew: accidental work claim is released abandoned, rc 1"
+
+# --- fleet_release_rework payloads ----------------------------------------------
+fleet_release_rework 234 done 456 || fail "fleet_release_rework done must return 0"
+req="$(tail -1 "$LOG_FILE")"
+[ "$(printf '%s' "$req" | jq -r .path)" = "/api/v1/work/release" ] || fail "rework release path"
+printf '%s' "$req" | jq -e '.body | fromjson | .kind == "rework" and .issue == 234 and .prNumber == 456 and .outcome == "done"' >/dev/null \
+  || fail "rework release done payload — issue is the worked issue, prNumber the PR (got: $req)"
+fleet_release_rework 234 abandoned || fail "fleet_release_rework abandoned must return 0"
+req="$(tail -1 "$LOG_FILE")"
+printf '%s' "$req" | jq -e '.body | fromjson | .kind == "rework" and .issue == 234 and .outcome == "abandoned"' >/dev/null \
+  || fail "rework release abandoned payload (got: $req)"
+( FLEET_SERVER="http://127.0.0.1:9" fleet_release_rework 234 done 456 ) || fail "rework release must swallow server failures"
+printf 'claim' > "$MODE_FILE"
+pass "fleet_release_rework sends kind:rework done/abandoned payloads and swallows failures"
 
 # --- fleet_pop_commands: drain-once + ownership guard --------------------------
 FLEET_CMDS_FILE="$TMP/cmds"

--- a/server/README.md
+++ b/server/README.md
@@ -263,11 +263,29 @@ curl -s -X POST $URL/api/v1/work/claim -H "$TOK" -H "$JSON" -d '{"kind":"review"
 # lapses at TTL. An abandoned PR cools down (REVIEW_ABANDON_COOLDOWN_SECONDS,
 # default 900) before it can be dispatched again.
 curl -s -X POST $URL/api/v1/work/release -H "$TOK" -H "$JSON" -d '{"kind":"review","issue":456,"outcome":"done"}'
+
+# Rework adoption (ADR-0020): the oldest stale `changes-requested` PR a DIFFERENT worker
+# may adopt — idle > REWORK_ADOPT_HOURS (default 6h) since its last review-at-head, author
+# NOT currently online, adopter neither author nor last reviewer, not draft, not
+# synthesis/*//discover/*, not a fork, not human-only/do-not-automate. UNLIKE a review it
+# WRITES labels: the server leases the WORKED issue and moves it changes-requested →
+# claimed + assigns the adopter (the atomic `status: changes-requested` removal is the
+# test-and-set), then hands back the PR + issue.
+# 200 {ok:true, kind:"rework", rework:{pr,issue,title,author,headSha,htmlUrl,headRef}, assignmentId, leaseTtlSeconds, handle}
+#     {ok:true, kind:"rework", rework:null} = nothing to adopt · 429 + retryAfterSeconds = rate-limited
+curl -s -X POST $URL/api/v1/work/claim -H "$TOK" -H "$JSON" -d '{"kind":"rework"}'
+
+# Release an adopted rework: `issue` is the WORKED issue number, `prNumber` the PR. "done"
+# on push (the runner flips the issue to in-review itself); "abandoned" reverts the issue
+# to changes-requested (author returned mid-window / crash / usage limit) and cools it down
+# (REWORK_ABANDON_COOLDOWN_SECONDS, default 900).
+curl -s -X POST $URL/api/v1/work/release -H "$TOK" -H "$JSON" -d '{"kind":"rework","issue":234,"prNumber":456,"outcome":"done"}'
 ```
 
 `release` with `"outcome":"done"` frees the lease and leaves labels to the normal
-PR/Actions transitions; `"abandoned"` also reverts the labels (`status: available` back,
-assignee removed). A telemetry heartbeat (`POST /api/v1/telemetry`) sent **with** the
+PR/Actions transitions; `"abandoned"` also reverts the labels (a work claim to
+`status: available`, a rework to `status: changes-requested`, assignee removed; a review
+holds no labels). A telemetry heartbeat (`POST /api/v1/telemetry`) sent **with** the
 bearer token additionally auto-renews the handle's active leases and piggybacks pending
 `commands` in its response; without a token it behaves exactly as before.
 
@@ -368,6 +386,12 @@ label + open PR count). Both answer 503 when orchestration is disabled.
 | `WEBHOOK_SECRET` | unset | HMAC secret for `/api/v1/webhooks/github`; unset = route 404 |
 | `ADMIN_TOKEN` | unset | Bearer token for `/api/v1/admin/*`; unset = routes 404 |
 | `LEASE_TTL_SECONDS` | `1800` | Claim lease TTL; auto-renewed by authed heartbeats. Enrolled runners derive their renew cadence from the TTL the claim response returns (TTL/3, floor 15s) |
+| `REVIEW_LEASE_TTL_SECONDS` | `3600` | `kind:"review"` lease TTL (a review round routinely takes ~an hour) |
+| `REVIEW_ABANDON_COOLDOWN_SECONDS` | `900` | Cooldown before an abandoned review PR is re-dispatched |
+| `MAX_REVIEW_ROUNDS` | `10` | Change-requesting review rounds before a PR is a human's (#287; same env the shell reads) |
+| `REWORK_LEASE_TTL_SECONDS` | `1800` | `kind:"rework"` adoption lease TTL (one agent run, like a work claim — ADR-0020) |
+| `REWORK_ADOPT_HOURS` | `6` | How long a `changes-requested` PR must sit idle before a *different* worker may adopt it |
+| `REWORK_ABANDON_COOLDOWN_SECONDS` | `900` | Cooldown before an abandoned rework issue is re-dispatched |
 | `FLEET_CMD_TTL_SECONDS` | `3600` | Expiry for one-shot `stop`/`abort` commands (`pause`/`resume` persist) |
 | `SYNC_INTERVAL_SECONDS` | `60` | Incremental mirror sync interval (±10% jitter) |
 | `SYNC_FULL_INTERVAL_SECONDS` | `900` | Full reconciliation sync interval (±10% jitter) |

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -105,6 +105,20 @@ export const config = {
   // mirror deems eligible but every runner skips sits at the head of the
   // oldest-first queue and burns one claim per runner per pass, forever.
   reviewAbandonCooldownSeconds: num(process.env.REVIEW_ABANDON_COOLDOWN_SECONDS, 900),
+  // Rework-adoption leases (kind: "rework" dispatch — ADR-0020). A rework is
+  // one agent run like a work claim, not the hour a review takes, so it reuses
+  // the work-lease value by default.
+  reworkLeaseTtlSeconds: num(process.env.REWORK_LEASE_TTL_SECONDS, 1800),
+  // How long a `changes-requested` PR must sit idle (no push/review since the
+  // last change-request at its head) before a DIFFERENT worker may adopt its
+  // rework (#656). Configured in HOURS to match the issue/docs; stored in
+  // seconds. Default 6h.
+  reworkAdoptSeconds: num(process.env.REWORK_ADOPT_HOURS, 6) * 3600,
+  // A rework claim released `abandoned` (the runner skipped it locally — the
+  // author pushed a new commit mid-window, a crash, a usage limit) cools down
+  // before claimNextRework may re-serve it, exactly like the review cooldown:
+  // without it a PR every runner skips pins the head of the oldest-first queue.
+  reworkAbandonCooldownSeconds: num(process.env.REWORK_ABANDON_COOLDOWN_SECONDS, 900),
   // Review-round cap before a PR is a human maintainer's (#287). Same env var
   // the shell reads (review_work.sh MAX_REVIEW_ROUNDS) so an operator
   // override can't diverge the server's cap from the runners'.

--- a/server/src/github/gh-api.ts
+++ b/server/src/github/gh-api.ts
@@ -46,6 +46,10 @@ export interface GhPull {
   labels: GhLabel[];
   user: GhUser | null;
   html_url: string;
+  /** PR description. Rework dispatch (ADR-0020) reads it to resolve the worked
+   *  issue from a `Closes` / `Part of #n` link. `GET /pulls/{n}` returns it;
+   *  the pulls LIST endpoint also carries it but the mirror doesn't store it. */
+  body?: string | null;
   head: { ref: string; sha: string; repo: { full_name: string } | null };
   base: { ref: string };
   merged?: boolean;

--- a/server/src/orchestrator/dispatch.ts
+++ b/server/src/orchestrator/dispatch.ts
@@ -55,13 +55,18 @@ import type { Collection } from "mongodb";
 import { config } from "../config.js";
 import { GitHubApiError } from "../github/gh-api.js";
 import { mergeReviewEntriesInto, PULL_REVIEWS_CAP, type PullDoc, type PullReviewEntry } from "../github/sync.js";
-import type { ClaimedIssue, ClaimedReview } from "../protocol.js";
+import type { ClaimedIssue, ClaimedReview, ClaimedRework } from "../protocol.js";
 import type { FleetStore } from "../state.js";
 import type { AgentTier } from "./auth.js";
-import { leaseKey, reviewCooldownKey, reviewLeaseKey, type Orchestrator } from "./stores.js";
+import { leaseKey, reviewCooldownKey, reviewLeaseKey, reworkCooldownKey, type Orchestrator } from "./stores.js";
 
 const AVAILABLE_LABEL = "status: available";
 const CLAIMED_LABEL = "status: claimed";
+/** Rework dispatch (ADR-0020) claims FROM this status (the test-and-set that
+ *  arbitrates adopters) and reverts BACK to it on abandon/expiry — the review
+ *  feedback still stands and the PR still exists, so it is never sent to
+ *  `available`. */
+const CHANGES_REQUESTED_LABEL = "status: changes-requested";
 const DO_NOT_AUTOMATE_LABEL = "do-not-automate";
 const HIGH_PRIORITY_LABEL = "priority: high";
 const STAGE_PREFIX = "stage: ";
@@ -94,6 +99,22 @@ const REVIEW_CLAIMED_LABEL = "review: claimed";
  *  starts further down the list. */
 const REVIEW_FETCH_BUDGET = 10;
 
+// Rework dispatch (kind: "rework", ADR-0020). Skip rules mirror the guards the
+// generic start_work.sh rework path already applies (pr_is_synthesis /
+// pr_is_framing / fork check in fg-common.sh), enforced server-side so a stale
+// worker never even sees a protected or unpushable PR.
+/** synthesize_work.sh mints synthesis draft branches `synthesis/<slug>`;
+ *  their rework belongs to synthesize_work.sh alone (ADR-0011). */
+const SYNTHESIS_BRANCH_PREFIX = "synthesis/";
+/** frame_work.sh mints discover framing branches `discover/<slug>`; their
+ *  rework belongs to frame_work.sh alone (ADR-0014). */
+const DISCOVER_BRANCH_PREFIX = "discover/";
+/** Bound on live `GET /pulls/{n}` reads per rework claim call (issue resolution
+ *  + liveness for a lease-winning candidate), mirroring REVIEW_FETCH_BUDGET.
+ *  A contended queue can burn a few; the first adoptable candidate normally
+ *  wins on the first read. */
+const REWORK_CANDIDATE_BUDGET = 8;
+
 /** Mirror `issues` doc (see the data model in stores.ts / the spec). */
 interface IssueDoc {
   _id: number;
@@ -118,10 +139,12 @@ interface AssignmentDoc {
   _id: ObjectId;
   /** What was claimed. Docs from before review dispatch carry no field —
    *  absent = "work" (read via kindOf below). */
-  kind?: "work" | "review";
+  kind?: "work" | "review" | "rework";
   /** For kind "work" the issue number; for kind "review" the PR NUMBER
    *  (GitHub numbers issues and PRs from one sequence, so the two kinds can
-   *  never collide on a number). */
+   *  never collide on a number); for kind "rework" the WORKED ISSUE number
+   *  (whose labels the claim moved and whose lease it holds — the PR is in
+   *  `prNumber`). */
   issueNumber: number;
   handle: string;
   tier: AgentTier;
@@ -175,9 +198,18 @@ export type ClaimReviewResult =
   | { status: "rate-limited"; retryAfterSeconds: number }
   | { status: "disabled"; reason: string };
 
+/** claimNextRework's result — shaped like ClaimResult with `rework` in place
+ *  of `issue` (the route maps the statuses identically). */
+export type ClaimReworkResult =
+  | { status: "claimed"; rework: ClaimedRework; assignmentId: string; leaseTtlSeconds: number }
+  | { status: "capped" }
+  | { status: "empty" }
+  | { status: "rate-limited"; retryAfterSeconds: number }
+  | { status: "disabled"; reason: string };
+
 export type ReleaseOutcome = "done" | "abandoned" | "lease-expired" | "admin-released";
 
-export type AssignmentKind = "work" | "review";
+export type AssignmentKind = "work" | "review" | "rework";
 
 const nowIso = () => new Date().toISOString();
 
@@ -198,19 +230,28 @@ function kindOf(doc: Pick<AssignmentDoc, "kind">): AssignmentKind {
   return doc.kind ?? "work";
 }
 
-/** Mongo filter clause matching assignments of `kind` (absent = work). */
+/** Mongo filter clause matching assignments of `kind` (absent = work). "work"
+ *  must exclude BOTH tagged kinds, or a rework/review doc would satisfy a work
+ *  release/lookup. */
 function kindFilter(kind: AssignmentKind): Record<string, unknown> {
-  return kind === "review" ? { kind: "review" } : { kind: { $ne: "review" } };
+  if (kind === "review") return { kind: "review" };
+  if (kind === "rework") return { kind: "rework" };
+  return { kind: { $nin: ["review", "rework"] } };
 }
 
-/** The Redis lease key an assignment doc arbitrates on. */
+/** The Redis lease key an assignment doc arbitrates on. Rework reuses the WORK
+ *  lease on its ISSUE number — a rework and a work claim can never target the
+ *  same issue (their statuses differ), so sharing `lease:issue:` is safe and
+ *  even makes them mutually exclude. */
 function assignmentLeaseKey(doc: Pick<AssignmentDoc, "kind" | "issueNumber">): string {
   return kindOf(doc) === "review" ? reviewLeaseKey(doc.issueNumber) : leaseKey(doc.issueNumber);
 }
 
 /** The lease TTL for an assignment kind. */
 function kindLeaseTtl(kind: AssignmentKind): number {
-  return kind === "review" ? config.reviewLeaseTtlSeconds : config.leaseTtlSeconds;
+  if (kind === "review") return config.reviewLeaseTtlSeconds;
+  if (kind === "rework") return config.reworkLeaseTtlSeconds;
+  return config.leaseTtlSeconds;
 }
 
 /** First "stage: <s>" label value, or null (fg-common.sh `label_field`). */
@@ -739,6 +780,314 @@ export async function claimNextReview(
   return { status: "empty" };
 }
 
+/** The worked issue linked by a PR body — a closing ref (closes/fixes/resolves)
+ *  first, else a `Part of #n` link (discover PRs deliberately don't close their
+ *  root). Mirrors fg-common.sh `issue_addressed_by_pr`. */
+function issueFromBody(body: string | null | undefined): number | null {
+  const text = body ?? "";
+  const closing = text.match(/(?:closes|fixes|resolves)\s*#(\d+)/i);
+  if (closing?.[1]) return Number(closing[1]);
+  const partOf = text.match(/part of\s*#(\d+)/i);
+  if (partOf?.[1]) return Number(partOf[1]);
+  return null;
+}
+
+/** The head repo owner login from "owner/repo", or null. */
+function headRepoOwner(fullName: string | null): string | null {
+  if (!fullName) return null;
+  return fullName.split("/")[0] ?? null;
+}
+
+function toClaimedRework(doc: PullDoc, issue: number): ClaimedRework {
+  return {
+    pr: doc.number,
+    issue,
+    title: doc.title,
+    author: doc.user,
+    headSha: doc.headSha,
+    htmlUrl: doc.htmlUrl,
+    headRef: doc.headRef,
+  };
+}
+
+/**
+ * Claim the next stale `changes-requested` PR a DIFFERENT worker may adopt
+ * (kind: "rework", ADR-0020). It is claimNext's shape (it WRITES issue labels
+ * and an assignee — a rework moves the worked issue `changes-requested →
+ * claimed`) selecting over the PULLS mirror like claimNextReview.
+ *
+ * Adoptability, evaluated on the mirror (fails toward NOT adopting):
+ *  - open, not draft; labels exclude `review: human-only` / `do-not-automate`;
+ *  - head branch is not `synthesis/*` (ADR-0011) or `discover/*` (ADR-0014) —
+ *    those reworks belong to synthesize_work.sh / frame_work.sh;
+ *  - head repo is the MAIN repo, not a fork — only a fork PR's author can push
+ *    its branch (forks are closed + released by reap.sh, ADR-0020 §5);
+ *  - the claiming handle is neither the PR author nor the last reviewer at head
+ *    (preserves author ≠ reviewer: the adopter becomes the author of the fix);
+ *  - the PR AUTHOR is not currently online (an online author is presumed to be
+ *    working their own rework);
+ *  - the LAST review at the current head SHA is `changes_requested` (a newer
+ *    commit means the author already pushed rework — awaiting re-review, not
+ *    adoption), and that change-request is older than reworkAdoptSeconds.
+ *
+ * The winning candidate's worked issue is resolved from its body via ONE live
+ * `GET /pulls/{n}` (bounded per call), which doubles as the ADR-0019 liveness
+ * check. The lease is `lease:issue:<worked-issue>` and the atomic claim is the
+ * `status: changes-requested` removal (test-and-set) exactly as claimNext
+ * arbitrates against `status: available`.
+ */
+export async function claimNextRework(
+  orch: Orchestrator,
+  store: FleetStore,
+  ctx: ClaimContext,
+): Promise<ClaimReworkResult> {
+  const gh = orch.gh;
+  if (!gh) return { status: "disabled", reason: "no github token" };
+
+  // Same anti-grief bound as claimNext/claimNextReview, over ALL kinds.
+  const activeCount = await assignmentsCol(orch).countDocuments({ handle: ctx.handle, active: true });
+  if (activeCount >= config.maxActiveClaims) return { status: "capped" };
+
+  const idleCutoffMs = Date.now() - config.reworkAdoptSeconds * 1000;
+  // The main repo's owner (this orchestrator's actual repo — NOT the module
+  // config, which a test/multi-repo deploy overrides per connection). A PR
+  // whose head repo is not this owner lives on a fork: only its author can push
+  // its branch, so it is never adoptable (ADR-0020 §5 — forks are closed +
+  // released to `available` by reap.sh, not reworked here).
+  const mainOwner = (gh.cfg.githubRepo ?? "").split("/")[0] ?? "";
+
+  const open = await pullsCol(orch).find({ state: "open" }).toArray();
+  const candidates = open
+    .filter((p) => {
+      if (p.draft) return false;
+      const labels = p.labels ?? [];
+      if (labels.includes(HUMAN_ONLY_LABEL) || labels.includes(DO_NOT_AUTOMATE_LABEL)) return false;
+      const head = p.headRef ?? "";
+      if (head.startsWith(SYNTHESIS_BRANCH_PREFIX) || head.startsWith(DISCOVER_BRANCH_PREFIX)) return false;
+      if (headRepoOwner(p.headRepoFullName) !== mainOwner) return false; // fork — unpushable
+      if (!p.headSha) return false; // partially-upserted doc — can't evaluate head
+      if (p.user && p.user === ctx.handle) return false; // never adopt my own frozen PR
+      if (p.user && store.isHandleOnline(p.user)) return false; // author is around — leave it to them
+      return true;
+    })
+    .sort((a, b) => {
+      if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+      return a.number - b.number;
+    });
+
+  // Post-abandon cooldowns (one MGET), keyed by ISSUE number — but the cooldown
+  // was set against the issue, and here we only have PRs whose issue we resolve
+  // lazily. So cool down by PR too: reworkCooldownKey takes the ISSUE, but an
+  // abandoned rework's PR head-SHA logic already re-filters most cases; the
+  // cooldown backstops crash/usage-limit loops and is checked AFTER we resolve
+  // the issue (below), so no per-PR MGET here.
+
+  const ttl = config.reworkLeaseTtlSeconds;
+  let liveBudget = REWORK_CANDIDATE_BUDGET;
+  let fetchBudget = REVIEW_FETCH_BUDGET;
+
+  for (const candidate of candidates) {
+    const n = candidate.number;
+    const headSha = candidate.headSha;
+
+    // --- Review-state gate (mirror, with a bounded lazy fetch) --------------
+    // Need the review(s) at the CURRENT head to decide changes-requested-at-head
+    // + idle + last-reviewer. Reuse the same lazy-fetch contract as
+    // claimNextReview (fetch once per revision, bounded per call).
+    let reviews = candidate.reviews ?? [];
+    const hasDataForHead =
+      candidate.reviewsFetchedFor === headSha || reviews.some((r) => r.commitId === headSha);
+    if (!hasDataForHead) {
+      if (fetchBudget <= 0) continue; // state unknown, budget spent — next claim resumes here
+      fetchBudget--;
+      let fetched;
+      try {
+        fetched = await gh.listPullReviews(n);
+      } catch (err) {
+        if (err instanceof GitHubApiError && err.isRateLimit) {
+          return { status: "rate-limited", retryAfterSeconds: err.retryAfterSeconds ?? 60 };
+        }
+        console.error(`dispatch: rework review-state fetch failed for PR #${n}:`, err);
+        continue;
+      }
+      const entries: PullReviewEntry[] = [];
+      for (const r of fetched) {
+        const state = REST_REVIEW_STATES[(r.state ?? "").toUpperCase()];
+        if (!state || !r.user?.login || !r.commit_id) continue;
+        entries.push({ reviewer: r.user.login, state, commitId: r.commit_id, at: r.submitted_at ?? nowIso() });
+      }
+      const merged = await mergeReviewEntriesInto(pullsCol(orch), n, entries, { reviewsFetchedFor: headSha });
+      if (merged === null) continue;
+      reviews = merged;
+    }
+
+    // The last review at head must be a change-request with nothing newer: an
+    // approval at head means it passed; a changes_requested at head with no
+    // approval means waiting-on-rework — the adoptable state. (A new commit
+    // after the review carries a different SHA, so it simply isn't "at head".)
+    const atHead = reviews.filter((r) => r.commitId === headSha);
+    if (atHead.some((r) => r.state === "approved")) continue; // passed at head
+    const changeReqs = atHead.filter((r) => r.state === "changes_requested");
+    if (changeReqs.length === 0) continue; // not in a change-requested-at-head state
+    const lastChangeReq = changeReqs.reduce((m, r) => (r.at > m.at ? r : m), changeReqs[0]!);
+    if (lastChangeReq.at > new Date(idleCutoffMs).toISOString()) continue; // not idle long enough
+    if (lastChangeReq.reviewer === ctx.handle) continue; // adopter would re-review its own fix
+
+    // --- Resolve the worked issue + liveness (one live read; bounded) -------
+    if (liveBudget <= 0) continue;
+    liveBudget--;
+    let live;
+    try {
+      live = await gh.getPull(n);
+    } catch (err) {
+      if (err instanceof GitHubApiError && err.isRateLimit) {
+        return { status: "rate-limited", retryAfterSeconds: err.retryAfterSeconds ?? 60 };
+      }
+      console.error(`dispatch: rework getPull failed for PR #${n}:`, err);
+      continue;
+    }
+    if (live.state !== "open") {
+      // Heal the mirror and skip — never adopt a merged/closed PR.
+      await pullsCol(orch)
+        .updateOne(
+          { _id: n },
+          {
+            $set: {
+              state: live.state,
+              merged: Boolean(live.merged ?? live.merged_at != null),
+              mergedAt: live.merged_at ?? null,
+              updatedAt: live.updated_at ?? nowIso(),
+            },
+          },
+        )
+        .catch(() => undefined);
+      continue;
+    }
+    const issue = issueFromBody(live.body);
+    if (issue === null) continue; // no worked-issue link — can't route the status
+
+    // Never adopt a `do-not-automate` issue — the label-path rework filters
+    // the same on the issue (fg-common.sh unassigned_reworks/rework_issues),
+    // and the PR often doesn't carry the label the ISSUE does. Mirror read is
+    // enough (the label is rarely toggled; the changes-requested test-and-set
+    // below is the hard gate). A mirror miss (null) proceeds — that gate stands.
+    const issueLabels = await issuesCol(orch).findOne({ _id: issue }, { projection: { labels: 1 } });
+    if (issueLabels?.labels.includes(DO_NOT_AUTOMATE_LABEL)) continue;
+
+    // Cooldown after a prior abandoned adoption of THIS issue (crash / usage
+    // limit / author returned mid-window). Checked here, once we know the issue.
+    const cooling = await orch.redis.get(reworkCooldownKey(issue));
+    if (cooling !== null && cooling !== undefined) continue;
+
+    // --- Atomic claim: lease the issue, test-and-set its label --------------
+    const assignmentId = new ObjectId();
+    const idStr = assignmentId.toHexString();
+
+    const took = await orch.redis.set(leaseKey(issue), idStr, "EX", ttl, "NX");
+    if (took !== "OK") continue; // another worker/adopter holds this issue
+
+    let step = 0; // 0 = nothing written; 1 = changes-requested removed; 2 = claimed added
+    let assigneeSet = false;
+    try {
+      const removed = await gh.removeLabel(issue, CHANGES_REQUESTED_LABEL);
+      if (!removed) {
+        // Live issue is no longer changes-requested (already adopted / author
+        // came back / stale mirror). Nothing written — free the lease, skip.
+        await delLeaseIfOwned(orch, leaseKey(issue), idStr).catch(() => undefined);
+        continue;
+      }
+      step = 1;
+      await gh.addLabels(issue, [CLAIMED_LABEL]);
+      step = 2;
+      try {
+        await gh.addAssignees(issue, [ctx.handle]);
+        assigneeSet = true;
+      } catch (err) {
+        if (err instanceof GitHubApiError && err.code === "assignee-ignored") {
+          // Auto-enrolled outside contributor without repo access — the lease +
+          // assignment doc carry the claim identity; labels still gate. Proceed.
+        } else {
+          throw err;
+        }
+      }
+    } catch (err) {
+      const undoPartialWrites = async (): Promise<void> => {
+        if (step >= 2) await gh.removeLabel(issue, CLAIMED_LABEL).catch(() => undefined);
+        if (step >= 1) await gh.addLabels(issue, [CHANGES_REQUESTED_LABEL]).catch(() => undefined);
+      };
+      if (err instanceof GitHubApiError && err.isRateLimit) {
+        await undoPartialWrites();
+        await delLeaseIfOwned(orch, leaseKey(issue), idStr).catch(() => undefined);
+        return { status: "rate-limited", retryAfterSeconds: err.retryAfterSeconds ?? 60 };
+      }
+      if (err instanceof GitHubApiError && err.status === 403) {
+        await undoPartialWrites();
+        await delLeaseIfOwned(orch, leaseKey(issue), idStr).catch(() => undefined);
+        return { status: "disabled", reason: "github token lacks write access" };
+      }
+      if (err instanceof GitHubApiError && err.status >= 400 && err.status < 500) {
+        await undoPartialWrites();
+        await delLeaseIfOwned(orch, leaseKey(issue), idStr).catch(() => undefined);
+        continue;
+      }
+      await undoPartialWrites();
+      await delLeaseIfOwned(orch, leaseKey(issue), idStr).catch(() => undefined);
+      throw err; // 5xx / network — surface to the route; lease is freed
+    }
+
+    // --- Durable audit + optimistic issue-mirror + fleet feed ---------------
+    const now = nowIso();
+    const assignment: AssignmentDoc = {
+      _id: assignmentId,
+      kind: "rework",
+      issueNumber: issue, // the WORKED issue — see AssignmentDoc.issueNumber
+      handle: ctx.handle,
+      tier: ctx.tier,
+      ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
+      ...(ctx.harness ? { harness: ctx.harness } : {}),
+      ...(ctx.model ? { model: ctx.model } : {}),
+      claimedAt: now,
+      renewedAt: now,
+      active: true,
+      assigneeSet,
+      prNumber: n,
+    };
+    try {
+      await assignmentsCol(orch).insertOne(assignment);
+      const issueDoc = await issuesCol(orch).findOne({ _id: issue });
+      if (issueDoc) {
+        const labels = issueDoc.labels.filter((l) => l !== CHANGES_REQUESTED_LABEL);
+        if (!labels.includes(CLAIMED_LABEL)) labels.push(CLAIMED_LABEL);
+        const assignees =
+          !assigneeSet || issueDoc.assignees.includes(ctx.handle)
+            ? issueDoc.assignees
+            : [...issueDoc.assignees, ctx.handle];
+        await issuesCol(orch).updateOne({ _id: issue }, { $set: { labels, assignees, updatedAt: now } });
+      }
+    } catch (err) {
+      await assignmentsCol(orch).deleteOne({ _id: assignmentId }).catch(() => undefined);
+      await revertClaimLabels(orch, issue, ctx.handle, CHANGES_REQUESTED_LABEL).catch(() => undefined);
+      await delLeaseIfOwned(orch, leaseKey(issue), idStr).catch(() => undefined);
+      throw err;
+    }
+
+    store.addEvent(
+      "claim",
+      `@${ctx.handle} adopted rework of PR #${n} (issue #${issue}) from @${candidate.user ?? "?"} — ${candidate.title}`,
+      { handle: ctx.handle, ...(ctx.harness ? { harness: ctx.harness } : {}), ref: `#${issue}` },
+    );
+
+    return {
+      status: "claimed",
+      rework: toClaimedRework(candidate, issue),
+      assignmentId: idStr,
+      leaseTtlSeconds: ttl,
+    };
+  }
+
+  return { status: "empty" };
+}
+
 /** Compare-and-EXPIRE: extend the lease only while it still belongs to this
  *  assignment — never extend a rival's lease or a sweeper's takeover
  *  sentinel. Atomic, so there is no GET→EXPIRE gap to race through. */
@@ -816,6 +1165,9 @@ async function revertClaimLabels(
   orch: Orchestrator,
   issue: number,
   handle: string,
+  /** The status to restore. Work claims go back to `available`; rework claims
+   *  go back to `changes-requested` (ADR-0020 — the review still stands). */
+  restoreLabel: string = AVAILABLE_LABEL,
 ): Promise<RevertResult> {
   const gh = orch.gh;
   if (!gh) return "skipped";
@@ -829,7 +1181,7 @@ async function revertClaimLabels(
   const liveLabels = (live.labels ?? []).map((l) => l.name);
   if (live.state !== "open" || !liveLabels.includes(CLAIMED_LABEL)) return "skipped";
   try {
-    await gh.addLabels(issue, [AVAILABLE_LABEL]);
+    await gh.addLabels(issue, [restoreLabel]);
     await gh.removeLabel(issue, CLAIMED_LABEL);
     await gh.removeAssignees(issue, [handle]);
   } catch (err) {
@@ -839,12 +1191,17 @@ async function revertClaimLabels(
   const doc = await issuesCol(orch).findOne({ _id: issue });
   if (!doc) return "reverted";
   const labels = doc.labels.filter((l) => l !== CLAIMED_LABEL);
-  if (!labels.includes(AVAILABLE_LABEL)) labels.push(AVAILABLE_LABEL);
+  if (!labels.includes(restoreLabel)) labels.push(restoreLabel);
   await issuesCol(orch).updateOne(
     { _id: issue },
     { $set: { labels, assignees: doc.assignees.filter((a) => a !== handle), updatedAt: nowIso() } },
   );
   return "reverted";
+}
+
+/** The status a kind's claim reverts to on abandon/expiry. */
+function revertTargetLabel(kind: AssignmentKind): string {
+  return kind === "rework" ? CHANGES_REQUESTED_LABEL : AVAILABLE_LABEL;
 }
 
 /** Mark one assignment inactive (race-safe on `active: true`), free its
@@ -874,25 +1231,27 @@ async function finishAssignment(
   );
   if (res.matchedCount === 0) return { finished: false, reverted: false };
   await delLeaseIfOwned(orch, assignmentLeaseKey(assignment), opts.leaseValue ?? assignment._id.toHexString());
-  // An ABANDONED review means the runner claimed the PR and then skipped it
+  // An ABANDONED review/rework means the runner claimed and then skipped it
   // locally (already passed at head, author == its posting identity, parked
-  // for a human, crash) — mirror state the server couldn't see. Re-serving
-  // the PR immediately would hand the deterministic oldest-first queue's
-  // head to every runner in a claim → skip → abandon loop, so park it out of
-  // dispatch for a cooldown instead (the walk can still reach it).
-  // Lease-expired releases deliberately DON'T cool down: the lease TTL
-  // itself already spaced that claim out, and a crashed reviewer's PR should
-  // re-queue promptly (ADR-0019 "back in the review queue").
-  if (kindOf(assignment) === "review" && outcome === "abandoned") {
-    await orch.redis
-      .set(reviewCooldownKey(assignment.issueNumber), assignment.handle, "EX", config.reviewAbandonCooldownSeconds)
-      .catch(() => undefined);
+  // for a human, the author pushed mid-window, crash) — mirror state the
+  // server couldn't see. Re-serving immediately would hand the deterministic
+  // oldest-first queue's head to every runner in a claim → skip → abandon
+  // loop, so park it out of dispatch for a cooldown (the walk can still reach
+  // it). Lease-expired releases deliberately DON'T cool down: the lease TTL
+  // itself already spaced that claim out, and a crashed worker's item should
+  // re-queue promptly.
+  const kind = kindOf(assignment);
+  if (outcome === "abandoned" && (kind === "review" || kind === "rework")) {
+    const cooldownKey = kind === "review" ? reviewCooldownKey(assignment.issueNumber) : reworkCooldownKey(assignment.issueNumber);
+    const cooldownSecs = kind === "review" ? config.reviewAbandonCooldownSeconds : config.reworkAbandonCooldownSeconds;
+    await orch.redis.set(cooldownKey, assignment.handle, "EX", cooldownSecs).catch(() => undefined);
   }
   let reverted = false;
-  // Label reverts are a kind:"work" concept only — review claims hold no
-  // labels (nothing was written on claim, so there is nothing to revert).
-  if (opts.revert && kindOf(assignment) === "work") {
-    const result = await revertClaimLabels(orch, assignment.issueNumber, assignment.handle);
+  // Review claims hold no labels — nothing to revert. Work and rework claims
+  // BOTH write `status: claimed` + an assignee, and revert to their own
+  // status: work → available, rework → changes-requested.
+  if (opts.revert && kind !== "review") {
+    const result = await revertClaimLabels(orch, assignment.issueNumber, assignment.handle, revertTargetLabel(kind));
     reverted = result === "reverted";
     if (result === "failed") {
       await assignmentsCol(orch)
@@ -948,14 +1307,19 @@ export async function releaseAssignment(
   });
   if (!finished) return false;
 
+  const kind = kindOf(doc);
   const text =
-    kindOf(doc) === "review"
+    kind === "review"
       ? opts.outcome === "done"
         ? `@${doc.handle} finished reviewing PR #${opts.issue}`
         : `@${doc.handle}'s review claim on PR #${opts.issue} released (${opts.outcome})`
-      : opts.outcome === "done"
-        ? `@${doc.handle} finished #${opts.issue}${opts.prNumber ? ` → PR #${opts.prNumber}` : ""}`
-        : `@${doc.handle}'s claim on #${opts.issue} released (${opts.outcome})`;
+      : kind === "rework"
+        ? opts.outcome === "done"
+          ? `@${doc.handle} pushed adopted rework of #${opts.issue}${opts.prNumber ? ` → PR #${opts.prNumber}` : doc.prNumber ? ` → PR #${doc.prNumber}` : ""}`
+          : `@${doc.handle}'s adopted rework of #${opts.issue} released (${opts.outcome}) — back to changes-requested`
+        : opts.outcome === "done"
+          ? `@${doc.handle} finished #${opts.issue}${opts.prNumber ? ` → PR #${opts.prNumber}` : ""}`
+          : `@${doc.handle}'s claim on #${opts.issue} released (${opts.outcome})`;
   store.addEvent("claim", text, { handle: doc.handle, ref: `#${opts.issue}` });
   return true;
 }
@@ -972,12 +1336,13 @@ export async function renewLeasesForHandle(orch: Orchestrator, handle: string): 
   try {
     const active = await assignmentsCol(orch).find({ handle, active: true }).toArray();
     for (const doc of active) {
-      // The claimed-label mirror guard applies ONLY to kind "work" — a review
-      // claim writes no labels/assignees anywhere, so there is no mirror
-      // state to cross-check; an active review assignment renews while the
-      // agent heartbeats (compare-and-EXPIRE on lease:review:<n>, so a lapsed
-      // lease is still never resurrected).
-      if (kindOf(doc) === "work") {
+      // The claimed-label mirror guard applies to kind "work" AND "rework" —
+      // both write `status: claimed` + an assignee on their issue, so the
+      // mirror can be cross-checked. A review claim writes no labels/assignees
+      // anywhere, so there is nothing to check; an active review assignment
+      // renews while the agent heartbeats (compare-and-EXPIRE on
+      // lease:review:<n>, so a lapsed lease is still never resurrected).
+      if (kindOf(doc) !== "review") {
         const issue = await issuesCol(orch).findOne(
           { _id: doc.issueNumber },
           { projection: { labels: 1, assignees: 1 } },
@@ -1042,8 +1407,10 @@ export async function sweepExpiredLeases(orch: Orchestrator, store: FleetStore):
         );
         if (took !== "OK") continue; // a lease exists (live, or just re-taken by renew)
         // Kind "review": no label revert (review claims hold no labels) —
-        // the PR simply becomes claimable again once the lease is gone.
-        const isReview = kindOf(doc) === "review";
+        // the PR simply becomes claimable again once the lease is gone. Work
+        // and rework both revert (to available / changes-requested resp.).
+        const swKind = kindOf(doc);
+        const isReview = swKind === "review";
         const { finished, reverted } = await finishAssignment(orch, doc, "lease-expired", {
           revert: !isReview,
           leaseValue: sentinel,
@@ -1057,9 +1424,13 @@ export async function sweepExpiredLeases(orch: Orchestrator, store: FleetStore):
           "claim",
           isReview
             ? `review lease expired — PR #${doc.issueNumber} back in the review queue (was @${doc.handle})`
-            : reverted
-              ? `lease expired — #${doc.issueNumber} is back in the queue (was @${doc.handle})`
-              : `lease expired — released @${doc.handle}'s claim on #${doc.issueNumber} (labels left as-is)`,
+            : swKind === "rework"
+              ? reverted
+                ? `rework lease expired — #${doc.issueNumber} back to changes-requested (was @${doc.handle})`
+                : `rework lease expired — released @${doc.handle}'s adoption of #${doc.issueNumber} (labels left as-is)`
+              : reverted
+                ? `lease expired — #${doc.issueNumber} is back in the queue (was @${doc.handle})`
+                : `lease expired — released @${doc.handle}'s claim on #${doc.issueNumber} (labels left as-is)`,
           { handle: doc.handle, ref: `#${doc.issueNumber}` },
         );
       } catch (err) {
@@ -1075,13 +1446,15 @@ export async function sweepExpiredLeases(orch: Orchestrator, store: FleetStore):
       .toArray();
     for (const doc of pending) {
       try {
-        const result = await revertClaimLabels(orch, doc.issueNumber, doc.handle);
+        const result = await revertClaimLabels(orch, doc.issueNumber, doc.handle, revertTargetLabel(kindOf(doc)));
         if (result === "failed") continue; // try again next pass
         await assignmentsCol(orch).updateOne({ _id: doc._id }, { $unset: { revertPending: "" } });
         if (result === "reverted") {
           store.addEvent(
             "claim",
-            `#${doc.issueNumber} is back in the queue (was @${doc.handle}; revert retried)`,
+            kindOf(doc) === "rework"
+              ? `#${doc.issueNumber} back to changes-requested (was @${doc.handle}; revert retried)`
+              : `#${doc.issueNumber} is back in the queue (was @${doc.handle}; revert retried)`,
             { handle: doc.handle, ref: `#${doc.issueNumber}` },
           );
         }

--- a/server/src/orchestrator/stores.ts
+++ b/server/src/orchestrator/stores.ts
@@ -47,6 +47,18 @@ export function reviewCooldownKey(pr: number): string {
   return `cooldown:review:${pr}`;
 }
 
+/** Redis key parking an issue out of rework dispatch after an ABANDONED
+ *  rework release (`SET EX reworkAbandonCooldownSeconds`, ADR-0020). A runner
+ *  that adopts a rework and then skips it locally (the author pushed a new
+ *  commit mid-window, a crash, a usage limit) releases `abandoned` and reverts
+ *  the label to `changes-requested` — which makes the PR adoptable again, so
+ *  without a cooldown the deterministic oldest-first queue re-serves it to
+ *  every runner on every pass. Keyed by the ISSUE number (the rework
+ *  assignment's number space), same as its lease. */
+export function reworkCooldownKey(issue: number): string {
+  return `cooldown:rework:${issue}`;
+}
+
 /** Redis key holding one handle's current command (JSON, or unset). */
 export function commandKey(handle: string): string {
   return `cmd:${handle}`;

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -275,8 +275,10 @@ export type EnrollRequest = z.infer<typeof enrollRequestSchema>;
 export const claimRequestSchema = z.object({
   /** What to claim: "work" = the next available issue (the default, and the
    *  only kind before ADR-0019); "review" = the next open PR needing an
-   *  adversarial review. `stages` only applies to kind "work". */
-  kind: z.enum(["work", "review"]).default("work"),
+   *  adversarial review; "rework" = the next stale `changes-requested` PR a
+   *  DIFFERENT worker may adopt (ADR-0020). `stages` only applies to kind
+   *  "work". */
+  kind: z.enum(["work", "review", "rework"]).default("work"),
   stages: z.array(z.enum(["research", "ideate", "build"])).optional(), // default: all three
   harness: z.string().max(32).optional(),
   model: z.string().max(128).optional(),
@@ -286,8 +288,10 @@ export type ClaimRequest = z.infer<typeof claimRequestSchema>;
 
 export const releaseRequestSchema = z.object({
   /** For kind "review", `issue` carries the PR number (one GitHub number
-   *  space — a number is never both an issue and a PR). */
-  kind: z.enum(["work", "review"]).default("work"),
+   *  space — a number is never both an issue and a PR). For kind "rework"
+   *  `issue` is the WORKED issue number (whose labels the claim moved), and
+   *  `prNumber` the PR being reworked. */
+  kind: z.enum(["work", "review", "rework"]).default("work"),
   issue: z.number().int().positive(),
   outcome: z.enum(["done", "abandoned"]),
   prNumber: z.number().int().positive().optional(),
@@ -304,6 +308,16 @@ export interface ClaimedIssue {
 export interface ClaimedReview {
   pr: number; title: string; author: string | null; headSha: string; htmlUrl: string;
   baseRef: string; headRef: string;
+}
+
+/** What a kind:"rework" claim hands the runner (ADR-0020): the PR to rework
+ *  AND the worked issue whose status the claim moved to `claimed` (the runner
+ *  flips it back to `in-review` on push). `author` is the PR author the
+ *  rework is being adopted FROM, `headSha` the revision the adopter must not
+ *  clobber if the author quietly returns (the pre-push guard). */
+export interface ClaimedRework {
+  pr: number; issue: number; title: string; author: string | null; headSha: string;
+  htmlUrl: string; headRef: string;
 }
 // Server->agent WS message (agents only, not watchers):
 //   { type: "command", command: FleetCommand }

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -34,10 +34,12 @@ import { bearerToken, enrollAgent, verifyAgentToken, type AgentIdentity } from "
 import {
   claimNext,
   claimNextReview,
+  claimNextRework,
   releaseAssignment,
   renewLease,
   type ClaimResult,
   type ClaimReviewResult,
+  type ClaimReworkResult,
 } from "../orchestrator/dispatch.js";
 import type { Orchestrator } from "../orchestrator/stores.js";
 import { claimRequestSchema, enrollRequestSchema, releaseRequestSchema } from "../protocol.js";
@@ -121,12 +123,14 @@ export function registerDispatchRoutes(
       ...(parsed.data.model ? { model: parsed.data.model } : {}),
       ...(parsed.data.agentId ? { agentId: parsed.data.agentId } : {}),
     };
-    let result: ClaimResult | ClaimReviewResult;
+    let result: ClaimResult | ClaimReviewResult | ClaimReworkResult;
     try {
       result =
         parsed.data.kind === "review"
           ? await claimNextReview(orch, store, ctx)
-          : await claimNext(orch, store, ctx);
+          : parsed.data.kind === "rework"
+            ? await claimNextRework(orch, store, ctx)
+            : await claimNext(orch, store, ctx);
     } catch (err) {
       // Never serialize upstream error messages to the client — they embed
       // the GitHub API path and upstream error text. Log server-side only.
@@ -136,18 +140,28 @@ export function registerDispatchRoutes(
       }
       return reply.code(500).send({ ok: false, error: "internal error" });
     }
-    // kind:"review" responses carry `review` where work carries `issue` —
-    // same statuses, so a runner's queue-empty/error handling is one path.
-    // Every response ECHOES the kind it executed, so a runner can detect a
-    // server that silently dropped an unknown kind (deploy skew — the
-    // pre-ADR-0019 schema stripped `kind` and ran a WORK claim).
-    const emptyPayload = parsed.data.kind === "review" ? { review: null } : { issue: null };
+    // kind:"review" responses carry `review`, kind:"rework" carry `rework`,
+    // where work carries `issue` — same statuses, so a runner's
+    // queue-empty/error handling is one path. Every response ECHOES the kind it
+    // executed, so a runner can detect a server that silently dropped an unknown
+    // kind (deploy skew — the pre-ADR-0019 schema stripped `kind` and ran a
+    // WORK claim).
+    const emptyPayload =
+      parsed.data.kind === "review"
+        ? { review: null }
+        : parsed.data.kind === "rework"
+          ? { rework: null }
+          : { issue: null };
     switch (result.status) {
       case "claimed":
         return {
           ok: true,
           kind: parsed.data.kind,
-          ...("review" in result ? { review: result.review } : { issue: result.issue }),
+          ...("review" in result
+            ? { review: result.review }
+            : "rework" in result
+              ? { rework: result.rework }
+              : { issue: result.issue }),
           assignmentId: result.assignmentId,
           leaseTtlSeconds: result.leaseTtlSeconds,
           handle: identity.handle,

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -280,6 +280,20 @@ export class FleetStore extends EventEmitter {
       .sort((a, b) => a.connectedAt.localeCompare(b.connectedAt));
   }
 
+  /** Is any live agent connected under this GitHub handle? Rework dispatch
+   *  (ADR-0020) uses this to skip a PR whose AUTHOR is currently online — an
+   *  online author is presumed to be working (or about to work) their own
+   *  rework, so adoption targets the absent author the bottleneck is about.
+   *  "Live" = present in the agents map and not past its TTL (sweepAgents runs
+   *  on a timer, so check expiry here rather than trusting prompt reaping). */
+  isHandleOnline(handle: string): boolean {
+    const now = Date.now();
+    for (const rec of this.agents.values()) {
+      if (rec.handle === handle && rec.expiresAt >= now) return true;
+    }
+    return false;
+  }
+
   /** Coalesced: heartbeats arrive per tool call once the harness hooks are
    *  wired, so publishing the whole fleet per heartbeat would be an
    *  O(agents × watchers) storm. Mark dirty, flush at most once per window. */

--- a/server/test/dispatch.test.mjs
+++ b/server/test/dispatch.test.mjs
@@ -60,6 +60,7 @@ function mirrorPull({
   user = "octocat",
   headRef = `branch-${number}`,
   headSha = `sha-${number}-1`,
+  headRepoFullName = "example/repo",
   baseRef = "main",
   createdAt = "2026-01-01T00:00:00Z",
   reviews,
@@ -76,7 +77,7 @@ function mirrorPull({
     htmlUrl: `https://github.com/example/repo/pull/${number}`,
     headRef,
     headSha,
-    headRepoFullName: "example/repo",
+    headRepoFullName,
     baseRef,
     merged: false,
     mergedAt: null,
@@ -126,7 +127,7 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
 
   try {
     const { config } = await import("../dist/config.js");
-    const { connectOrchestrator, leaseKey, reviewLeaseKey, reviewCooldownKey } = await import("../dist/orchestrator/stores.js");
+    const { connectOrchestrator, leaseKey, reviewLeaseKey, reviewCooldownKey, reworkCooldownKey } = await import("../dist/orchestrator/stores.js");
     const dispatch = await import("../dist/orchestrator/dispatch.js");
     const { FleetStore } = await import("../dist/state.js");
 
@@ -1307,6 +1308,240 @@ test("dispatch (real redis+mongo, mock github)", async (t) => {
       assert.equal(healed.state, "closed", "mirror self-healed from the live read");
       assert.equal(healed.merged, true);
       assert.equal(await anyAssignment(321), null, "no assignment recorded for the merged PR");
+    });
+
+    // ---------------------------------------------------- rework dispatch
+    // (ADR-0020 — adopt a stale changes-requested PR from an absent author)
+
+    /** Seed a rework scenario: PULL fixtures (mirror + mock, body carries the
+     *  `Closes #issue` link the winner is resolved from) AND the linked ISSUE
+     *  fixtures (mirror + mock, carrying `status: changes-requested`). */
+    async function seedReworks(pullSpecs, issueSpecs) {
+      await o.redis.flushdb();
+      await o.db.collection("issues").deleteMany({});
+      await o.db.collection("assignments").deleteMany({});
+      await o.db.collection("pulls").deleteMany({});
+      mock.reset();
+      mock.assignableUsers = null;
+      mock.seed({
+        issues: issueSpecs.map((s) => makeIssue(s)),
+        pulls: pullSpecs.map(({ restReviews, reviews, reviewsFetchedFor, ...s }) =>
+          makePull({ ...s, reviews: restReviews ?? [] })),
+      });
+      if (issueSpecs.length) await o.db.collection("issues").insertMany(issueSpecs.map(mirrorIssue));
+      if (pullSpecs.length) await o.db.collection("pulls").insertMany(pullSpecs.map(mirrorPull));
+    }
+
+    const hoursAgo = (h) => new Date(Date.now() - h * 3600 * 1000).toISOString();
+    const IDLE = hoursAgo(10); // older than the 6h default → adoptable
+    const FRESH = hoursAgo(1); // within 6h → NOT idle enough
+
+    // A single clean adoptable candidate (PR 460 → issue 234), plus a bag of
+    // UNCONDITIONALLY ineligible ones — each predates it and would win if
+    // eligible, and each is ineligible for ANY claimant (author/last-reviewer
+    // exclusion is claimant-specific and is tested separately). All authored by
+    // "carol", reviewed by "bob", so no claimant below (alice/erin) is ever the
+    // author or reviewer of these.
+    const cleanRework = (over = {}) => ({
+      pulls: [
+        { number: 443, user: "carol", headSha: "sha-443-1", body: "Closes #243", createdAt: "2026-06-01T00:00:00Z",
+          reviewsFetchedFor: "sha-443-1", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-443-1", at: FRESH }] }, // not idle
+        { number: 444, user: "carol", headSha: "sha-444-1", headRef: "synthesis/x", body: "Part of #244", createdAt: "2026-06-01T00:00:00Z",
+          reviewsFetchedFor: "sha-444-1", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-444-1", at: IDLE }] }, // synthesis
+        { number: 445, user: "carol", headSha: "sha-445-1", headRef: "discover/x", body: "Part of #245", createdAt: "2026-06-01T00:00:00Z",
+          reviewsFetchedFor: "sha-445-1", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-445-1", at: IDLE }] }, // framing
+        { number: 446, user: "carol", headSha: "sha-446-1", headRepoFullName: "someforker/repo", body: "Closes #246", createdAt: "2026-06-01T00:00:00Z",
+          reviewsFetchedFor: "sha-446-1", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-446-1", at: IDLE }] }, // fork
+        { number: 447, user: "carol", headSha: "sha-447-1", labels: ["review: human-only"], body: "Closes #247", createdAt: "2026-06-01T00:00:00Z",
+          reviewsFetchedFor: "sha-447-1", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-447-1", at: IDLE }] }, // human-only
+        { number: 448, user: "carol", headSha: "sha-448-2", body: "Closes #248", createdAt: "2026-06-01T00:00:00Z",
+          reviewsFetchedFor: "sha-448-2", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-448-1", at: IDLE }] }, // author pushed since review (new head)
+        { number: 449, user: "carol", headSha: "sha-449-1", body: "Closes #249", createdAt: "2026-06-01T00:00:00Z",
+          reviewsFetchedFor: "sha-449-1", reviews: [{ reviewer: "bob", state: "approved", commitId: "sha-449-1", at: IDLE }] }, // approved at head
+        { number: 450, user: "carol", headSha: "sha-450-1", labels: ["do-not-automate"], body: "Closes #250", createdAt: "2026-06-01T00:00:00Z",
+          reviewsFetchedFor: "sha-450-1", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-450-1", at: IDLE }] }, // do-not-automate
+        // The clean winner — newest createdAt so it only wins once all the
+        // older ones are correctly excluded.
+        { number: 460, user: "dave", headSha: "sha-460-1", body: "Closes #234", title: "research: finding Y", createdAt: "2026-06-09T00:00:00Z",
+          reviewsFetchedFor: "sha-460-1", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-460-1", at: IDLE }], ...over },
+      ],
+      issues: [
+        { number: 243, labels: ["status: changes-requested"] },
+        { number: 246, labels: ["status: changes-requested"] },
+        { number: 247, labels: ["status: changes-requested"] },
+        { number: 248, labels: ["status: changes-requested"] },
+        { number: 249, labels: ["status: changes-requested"] },
+        { number: 250, labels: ["status: changes-requested"] },
+        { number: 234, labels: ["status: changes-requested"], title: "research: finding Y" },
+      ],
+    });
+
+    await t.test("claimNextRework: adopts an idle stale rework, moves labels, skips every ineligible", async () => {
+      const { pulls, issues } = cleanRework();
+      await seedReworks(pulls, issues);
+      const store = new FleetStore();
+
+      const result = await dispatch.claimNextRework(o, store, {
+        handle: "alice", tier: "standard", harness: "claude", model: "claude-opus-4-8",
+      });
+      assert.equal(result.status, "claimed");
+      assert.deepEqual(result.rework, {
+        pr: 460, issue: 234, title: "research: finding Y", author: "dave",
+        headSha: "sha-460-1", htmlUrl: "https://github.com/example/repo/pull/460", headRef: "branch-460",
+      });
+      assert.equal(result.leaseTtlSeconds, config.reworkLeaseTtlSeconds);
+
+      // Issue 234 moved changes-requested → claimed + adopter assigned.
+      const liveIssue = await mock.getIssue(234);
+      const names = liveIssue.labels;
+      assert.ok(names.includes("status: claimed") && !names.includes("status: changes-requested"), names.join(","));
+      assert.ok(liveIssue.assignees.includes("alice"), "adopter assigned");
+
+      // Lease on the ISSUE (reused work lease), assignment kind "rework" w/ PR.
+      assert.equal(await o.redis.get(leaseKey(234)), result.assignmentId);
+      const assignment = await activeAssignment(234);
+      assert.equal(assignment.kind, "rework");
+      assert.equal(assignment.handle, "alice");
+      assert.equal(assignment.prNumber, 460);
+
+      // Mirror optimistically updated.
+      const mirror = await o.db.collection("issues").findOne({ _id: 234 });
+      assert.ok(mirror.labels.includes("status: claimed") && !mirror.labels.includes("status: changes-requested"));
+
+      const event = store.recentEvents().find((e) => e.kind === "claim");
+      assert.ok(event && event.text.includes("adopted rework of PR #460") && event.text.includes("from @dave"), event?.text);
+
+      // Nothing else is adoptable now (all the others are unconditionally
+      // ineligible, and 460 is now leased).
+      const again = await dispatch.claimNextRework(o, new FleetStore(), { handle: "erin", tier: "standard" });
+      assert.equal(again.status, "empty", "idle/synthesis/framing/fork/human-only/new-head/approved/dna all excluded");
+    });
+
+    await t.test("claimNextRework: excludes the PR's OWN author and its last reviewer (per claimant)", async () => {
+      // One adoptable PR authored by @dave, last-reviewed by @bob. It is
+      // adoptable by a THIRD party, but never by dave (author) or bob (reviewer)
+      // — that's what keeps author ≠ reviewer after the fix is re-reviewed.
+      await seedReworks(
+        [{ number: 480, user: "dave", headSha: "sha-480-1", body: "Closes #280", createdAt: "2026-06-01T00:00:00Z",
+           reviewsFetchedFor: "sha-480-1", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-480-1", at: IDLE }] }],
+        [{ number: 280, labels: ["status: changes-requested"] }],
+      );
+      const asAuthor = await dispatch.claimNextRework(o, new FleetStore(), { handle: "dave", tier: "standard" });
+      assert.equal(asAuthor.status, "empty", "the author can't adopt their own frozen PR");
+      const asReviewer = await dispatch.claimNextRework(o, new FleetStore(), { handle: "bob", tier: "standard" });
+      assert.equal(asReviewer.status, "empty", "the last reviewer can't adopt (would re-review their own fix)");
+      const asThird = await dispatch.claimNextRework(o, new FleetStore(), { handle: "erin", tier: "standard" });
+      assert.equal(asThird.status, "claimed", "a third identity adopts it");
+      assert.equal(asThird.rework.pr, 480);
+    });
+
+    await t.test("claimNextRework: an ONLINE author is skipped; an OFFLINE author is adopted", async () => {
+      const { pulls, issues } = cleanRework();
+      await seedReworks(pulls, issues);
+      const store = new FleetStore();
+      // Bring @dave (author of PR 460) online in this store.
+      store.upsertAgent({ type: "hello", handle: "dave", harness: "claude", model: "x" }, "http");
+
+      const skipped = await dispatch.claimNextRework(o, store, { handle: "alice", tier: "standard" });
+      assert.equal(skipped.status, "empty", "author online → not adopted (they're presumed to be reworking it)");
+
+      // Offline store → adopted.
+      const adopted = await dispatch.claimNextRework(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(adopted.status, "claimed");
+      assert.equal(adopted.rework.pr, 460);
+    });
+
+    await t.test("claimNextRework: the lease stops two adopters colliding on one PR", async () => {
+      const { pulls, issues } = cleanRework();
+      await seedReworks(pulls, issues);
+      const results = await Promise.all([
+        dispatch.claimNextRework(o, new FleetStore(), { handle: "alice", tier: "standard" }),
+        dispatch.claimNextRework(o, new FleetStore(), { handle: "erin", tier: "standard" }),
+      ]);
+      const claimed = results.filter((r) => r.status === "claimed");
+      assert.equal(claimed.length, 1, "exactly one adopter wins the single candidate");
+      assert.equal(claimed[0].rework.pr, 460);
+    });
+
+    await t.test("rework release done: labels left claimed (runner flips to in-review itself), lease gone", async () => {
+      const { pulls, issues } = cleanRework();
+      await seedReworks(pulls, issues);
+      const claim = await dispatch.claimNextRework(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(claim.status, "claimed");
+      const ok = await dispatch.releaseAssignment(o, new FleetStore(), {
+        issue: 234, outcome: "done", kind: "rework", handle: "alice", prNumber: 460,
+      });
+      assert.equal(ok, true);
+      const live = await mock.getIssue(234);
+      const names = live.labels;
+      assert.ok(names.includes("status: claimed"), "done never reverts — the runner owns the → in-review flip");
+      assert.equal(await o.redis.exists(leaseKey(234)), 0, "lease freed");
+      const a = await anyAssignment(234);
+      assert.equal(a.active, false);
+      assert.equal(a.outcome, "done");
+    });
+
+    await t.test("rework release abandoned: reverts to changes-requested, assignee removed, cools down", async () => {
+      const { pulls, issues } = cleanRework();
+      await seedReworks(pulls, issues);
+      const claim = await dispatch.claimNextRework(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(claim.status, "claimed");
+      const ok = await dispatch.releaseAssignment(o, new FleetStore(), {
+        issue: 234, outcome: "abandoned", kind: "rework", handle: "alice", prNumber: 460,
+      });
+      assert.equal(ok, true);
+      const live = await mock.getIssue(234);
+      const names = live.labels;
+      assert.ok(names.includes("status: changes-requested") && !names.includes("status: claimed"),
+        "abandon reverts to changes-requested (NOT available), so the PR/feedback still stands");
+      assert.ok(!live.assignees.includes("alice"), "adopter unassigned");
+      assert.equal(await o.redis.exists(leaseKey(234)), 0, "lease freed");
+      // Cooldown parks it out of re-adoption immediately.
+      assert.equal(await o.redis.exists(reworkCooldownKey(234)), 1, "cooldown set");
+      const again = await dispatch.claimNextRework(o, new FleetStore(), { handle: "erin", tier: "standard" });
+      assert.equal(again.status, "empty", "cooling down → not re-served");
+    });
+
+    await t.test("sweeper: an expired rework lease reverts the issue to changes-requested", async () => {
+      const { pulls, issues } = cleanRework();
+      await seedReworks(pulls, issues);
+      const claim = await dispatch.claimNextRework(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(claim.status, "claimed");
+      await o.redis.del(leaseKey(234)); // simulate a crashed adopter's lapsed lease
+      const expired = await dispatch.sweepExpiredLeases(o, new FleetStore());
+      assert.ok(expired >= 1);
+      const live = await mock.getIssue(234);
+      const names = live.labels;
+      assert.ok(names.includes("status: changes-requested") && !names.includes("status: claimed"),
+        "sweeper reverts a rework to changes-requested, not available");
+      const a = await anyAssignment(234);
+      assert.equal(a.active, false);
+      assert.equal(a.outcome, "lease-expired");
+    });
+
+    await t.test("claimNextRework: a do-not-automate ISSUE is never adopted (label lives on the issue, not the PR)", async () => {
+      await seedReworks(
+        [{ number: 490, user: "dave", headSha: "sha-490-1", body: "Closes #290", createdAt: "2026-06-01T00:00:00Z",
+           reviewsFetchedFor: "sha-490-1", reviews: [{ reviewer: "bob", state: "changes_requested", commitId: "sha-490-1", at: IDLE }] }],
+        [{ number: 290, labels: ["status: changes-requested", "do-not-automate"] }],
+      );
+      const result = await dispatch.claimNextRework(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(result.status, "empty", "do-not-automate on the worked issue blocks adoption");
+    });
+
+    await t.test("claimNextRework: lazy-fetches review state when the mirror lacks it at head", async () => {
+      // No mirror `reviews`/`reviewsFetchedFor` — only the mock's REST reviews.
+      // Dispatch must fetch once to discover the idle changes-request at head.
+      await seedReworks(
+        [{ number: 470, user: "dave", headSha: "sha-470-1", body: "Closes #270", createdAt: "2026-06-01T00:00:00Z",
+           restReviews: [makeReview({ reviewer: "bob", state: "CHANGES_REQUESTED", commitId: "sha-470-1", submittedAt: IDLE })] }],
+        [{ number: 270, labels: ["status: changes-requested"] }],
+      );
+      const result = await dispatch.claimNextRework(o, new FleetStore(), { handle: "alice", tier: "standard" });
+      assert.equal(result.status, "claimed");
+      assert.equal(result.rework.pr, 470);
+      const doc = await o.db.collection("pulls").findOne({ _id: 470 });
+      assert.equal(doc.reviewsFetchedFor, "sha-470-1", "fetch marker persisted");
     });
 
     // ------------------------------------------------------------- routes

--- a/server/test/helpers/mock-github.mjs
+++ b/server/test/helpers/mock-github.mjs
@@ -88,6 +88,7 @@ export function makePull({
   createdAt = nowIso(),
   updatedAt = createdAt,
   reviews = [],
+  body = "",
 } = {}) {
   if (!Number.isInteger(number)) throw new Error("makePull: number is required");
   return {
@@ -98,6 +99,9 @@ export function makePull({
     labels: labels.map((l) => (typeof l === "string" ? { name: l } : l)),
     user: { login: user },
     html_url: `https://github.com/example/repo/pull/${number}`,
+    // GET /pulls/:n returns the body; rework dispatch (ADR-0020) reads it to
+    // resolve the worked issue from a `Closes`/`Part of #n` link.
+    body,
     head: { ref: headRef, sha: headSha, repo: { full_name: headRepoFullName } },
     base: { ref: baseRef },
     merged,


### PR DESCRIPTION
Closes #656.

## What

Rework only advanced when a PR's **own author** re-ran — so a `changes-requested` PR whose author went offline could freeze for days while idle enrolled workers had nothing to do (the live bottleneck in #656). This adds a third fleet-server dispatch **`kind: "rework"`** (mirroring ADR-0019's review dispatch) that hands an idle **>6h** (`REWORK_ADOPT_HOURS`) changes-requested PR to a **different** enrolled worker under an atomic lease, so the fleet self-heals instead of stalling on absent authors.

New **[ADR-0020](https://github.com/thecolab-ai/the-for-good-project/blob/pipeline/adopt-stale-rework/docs/adr/0020-adopt-stale-rework.md)** amends ADR-0008's implicit "author reworks their own PR" assumption.

## Adoptability (mirror-evaluated, fails toward *not* adopting)

- last review at the current head is `changes_requested`, older than the idle window (a newer commit ⇒ author already pushed rework ⇒ not adopted);
- PR author is **not currently online** (an online author is presumed to be working their own rework — uses fleet presence);
- adopter is **neither the author nor the last reviewer** → author ≠ reviewer is preserved through the re-review;
- not draft; not `synthesis/*` (ADR-0011) or `discover/*` (ADR-0014); not a fork; not `review: human-only`/`do-not-automate` (checked on the worked **issue** too, not just the PR).

## Mechanics

- **Atomic claim**: reuses the work lease on the worked issue; the `status: changes-requested` removal is the test-and-set (a rework and a work claim can never target the same issue). Release/expiry **reverts to `changes-requested`** (never `available` — the review still stands); an abandoned adoption cools down.
- **Client** (`start_work.sh`): tried after own-rework and TTL-freed rework, before a fresh claim. Adopter flow posts a `rework adopted by @x from @y` provenance comment, sets the finding's `agent`/`model` to the adopter, and uses `--force-with-lease` + a **pre-push guard** (re-reads live head vs the reviewed SHA) so a returning author is never clobbered.
- **Flag**: gated by `REWORK_ADOPT` **and** `FLEET_CLAIM` (the atomic lease, not a label race, arbitrates). `autopilot.sh` defaults it **on**; standalone `start_work.sh` is opt-in. Fail-open: any server trouble → the loop just skips adoption.
- **Forks**: per maintainer direction we're not taking outside fork branches into the automated pipeline for now — `reap.sh` closes fork-origin `changes-requested` PRs and releases their issue to `available` (`CLOSE_FORK_REWORKS=1`); the recorded review stays on the closed PR.

## Tests

- server: **+10** dispatch tests (adoption + every exclusion, presence skip, lease atomicity, done leaves labels, abandon reverts to changes-requested + cooldown, sweeper revert, lazy review-fetch, do-not-automate issue) — full server suite **145 pass**;
- client: **+bash** tests for `fleet_claim_rework`/`fleet_release_rework` (payloads, fallback, deploy-skew guard) — all fleet/queue/preflight/gh-shim suites pass;
- `npm run validate` clean (210 files).

## ⚠️ Review routing

This is a **pipeline/governance** change (dispatch, runner status flow, a new ADR). It should be labelled **`review: human-only`** and reviewed + merged by a human maintainer, and **ADR-0020 ratified on merge** — agents don't self-ratify pipeline changes. (I have not applied the label — that's a maintainer's to set.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)