### PR TITLE
docs: repair ./<script>.sh references after the scripts/ move

### DIFF
--- a/.claude/skills/onboard-contributor/SKILL.md
+++ b/.claude/skills/onboard-contributor/SKILL.md
@@ -6,10 +6,10 @@ description: Use when a new person or their AI agent wants to start contributing
 # Onboard a contributor: paste-this-and-go
 
 The runner scripts already automate contributing here, so **do not hand-claim
-issues or juggle status labels.** Run `./start_work.sh`; it claims available work, runs an agent in a
+issues or juggle status labels.** Run `scripts/start_work.sh`; it claims available work, runs an agent in a
 fresh throwaway git worktree, and moves the issue through the status lifecycle
 described in [`docs/AUTOMATION.md`](../../../docs/AUTOMATION.md). For review,
-run `./review_work.sh`; it reviews open PRs in fresh worktrees and owns the
+run `scripts/review_work.sh`; it reviews open PRs in fresh worktrees and owns the
 adversarial-review check.
 
 ## When to use
@@ -25,7 +25,7 @@ adversarial-review check.
 
 | You have | Do this |
 |---|---|
-| Write/triage access plus a terminal and AI CLI | **Autopilot**: run `./start_work.sh` — the scripts do the claiming and PR routing for you. |
+| Write/triage access plus a terminal and AI CLI | **Autopilot**: run `scripts/start_work.sh` — the scripts do the claiming and PR routing for you. |
 | Write access but no AI CLI | **Manual claim**: use the GitHub UI to assign yourself, move `status: available` to `status: claimed`, do one issue, and open a PR that says `Closes #<n>` unless the issue is a Discover stream root. |
 | No write access | **Fork + PR**: follow [`AGENTS.md`](../../../AGENTS.md#no-write-access-most-contributors). You can still contribute, but the upstream queue runner cannot claim issues without permission. |
 
@@ -58,7 +58,7 @@ Do this, checking with me only if something genuinely needs a human decision:
    confidence High/Medium/Low, end with what would change the conclusion, never
    invent sources or publish personal data, and respect the human gates.
 4. Run the work loop:
-   ./start_work.sh
+   scripts/start_work.sh
    It picks up your assigned rework first, otherwise claims the next available
    issue, creates a fresh worktree, gives the issue to the agent, and moves the
    issue to in-review once the PR is open. The script owns status labels,
@@ -66,12 +66,12 @@ Do this, checking with me only if something genuinely needs a human decision:
    anything past the adversarial review gate.
 
    Common options:
-   - One task then stop:       MAX=1 ./start_work.sh
-   - Only one stage:           STAGE=research ./start_work.sh
-   - A specific CLI:           ./start_work.sh codex
-   - A specific model:         ./start_work.sh codex --model gpt-5.5
-   - Stop when queue is empty: POLL_SECONDS=0 ./start_work.sh
-   - Dry run:                  DRY_RUN=1 ./start_work.sh
+   - One task then stop:       MAX=1 scripts/start_work.sh
+   - Only one stage:           STAGE=research scripts/start_work.sh
+   - A specific CLI:           scripts/start_work.sh codex
+   - A specific model:         scripts/start_work.sh codex --model gpt-5.5
+   - Stop when queue is empty: POLL_SECONDS=0 scripts/start_work.sh
+   - Dry run:                  DRY_RUN=1 scripts/start_work.sh
 5. When it opens a PR, show me the PR URL and a two-line summary.
 ```
 
@@ -82,7 +82,7 @@ branch protection requires a non-author approval, and `review_work.sh` refuses
 to review a PR authored by the reviewer identity.
 
 ```bash
-REVIEW_GITHUB_TOKEN=<second-account-or-bot-PAT-with-write> ./review_work.sh
+REVIEW_GITHUB_TOKEN=<second-account-or-bot-PAT-with-write> scripts/review_work.sh
 ```
 
 `review_work.sh` claims an open PR with `review: claimed`, checks out the PR
@@ -91,11 +91,11 @@ review, sets the required `for-good/adversarial-review` status check, and
 merges on PASS by default. Useful options:
 
 ```bash
-REVIEW_GITHUB_TOKEN=<token> ./review_work.sh codex
-REVIEW_GITHUB_TOKEN=<token> ./review_work.sh hermes --model <name>
-REVIEW_GITHUB_TOKEN=<token> AUTO_MERGE=0 ./review_work.sh
-PR=7 ./review_work.sh
-MAX=1 POLL_SECONDS=0 ./review_work.sh
+REVIEW_GITHUB_TOKEN=<token> scripts/review_work.sh codex
+REVIEW_GITHUB_TOKEN=<token> scripts/review_work.sh hermes --model <name>
+REVIEW_GITHUB_TOKEN=<token> AUTO_MERGE=0 scripts/review_work.sh
+PR=7 scripts/review_work.sh
+MAX=1 POLL_SECONDS=0 scripts/review_work.sh
 ```
 
 If you run without `REVIEW_GITHUB_TOKEN`, the script reviews as the currently

--- a/.github/workflows/stream-sync.yml
+++ b/.github/workflows/stream-sync.yml
@@ -169,7 +169,7 @@ jobs:
               # research closing, ADR-0012) puts the stream back in the
               # MACHINE's court — re-synthesis runs before the steward gate.
               gh issue edit "$stream" --repo "$REPO" --add-label "status: needs-synthesis" --remove-label "status: awaiting-direction" || true
-              gh issue comment "$stream" --repo "$REPO" --body "🧭 All open work in **Stream #$stream** is done. This is **gate G1**. Anyone can run \`./synthesize_work.sh\` to have an agent draft the plain-language overview as a PR; a human **steward** then edits it, writes the direction decision — go deeper, pivot, proceed, or park — and merges. See \`docs/STREAMS.md\`. Nothing moves to solutions until then. (Automation counts labelled children — worth a quick scan for stragglers before synthesising.)" || true
+              gh issue comment "$stream" --repo "$REPO" --body "🧭 All open work in **Stream #$stream** is done. This is **gate G1**. Anyone can run \`scripts/synthesize_work.sh\` to have an agent draft the plain-language overview as a PR; a human **steward** then edits it, writes the direction decision — go deeper, pivot, proceed, or park — and merges. See \`docs/STREAMS.md\`. Nothing moves to solutions until then. (Automation counts labelled children — worth a quick scan for stragglers before synthesising.)" || true
               echo "Stream #$stream drained → root flagged needs-synthesis."
             else
               echo "Stream #$stream still has $open_children labelled + $unlabelled unlabelled open child issue(s)."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,17 +191,17 @@ skill you add makes the next contributor's research faster.
 
 Six scripts wrap your `codex`, `claude`, or `hermes` CLI so you can put spare tokens to work without babysitting each step — `frame_work.sh` (frame new streams, capability-floored), `start_work.sh` (do), `review_work.sh` (review), `synthesize_work.sh` (stream rollups), `merge_ready.sh` (maintainer merges), `reap.sh` (free stale claims); see [`docs/AUTOMATION.md`](docs/AUTOMATION.md):
 
-- **`./frame_work.sh`** — claims discover roots only (the general fleet never
+- **`scripts/frame_work.sh`** — claims discover roots only (the general fleet never
   does), writes the framing analysis as a PR, and opens the child research
   issues itself. Refuses to run unless your identity is on the `framers`
   allow-list (ADR-0014).
-- **`./start_work.sh`** — claims the next available research/ideate/build
+- **`scripts/start_work.sh`** — claims the next available research/ideate/build
   issue, runs the loop above, and moves the issue to *in review* when a PR is
   opened. The script owns the status labels; you (the agent) just do the work
   and open the PR. Under autopilot it also **adopts stale rework** — a
   `changes-requested` PR whose author went offline for 6h+ is taken over by a
   different worker so the queue doesn't freeze on absent authors ([ADR-0020](docs/adr/0020-adopt-stale-rework.md)).
-- **`./review_work.sh`** — runs an adversarial review on open PRs and sets the
+- **`scripts/review_work.sh`** — runs an adversarial review on open PRs and sets the
   merge gate.
 
 **Every PR is adversarially reviewed before it can merge, and the review must be

--- a/README.md
+++ b/README.md
@@ -120,25 +120,25 @@ Read [AGENTS.md](AGENTS.md). It is the operating contract for agents in this rep
 For unattended queue work:
 
 ```bash
-./start_work.sh
+scripts/start_work.sh
 ```
 
 For adversarial PR review:
 
 ```bash
-./review_work.sh
+scripts/review_work.sh
 ```
 
 For stream synthesis drafts after research drains:
 
 ```bash
-./synthesize_work.sh
+scripts/synthesize_work.sh
 ```
 
 Maintainers use:
 
 ```bash
-./merge_ready.sh
+scripts/merge_ready.sh
 ```
 
 See [docs/AUTOMATION.md](docs/AUTOMATION.md) for how the scripts claim work, create fresh worktrees, route rework, draft synthesis, and merge reviewed PRs.

--- a/analysis/gap-analysis-and-operating-plan.md
+++ b/analysis/gap-analysis-and-operating-plan.md
@@ -163,7 +163,7 @@ _Proposed framing and criteria, not adopted standards._ The intent to package th
 └───────────────────────────────┘        └──────────────────────────────┘
 ```
 
-The kernel's automation and gates already exist in part — the runner scripts ([`start_work.sh`](../start_work.sh), [`synthesize_work.sh`](../synthesize_work.sh), [`review_work.sh`](../review_work.sh), [`merge_ready.sh`](../merge_ready.sh); [`docs/AUTOMATION.md`](../docs/AUTOMATION.md)) and the binding gates ([`docs/STREAMS.md`](../docs/STREAMS.md); [`CONSTITUTION.md`](../CONSTITUTION.md) Article III–IV). The Deliver stage, `IMPACT.md`, broker role, charter template and legitimacy slot are the pieces this analysis proposes adding.
+The kernel's automation and gates already exist in part — the runner scripts ([`start_work.sh`](../scripts/start_work.sh), [`synthesize_work.sh`](../scripts/synthesize_work.sh), [`review_work.sh`](../scripts/review_work.sh), [`merge_ready.sh`](../scripts/merge_ready.sh); [`docs/AUTOMATION.md`](../docs/AUTOMATION.md)) and the binding gates ([`docs/STREAMS.md`](../docs/STREAMS.md); [`CONSTITUTION.md`](../CONSTITUTION.md) Article III–IV). The Deliver stage, `IMPACT.md`, broker role, charter template and legitimacy slot are the pieces this analysis proposes adding.
 
 **Close every gap as a kernel pattern, not an NZ patch (proposed).**
 

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -101,11 +101,11 @@ where model strength matters most — framing a stream and gating a merge —
 both get a floor (ADR-0014).
 
 ```bash
-./frame_work.sh                          # frame available discover roots (default agent: claude)
-./frame_work.sh claude --model <name>    # pin the framing model explicitly
-MAX=1 ./frame_work.sh                    # one root, then stop
-DRY_RUN=1 ./frame_work.sh                # show what it would do, change nothing
-FANOUT_MAX=6 ./frame_work.sh             # cap on child issues opened per framing (default 6)
+scripts/frame_work.sh                          # frame available discover roots (default agent: claude)
+scripts/frame_work.sh claude --model <name>    # pin the framing model explicitly
+MAX=1 scripts/frame_work.sh                    # one root, then stop
+DRY_RUN=1 scripts/frame_work.sh                # show what it would do, change nothing
+FANOUT_MAX=6 scripts/frame_work.sh             # cap on child issues opened per framing (default 6)
 ```
 
 One framing run:
@@ -150,15 +150,15 @@ never picked up here** — framing is `frame_work.sh`'s alone (ADR-0014;
 `STAGE=discover` refuses to run).
 
 ```bash
-./start_work.sh                 # work the queue until it's empty (default agent: claude)
-./start_work.sh codex           # use `codex exec` instead
-./start_work.sh hermes          # use `hermes chat` instead
-./start_work.sh --model <name>  # override the agent model
-./start_work.sh codex --model gpt-5.5
-HERMES_PROFILE=reviewer ./start_work.sh hermes
-STAGE=research ./start_work.sh  # only pick up research-stage issues
-MAX=1 ./start_work.sh           # one issue, then stop
-DRY_RUN=1 ./start_work.sh       # show what it would do, change nothing
+scripts/start_work.sh                 # work the queue until it's empty (default agent: claude)
+scripts/start_work.sh codex           # use `codex exec` instead
+scripts/start_work.sh hermes          # use `hermes chat` instead
+scripts/start_work.sh --model <name>  # override the agent model
+scripts/start_work.sh codex --model gpt-5.5
+HERMES_PROFILE=reviewer scripts/start_work.sh hermes
+STAGE=research scripts/start_work.sh  # only pick up research-stage issues
+MAX=1 scripts/start_work.sh           # one issue, then stop
+DRY_RUN=1 scripts/start_work.sh       # show what it would do, change nothing
 ```
 
 The agent can be given as a positional word (`claude`, `codex`, or `hermes`)
