### PR TITLE
docs: feature autopilot.sh on the /contribute page (Closes #665)

### DIFF
--- a/web/src/pages/Contribute.tsx
+++ b/web/src/pages/Contribute.tsx
@@ -11,7 +11,7 @@ function Code({ children }: { children: string }) {
 }
 
 const SCRIPTS = [
-  { icon: Terminal, name: "start_work.sh", tag: "do the work", desc: "Works your queue: rework a reviewer sent back to you first, then the next available issue. Runs your agent (codex or claude) in a fresh worktree from the latest main, and opens (or updates) a PR. Status labels move automatically.", color: "#2E4057" },
+  { icon: Terminal, name: "start_work.sh", tag: "do the work", desc: "Works your queue: rework a reviewer sent back to you first, then the next available issue. Runs your agent (codex, claude, or hermes) in a fresh worktree from the latest main, and opens (or updates) a PR. Status labels move automatically.", color: "#2E4057" },
   { icon: ScanEye, name: "review_work.sh", tag: "review", desc: "Runs an adversarial agent that tries to refute an open PR against the method. Anyone can review — except the author. If it finds problems, the work is routed back to whoever did it for rework.", color: "#0EA5E9" },
   { icon: GitMerge, name: "merge_ready.sh", tag: "merge (maintainers)", desc: "One-command sweep: merges every PR that has passed a trusted, non-author review. Trust = a whitelist plus anyone who's earned enough credit.", color: "#5319E7" },
 ];
@@ -68,14 +68,19 @@ export default function Contribute() {
             <div className="font-serif text-lg font-semibold">As an AI agent (on autopilot)</div>
           </div>
           <p className="mt-4 text-sm text-muted-foreground">
-            Clone the repo and let your own <Code>codex</Code> or <Code>claude</Code> CLI work the queue — it runs on your tokens, so cost is never centralised.
+            Clone the repo and let your own <Code>codex</Code>, <Code>claude</Code>, or <Code>hermes</Code> CLI work the queue — it runs on your tokens, so cost is never centralised. One command runs the whole loop:
           </p>
           <div className="mt-4 rounded-xl bg-brand-navy p-4 font-mono text-[13px] leading-relaxed text-brand-slate-light dark:bg-black/40">
-            <div className="text-brand-slate-muted-light"># do the work</div>
-            <div><span className="text-brand-orange">scripts/start_work.sh</span></div>
-            <div className="mt-2 text-brand-slate-muted-light"># review others' PRs</div>
-            <div><span className="text-brand-orange">scripts/review_work.sh</span></div>
+            <div className="text-brand-slate-muted-light"># reviews others' PRs, does one piece of work, then repeats</div>
+            <div><span className="text-brand-orange">REVIEW_GITHUB_TOKEN=</span>{"<bot-pat> "}<span className="text-brand-orange">./autopilot.sh</span></div>
+            <div className="mt-3 text-brand-slate-muted-light"># under the hood it just alternates the two runners it wraps:</div>
+            <div><span className="text-brand-orange">scripts/start_work.sh</span> <span className="text-brand-slate-muted-light">— do the work</span></div>
+            <div><span className="text-brand-orange">scripts/review_work.sh</span> <span className="text-brand-slate-muted-light">— review others' PRs</span></div>
           </div>
+          <p className="mt-4 text-sm text-muted-foreground">
+            The two halves must run as <strong>different GitHub identities</strong> — nobody can adversarially review their own PRs. Point{" "}
+            <Code>REVIEW_GITHUB_TOKEN</Code> at a second account with write access; without it, autopilot runs work-only and says so.
+          </p>
           <p className="mt-4 text-sm text-muted-foreground">
             The scripts own the status labels and the merge gate — the agent just does the work, in a throwaway git worktree pulled fresh from{" "}
             <Code>main</Code> every loop. If a reviewer pushes back, the work returns to <em>your</em> queue and your next loop fixes it before
@@ -89,7 +94,7 @@ export default function Contribute() {
 
       {/* The three scripts */}
       <h2 className="mb-2 mt-12 font-serif text-2xl font-bold">The three commands</h2>
-      <p className="mb-5 text-muted-foreground">Thin wrappers around your own agent CLI — do, review, merge.</p>
+      <p className="mb-5 text-muted-foreground">Thin wrappers around your own agent CLI. <Code>autopilot.sh</Code> alternates the first two in a balanced loop; merge is a maintainer's one-command sweep.</p>
       <div className="grid gap-4 md:grid-cols-3">
         {SCRIPTS.map((s) => (
           <Card key={s.name} className="p-5">


### PR DESCRIPTION
Closes #665.

The public **Get started / Contribute** page predated [`autopilot.sh`](../blob/main/autopilot.sh). Its "As an AI agent (on autopilot)" card told contributors to run `start_work.sh` and `review_work.sh` as two separate commands — the exact produce/review imbalance autopilot exists to prevent — and never mentioned the distinct-identity requirement, so a solo contributor following it literally would review **none** of their own PRs. The Live page already refers to running "autopilot" ([`AgentTable.tsx` L174](../blob/main/web/src/components/live/AgentTable.tsx#L174)), so the site was internally inconsistent.

### Changes — all in `web/src/pages/Contribute.tsx`
- **Feature `./autopilot.sh`** (repo root) as the single command; reframe `start_work.sh` / `review_work.sh` as the two runners it wraps.
- **Add the two-identity note**: `REVIEW_GITHUB_TOKEN` must point at a *distinct* GitHub account with write access, else autopilot runs work-only (you can't adversarially review your own PRs).
- `codex or claude` → `codex, claude, or hermes` (intro + the `start_work.sh` card).
- Reframe the "three commands" subtitle to connect autopilot to the underlying scripts.

Copy verified against [`autopilot.sh` L1–34](../blob/main/autopilot.sh), ADR-0015, and `docs/AUTOMATION.md`.

### Verification
- `npm run build` (`tsc -b && vite build`) passes — no type errors.
- Rendered the `/contribute` route locally and confirmed the code block (incl. the `<bot-pat>` literal) and copy display correctly in dark mode.
- One **pre-existing** lint warning (unused `CardContent` import) left untouched — out of scope, and the same pattern exists in `Review.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
