### PR TITLE
reap: don't auto-close synthesis/framing fork reworks (follow-up to #657)

### DIFF
--- a/scripts/reap.sh
+++ b/scripts/reap.sh
@@ -115,11 +115,15 @@ reap_synthesis_claims() {
 #    we are not taking outside fork branches into the automated pipeline for
 #    now. Close the PR with an explanatory comment and release the issue to
 #    `available` so a fresh worker picks it up clean on a same-repo branch (the
-#    recorded review stays on the closed PR as reference). A `review: human-only`
-#    PR is left for the human maintainer.
+#    recorded review stays on the closed PR as reference). Left alone: a
+#    `review: human-only` PR (a human maintainer's), and — critically — a
+#    `synthesis/*` or `discover/*` fork PR: those reworks route to
+#    synthesize_work.sh / frame_work.sh under their capability floors (ADR-0011
+#    / ADR-0014), and a discover root must never be flipped to `available` by a
+#    generic cron. Those are surfaced for a human instead of auto-closed.
 reap_fork_reworks() {
   [ "$CLOSE_FORK_REWORKS" = 1 ] || return 0
-  local n pr owner labels who a
+  local n pr owner branch labels who a
   for n in $(gh issue list --repo "$REPO" --state open --label "status: changes-requested" \
       --json number --limit 100 --jq '.[].number'); do
     pr="$(pr_for_issue "$n" || true)"; [ -z "$pr" ] && continue
@@ -127,6 +131,15 @@ reap_fork_reworks() {
     # Empty owner = couldn't read (rate limit / transient) — fail closed, skip.
     [ -n "$owner" ] || continue
     [ "$owner" = "$OWNER" ] && continue   # same-repo branch — adoptable, leave it
+    # NEVER auto-close a synthesis/framing fork PR: those belong to
+    # synthesize_work.sh / frame_work.sh (ADR-0011 / ADR-0014), and closing a
+    # framing PR would flip a stream ROOT to `available`. Flag for a human.
+    branch="$(gh pr view "$pr" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null || true)"
+    case "$branch" in
+      synthesis/*|discover/*)
+        warn "#$n's fork PR #$pr is a ${branch%%/*} branch on a fork ($owner) — leaving it for a human (belongs to $([ "${branch%%/*}" = synthesis ] && echo synthesize_work.sh || echo frame_work.sh))."
+        continue ;;
+    esac
     labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '[.labels[].name]|join(",")' 2>/dev/null || true)"
     case ",$labels," in *",review: human-only,"*) log "#$n's fork PR #$pr is review: human-only — leaving it for a human."; continue ;; esac
     if [ "$DRY_RUN" = 1 ]; then info "[dry-run] would close fork PR #$pr ($owner) and release #$n → available"; continue; fi


### PR DESCRIPTION
Follow-up to #657 (ADR-0020). A gap I caught in the fork-cleanup sweep **before the next reap cron runs**.

## Problem

`reap_fork_reworks` (merged in #657) closes any fork-origin `changes-requested` PR and flips its issue to `available`. But that would also fire on a **fork `discover/*` framing PR** — e.g. live PR **#449** (`discover/hospital-wait-times`, fork `muhamdasim`) links **discover root #434**. Closing that PR and flipping a **stream root** to `available` violates the framing capability floor (ADR-0014) — framing rework belongs to `frame_work.sh`, and a root must never be genericised to `available` by a cron. Same reasoning for `synthesis/*` (ADR-0011).

`reap.sh` runs every 30 min from `main` with `CLOSE_FORK_REWORKS=1`, so this is time-sensitive.

## Fix

Skip `synthesis/*` and `discover/*` head branches in the fork sweep and surface them for a human instead of auto-closing.

## Verified (DRY_RUN against the live repo)

```
would close fork PR #648 (CapitalCantrip) → release #640
would close fork PR #604 (gligor-ai)      → release #515
would close fork PR #447 (muhamdasim)     → release #446
would close fork PR #219 (mcinteerj)      → release #198
#434's fork PR #449 is a discover branch on a fork (muhamdasim) — leaving it for a human (frame_work.sh)   ← the fix
```

Same `review: human-only` routing as #657 — please label + merge as maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)