@@ -261,8 +261,8 @@ attempt (the recorded review stays on the closed PR as reference). A
 Run it manually when you want an immediate sweep:
 
 ```bash
-./reap.sh              # release stale items
-DRY_RUN=1 ./reap.sh    # report what would be released
+scripts/reap.sh              # release stale items
+DRY_RUN=1 scripts/reap.sh    # report what would be released
 ```
 
 The workflow can also be started manually from GitHub's Actions tab, including
@@ -402,12 +402,12 @@ already injected into every reviewer prompt as untrusted context, so a fresh
 reviewer must bring *new* evidence rather than re-litigate resolved points.
 
 ```bash
-REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh              # review all open PRs
-REVIEW_GITHUB_TOKEN=<bot-pat> AGENT=claude ./review_work.sh
-REVIEW_GITHUB_TOKEN=<bot-pat> AGENT=hermes ./review_work.sh
-REVIEW_GITHUB_TOKEN=<bot-pat> HERMES_PROFILE=reviewer AGENT=hermes ./review_work.sh
-REVIEW_GITHUB_TOKEN=<bot-pat> AUTO_MERGE=1 ./review_work.sh # merge on PASS
-PR=7 ./review_work.sh                                       # one PR
+REVIEW_GITHUB_TOKEN=<bot-pat> scripts/review_work.sh              # review all open PRs
+REVIEW_GITHUB_TOKEN=<bot-pat> AGENT=claude scripts/review_work.sh
+REVIEW_GITHUB_TOKEN=<bot-pat> AGENT=hermes scripts/review_work.sh
+REVIEW_GITHUB_TOKEN=<bot-pat> HERMES_PROFILE=reviewer AGENT=hermes scripts/review_work.sh
+REVIEW_GITHUB_TOKEN=<bot-pat> AUTO_MERGE=1 scripts/review_work.sh # merge on PASS
+PR=7 scripts/review_work.sh                                       # one PR
 ```
 
 ### `review: human-only` — keep a PR out of the agent loop
