### PR TITLE
fix(ci): reap.yml runs scripts/reap.sh — reap has been silently failing since the scripts moved

### DIFF
--- a/.github/workflows/reap.yml
+++ b/.github/workflows/reap.yml
@@ -33,4 +33,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           FOR_GOOD_REPO: ${{ github.repository }}
           DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '0' }}
-        run: ./reap.sh
+        run: scripts/reap.sh


### PR DESCRIPTION
## The queue was frozen because reap never ran

Commit `2c4ffa4` ("move runner scripts into scripts/") relocated `reap.sh` to `scripts/reap.sh`, but `.github/workflows/reap.yml` still ran `./reap.sh`. **Every scheduled run since has failed** with `./reap.sh: No such file or directory` (exit 127) — verified in the last 3 run logs.

Consequence: **no reaping at all** —
- stale `status: claimed` issues never released,
- sent-back reworks never unassigned (`REWORK_TTL`),
- the new fork-rework cleanup (ADR-0020 §5) never fires.

That's why the work queue looks frozen with "nothing available" despite 5 fork-blocked `changes-requested` issues (#640/#515/#446/#198 + framing #434) sitting there — reap is the thing that would release them.

## Fix

One line: `run: ./reap.sh` → `run: scripts/reap.sh`. `reap.sh` already `cd`s to the repo root itself, so nothing else changes.

reap.yml is the only workflow that invokes a moved script in CI (the worker/review scripts run locally by contributors, by design).

`review: human-only` (CI/pipeline change) — please label + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)