### PR TITLE
fix(ci): unwedge update-skills-submodule (force-push the bump branch)

### DIFF
--- a/.github/workflows/update-skills-submodule.yml
+++ b/.github/workflows/update-skills-submodule.yml
@@ -58,10 +58,17 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
+          git checkout -B "$branch"
           git add .skills
           git commit -m "chore: update .skills submodule to ${new_sha}"
-          git push -u origin "$branch"
+          # FORCE the push: the branch name is derived from the upstream sha, so
+          # a run for a pointer whose PR was CLOSED (not merged) leaves a stale
+          # same-named remote branch. A plain push is then non-fast-forward and
+          # rejected ("fetch first"), which wedged this workflow — every hourly
+          # run recreated the same branch and failed. Force is safe here: the
+          # branch namespace is automation-owned, and a still-OPEN PR already
+          # short-circuited above, so we never clobber a branch under review.
+          git push -u --force origin "$branch"
           gh pr create --title "chore: update .skills submodule to ${new_sha}" \
             --body "Automated bump of the vendored \`.skills\` submodule to its latest upstream commit (thecolab-ai/.skills@${new_sha}). Pointer-only change, no other content in this repo touched."
           gh pr merge "$branch" --auto --squash --delete-branch \


### PR DESCRIPTION
`update-skills-submodule.yml` has been failing every hourly run:

```
! [rejected]  chore/update-skills-submodule-f7cec20 -> ... (fetch first)
error: failed to push some refs
```

**Cause:** the branch name is derived from the upstream `.skills` sha, and the workflow only short-circuits on an **open PR**. Once a pointer's PR was closed without merging (or a `gh pr create` failed), the stale same-named remote branch lingered — and since the pointer never advanced, every subsequent hourly run recreated *that same branch* and the plain `git push` was non-fast-forward → rejected → exit 1, forever. (6 orphan `chore/update-skills-submodule-*` branches accumulated.)

**Fix:** force-push the throwaway automation branch (`git push -u --force`) + `git checkout -B` for a clean local branch. Safe: the branch namespace is automation-owned, and a still-open PR already short-circuits above, so nothing under review is clobbered.

I'll prune the 6 orphan branches separately. `review: human-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)