@@ -462,11 +462,11 @@ the plain-language overview in `streams/` — **as a PR for a human steward to
 edit, decide direction on, and merge.**
 
 ```bash
-./synthesize_work.sh                  # draft every flagged stream (default agent: claude)
-./synthesize_work.sh codex            # use `codex exec` instead
-STREAM=4 ./synthesize_work.sh         # target one stream root
-MAX=1 ./synthesize_work.sh            # one stream, then stop
-DRY_RUN=1 ./synthesize_work.sh        # print target + evidence + prompt, change nothing
+scripts/synthesize_work.sh                  # draft every flagged stream (default agent: claude)
+scripts/synthesize_work.sh codex            # use `codex exec` instead
+STREAM=4 scripts/synthesize_work.sh         # target one stream root
+MAX=1 scripts/synthesize_work.sh            # one stream, then stop
+DRY_RUN=1 scripts/synthesize_work.sh        # print target + evidence + prompt, change nothing
 ```
 
 The judgement stays human, structurally:
@@ -540,9 +540,9 @@ The flow:
 ### `merge_ready.sh` — the merge gate
 
 ```bash
-./merge_ready.sh            # dry run: report every PR's status, merge nothing
-MERGE=1 ./merge_ready.sh    # merge the ones that qualify
-PR=12 MERGE=1 ./merge_ready.sh
+scripts/merge_ready.sh            # dry run: report every PR's status, merge nothing
+MERGE=1 scripts/merge_ready.sh    # merge the ones that qualify
+PR=12 MERGE=1 scripts/merge_ready.sh
 ```
 
 A PR qualifies when it has **≥ N** reviews where each review is:

--- a/scripts/frame_work.sh
+++ b/scripts/frame_work.sh
@@ -37,11 +37,11 @@
 # spawned child issue record who/what framed the stream.
 #
 # Usage:
-#   ./frame_work.sh                     # frame available discover roots (default agent: claude)
-#   ./frame_work.sh claude --model claude-fable-5
-#   MAX=1 ./frame_work.sh               # one root, then stop
-#   DRY_RUN=1 ./frame_work.sh           # show what it would do, touch nothing
-#   POLL_SECONDS=0 ./frame_work.sh      # exit instead of polling when queue empty
+#   scripts/frame_work.sh                     # frame available discover roots (default agent: claude)
+#   scripts/frame_work.sh claude --model claude-fable-5
+#   MAX=1 scripts/frame_work.sh               # one root, then stop
+#   DRY_RUN=1 scripts/frame_work.sh           # show what it would do, touch nothing
+#   POLL_SECONDS=0 scripts/frame_work.sh      # exit instead of polling when queue empty
 #                                        # (default: poll every 3 min and never exit)
 #
 # Args: [claude|codex|hermes] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
@@ -668,7 +668,7 @@ main() {
   info "frame_work.sh · repo=$REPO · agent=$AGENT${MODEL:+ · model=$MODEL}$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"
   local done=0
   # One-shot: let an operator target a stuck discover root/framing rework
-  # directly, e.g. ISSUE=441 PR=469 ./frame_work.sh codex. Normal autopilot
+  # directly, e.g. ISSUE=441 PR=469 scripts/frame_work.sh codex. Normal autopilot
   # still uses the queue below.
   if [ -n "${ISSUE:-}" ]; then
     local forced_pr="${PR:-}"

--- a/scripts/merge_ready.sh
+++ b/scripts/merge_ready.sh
@@ -16,9 +16,9 @@
 # raised for sensitive domains (see .github/trusted-reviewers.json).
 #
 # Usage:
-#   ./merge_ready.sh            # dry run — report each PR's status, merge nothing
-#   MERGE=1 ./merge_ready.sh    # actually merge the ones that qualify
-#   PR=12 MERGE=1 ./merge_ready.sh
+#   scripts/merge_ready.sh            # dry run — report each PR's status, merge nothing
+#   MERGE=1 scripts/merge_ready.sh    # actually merge the ones that qualify
+#   PR=12 MERGE=1 scripts/merge_ready.sh
 #
 # Env: MERGE PR TRUST_WHITELIST MIN_REVIEWER_CREDIT REQUIRED_APPROVALS
 #      FOR_GOOD_REPO REPO_DIR

--- a/scripts/reap.sh
+++ b/scripts/reap.sh
@@ -3,8 +3,8 @@
 # reap.sh — release stale work back to the pool so nothing stays stuck on a
 # worker who wandered off. Run it on a cron, or by hand.
 #
-#   ./reap.sh              # free anything past its TTL
-#   DRY_RUN=1 ./reap.sh    # show what it would free, change nothing
+#   scripts/reap.sh              # free anything past its TTL
+#   DRY_RUN=1 scripts/reap.sh    # show what it would free, change nothing
 #
 # Four cases:
 #   - CLAIMED but no PR opened within CLAIM_TTL  → back to `status: available`.

--- a/scripts/review_work.sh
+++ b/scripts/review_work.sh
@@ -36,14 +36,14 @@
 # (a bot / second GitHub account, or a GitHub App token, with write access).
 #
 # Usage:
-#   REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh           # review all open PRs (claude)
-#   REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh codex     # review with codex
-#   REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh hermes    # review with hermes
-#   REVIEW_GITHUB_TOKEN=<bot-pat> ./review_work.sh --model <name>
-#   REVIEW_GITHUB_TOKEN=<bot-pat> AUTO_MERGE=1 ./review_work.sh
-#   PR=7 ./review_work.sh                                    # a single PR
-#   DRY_RUN=1 ./review_work.sh
-#   POLL_SECONDS=0 ./review_work.sh                          # exit instead of polling when empty
+#   REVIEW_GITHUB_TOKEN=<bot-pat> scripts/review_work.sh           # review all open PRs (claude)
+#   REVIEW_GITHUB_TOKEN=<bot-pat> scripts/review_work.sh codex     # review with codex
+#   REVIEW_GITHUB_TOKEN=<bot-pat> scripts/review_work.sh hermes    # review with hermes
+#   REVIEW_GITHUB_TOKEN=<bot-pat> scripts/review_work.sh --model <name>
+#   REVIEW_GITHUB_TOKEN=<bot-pat> AUTO_MERGE=1 scripts/review_work.sh
+#   PR=7 scripts/review_work.sh                                    # a single PR
+#   DRY_RUN=1 scripts/review_work.sh
+#   POLL_SECONDS=0 scripts/review_work.sh                          # exit instead of polling when empty
 #                                                             # (default: poll every 60s and never exit)
 #
 # REVIEW-ROUND CAP (#287 / ADR-0013): a PR gets at most MAX_REVIEW_ROUNDS
@@ -224,7 +224,7 @@ park_for_human() {  # $1 = pr number, $2 = head sha, $3 = url, $4 = rounds
     review_feedback "$pr" | head -c 3000
     echo '```'
     echo
-    echo "Maintainer options: decide the dispute and merge (\`merge_ready.sh\` / by hand), send it back with concrete asks, apply \`review: human-only\`, or force one more agent round with \`FORCE=1 PR=$pr ./review_work.sh\`."
+    echo "Maintainer options: decide the dispute and merge (\`merge_ready.sh\` / by hand), send it back with concrete asks, apply \`review: human-only\`, or force one more agent round with \`FORCE=1 PR=$pr scripts/review_work.sh\`."
   } >"$body"
   gh pr comment "$pr" --repo "$REPO" --body-file "$body" >/dev/null 2>&1 || true
   rm -f "$body"
@@ -582,7 +582,7 @@ review_one() {  # $1 = PR number
         tail -80 "$tmp"
         echo '```'
         echo
-        echo "The review loop will retry automatically. To force a retry now: \`FORCE=1 PR=$pr ./review_work.sh\`."
+        echo "The review loop will retry automatically. To force a retry now: \`FORCE=1 PR=$pr scripts/review_work.sh\`."
       } >"$diag"
       warn "No review file produced for PR #$pr; posting a diagnostic (check left unset so a later loop retries)."
       gh pr comment "$pr" --repo "$REPO" --body-file "$diag" >/dev/null || true

--- a/scripts/start_work.sh
+++ b/scripts/start_work.sh
@@ -12,20 +12,20 @@
 # agent runs or how it behaves.
 #
 # Usage:
-#   ./start_work.sh                 # work the queue with the default agent (claude)
-#   ./start_work.sh codex           # use `codex exec` instead
-#   ./start_work.sh hermes          # use `hermes chat` instead
-#   ./start_work.sh --model <name>  # override the agent model
-#   ./start_work.sh codex --model gpt-5.5
-#   STAGE=research ./start_work.sh  # only pick up research-stage issues
+#   scripts/start_work.sh                 # work the queue with the default agent (claude)
+#   scripts/start_work.sh codex           # use `codex exec` instead
+#   scripts/start_work.sh hermes          # use `hermes chat` instead
+#   scripts/start_work.sh --model <name>  # override the agent model
+#   scripts/start_work.sh codex --model gpt-5.5
+#   STAGE=research scripts/start_work.sh  # only pick up research-stage issues
 #                                    # (stage: discover is NEVER picked up here —
 #                                    # framing is frame_work.sh's, ADR-0014)
-#   MAX=1 ./start_work.sh           # do a single issue and stop
-#   ISSUE=390 ./start_work.sh       # work THIS issue first (one shot), then fall
+#   MAX=1 scripts/start_work.sh           # do a single issue and stop
+#   ISSUE=390 scripts/start_work.sh       # work THIS issue first (one shot), then fall
 #                                    # back into the normal queue loop
-#   ISSUE=390 MAX=1 ./start_work.sh # work only that one issue, then stop
-#   DRY_RUN=1 ./start_work.sh       # show what it would do, touch nothing
-#   POLL_SECONDS=0 ./start_work.sh  # exit instead of polling when queue empty
+#   ISSUE=390 MAX=1 scripts/start_work.sh # work only that one issue, then stop
+#   DRY_RUN=1 scripts/start_work.sh       # show what it would do, touch nothing
+#   POLL_SECONDS=0 scripts/start_work.sh  # exit instead of polling when queue empty
 #                                    # (default: poll every 3 min and never exit)
 #
 # Args: [claude|codex|hermes] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
@@ -840,7 +840,7 @@ main() {
   # Discover is not this runner's stage at all (ADR-0014) — refuse loudly
   # rather than poll an empty queue forever.
   if [ "${STAGE:-}" = "discover" ]; then
-    err "STAGE=discover is frame_work.sh territory (ADR-0014) — start_work.sh never claims discover roots. Run ./frame_work.sh instead."
+    err "STAGE=discover is frame_work.sh territory (ADR-0014) — start_work.sh never claims discover roots. Run scripts/frame_work.sh instead."
     exit 1
   fi
   info "start_work.sh · repo=$REPO · agent=$AGENT${STAGE:+ · stage=$STAGE}$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"

--- a/scripts/synthesize_work.sh
+++ b/scripts/synthesize_work.sh
@@ -22,13 +22,13 @@
 # reach, not the first one.
 #
 # Usage:
-#   ./synthesize_work.sh                  # draft every flagged stream (default agent: claude)
-#   ./synthesize_work.sh codex            # use `codex exec` instead
-#   ./synthesize_work.sh --model <name>   # override the agent model
-#   STREAM=4 ./synthesize_work.sh         # target one stream root
-#   MAX=1 ./synthesize_work.sh            # one stream, then stop
-#   DRY_RUN=1 ./synthesize_work.sh        # print target + evidence + prompt, touch nothing
-#   POLL_SECONDS=0 ./synthesize_work.sh   # exit instead of polling when queue empty
+#   scripts/synthesize_work.sh                  # draft every flagged stream (default agent: claude)
+#   scripts/synthesize_work.sh codex            # use `codex exec` instead
+#   scripts/synthesize_work.sh --model <name>   # override the agent model
+#   STREAM=4 scripts/synthesize_work.sh         # target one stream root
+#   MAX=1 scripts/synthesize_work.sh            # one stream, then stop
+#   DRY_RUN=1 scripts/synthesize_work.sh        # print target + evidence + prompt, touch nothing
+#   POLL_SECONDS=0 scripts/synthesize_work.sh   # exit instead of polling when queue empty
 #                                          # (default: poll every 60s and never exit)
 #
 # Args: [claude|codex|hermes] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)

--- a/web/src/pages/Contribute.tsx
+++ b/web/src/pages/Contribute.tsx
@@ -72,9 +72,9 @@ export default function Contribute() {
           </p>
           <div className="mt-4 rounded-xl bg-brand-navy p-4 font-mono text-[13px] leading-relaxed text-brand-slate-light dark:bg-black/40">
             <div className="text-brand-slate-muted-light"># do the work</div>
-            <div><span className="text-brand-orange">./start_work.sh</span></div>
+            <div><span className="text-brand-orange">scripts/start_work.sh</span></div>
             <div className="mt-2 text-brand-slate-muted-light"># review others' PRs</div>
-            <div><span className="text-brand-orange">./review_work.sh</span></div>
+            <div><span className="text-brand-orange">scripts/review_work.sh</span></div>
           </div>
           <p className="mt-4 text-sm text-muted-foreground">
             The scripts own the status labels and the merge gate — the agent just does the work, in a throwaway git worktree pulled fresh from{" "}


### PR DESCRIPTION
Companion to #659. Commit `2c4ffa4` ("move runner scripts into scripts/") relocated `start_work.sh`, `review_work.sh`, `frame_work.sh`, `synthesize_work.sh`, `merge_ready.sh`, and `reap.sh` into `scripts/`, but the **documented invocations** were left as `./start_work.sh` etc. — so anyone following the docs hit `No such file or directory`.

Repoints every `./<script>.sh` reference at `scripts/<script>.sh` in:
- `docs/AUTOMATION.md` (30), `.claude/skills/onboard-contributor/SKILL.md` (16), `README.md` (4), `AGENTS.md` (3), the one instruction in a `stream-sync.yml` issue-comment body, and each script's own `# Usage:` header comments.

Mechanical, **docs/comments only** — no executable lines changed; all scripts still `bash -n` clean and `npm run validate` passes. `review: human-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)