### PR TITLE
fix(reap): route absent-authors' unaddressed change-requests → changes-requested (ADR-0021)

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -249,7 +249,20 @@ Two TTLs are enforced:
   `synthesize_work.sh`, for a synthesis draft (ADR-0011) — can pick up the
   rework.
 
-It also **closes fork-origin stale reworks** (ADR-0020 §5): a
+It also **reconciles unrouted change-requests** (ADR-0021): any open PR whose
+*current* review is `CHANGES_REQUESTED` (no commit after it) whose worked
+research/ideate/build issue is still `status: in-review`/`claimed` gets that
+issue flipped to `status: changes-requested`. `start_work.sh`'s reconcile
+(ADR-0008) only handles the *running identity's own* PRs, so an **absent
+author's** reviewed work never reached `changes-requested` and ADR-0020
+adoption couldn't see it — this author-agnostic sweep is what lets that work
+re-enter the queue. It flips status only (keeps the assignee; the `REWORK_TTL`
+unassign and adoption handle absence), is currency- and canonical-PR-guarded,
+skips `synthesis/*`/`discover/*` and human-only/do-not-automate, and runs
+**before** the fork sweep so a flipped fork issue is closed in the same pass.
+Opt out with `RECONCILE_UNROUTED=0`.
+
+And it **closes fork-origin stale reworks** (ADR-0020 §5): a
 `changes-requested` PR whose branch lives on a **fork** can't be adopted (only
 its author can push it), and the project isn't taking outside fork branches
 into the automated pipeline for now — so the PR is closed with an explanatory

--- a/docs/adr/0021-author-agnostic-rework-reconcile.md
+++ b/docs/adr/0021-author-agnostic-rework-reconcile.md
@@ -1,0 +1,79 @@
+# ADR-0021: reap routes ANY unaddressed change-request back to `changes-requested`, regardless of author
+
+- **Status:** proposed (ratified on merge by the human maintainer, who directed this
+  on 2026-07-07; agents do not self-ratify pipeline changes)
+- **Date:** 2026-07-07
+- **Deciders:** @adam91holt (human maintainer); drafted by an agent (Claude Opus 4.8,
+  "Fable") on his direct instructions
+- **Amends:** ADR-0008 (rework hand-off routes by worked issue) — generalises its
+  reconcile from the running identity's own PRs to every author
+- **Enables:** ADR-0020 (adopt stale rework) — adoption can only see an issue that is
+  `status: changes-requested`; this is what puts an absent author's reviewed work there
+
+## Context
+
+ADR-0020 lets an idle worker adopt a stale `changes-requested` PR from an absent
+author. But it only *sees* a PR whose worked issue is `status: changes-requested`,
+and in practice most sent-back PRs from absent authors never reached that state:
+their issues sat in `status: in-review` or `status: claimed` indefinitely. The only
+things that flip an issue to `changes-requested` are (a) `review_work.sh` when it
+posts NEEDS_WORK, and (b) `start_work.sh`'s `reconcile_rework` — which by design only
+touches the *running identity's own* authored PRs (ADR-0008). So when a review is
+posted but the flip is lost (a reviewer crash after posting, a human/bot review
+outside `review_work.sh`, an author who never runs their own loop), the issue is
+stranded: the PR carries an unaddressed change-request, but nothing routes the issue
+back, and adoption is blind to it. We hit this live — a backlog of PRs with
+`CHANGES_REQUESTED` reviews whose issues were stuck `in-review`/`claimed`, invisible
+to both the author (absent) and the adoption path.
+
+## Decision
+
+We add a deterministic, author-agnostic reconcile to `reap.sh` (the periodic
+bookkeeping sweep, no model calls). Each run, for every open PR whose **current**
+review decision is `CHANGES_REQUESTED` (no commit landed after the last such review —
+otherwise it is awaiting *re-review*, not rework), we flip its **worked issue** from
+`status: in-review`/`claimed` to `status: changes-requested`. This is exactly
+`start_work.sh`'s ADR-0008 reconcile, minus the "only my own PRs" restriction — so an
+**absent author's** reviewed work re-enters the rework queue and adoption (ADR-0020),
+`take_unassigned_rework`, and the author's own loop can all route it.
+
+It is deliberately narrow and fails closed:
+- **Only work issues** (`stage: research | ideate | build`). Stream roots and discover
+  issues are never touched — their lifecycle (needs-synthesis / awaiting-direction) is
+  not "changes-requested".
+- **Skips `synthesis/*` and `discover/*` PRs** (their rework routes to
+  `synthesize_work.sh` / `frame_work.sh` under ADR-0011 / ADR-0014), and any PR labelled
+  `review: human-only`, and any issue labelled `do-not-automate`.
+- **Canonical-PR guarded** (a stale sibling PR must not route the issue — the #305/#307
+  protection) and **currency-checked** (a rework pushed after the review is left alone).
+- It **flips status only** and keeps the existing assignee (ADR-0008 posture — a
+  returning author keeps their window); the existing `reap_reworks` TTL (`REWORK_TTL`)
+  still unassigns it later so any worker can take it, and ADR-0020 adoption does not
+  require it to be unassigned. Runs **before** the fork-close sweep (ADR-0020 §5) so a
+  flipped fork issue is closed + released in the same pass. Opt out with
+  `RECONCILE_UNROUTED=0`.
+
+Alternatives considered: doing this in `start_work.sh` for all authors (rejected — it is
+periodic bookkeeping, not per-worker, and belongs with the other reap reconciles);
+unassigning on flip (rejected — a returning author should keep their window, and
+`reap_reworks`/adoption already cover absence); adding a webhook-driven flip (rejected —
+`reap.sh` on its 30-min cron is simpler and covers reviews posted by any actor).
+
+## Consequences
+
+- Adoption (ADR-0020) actually drains the backlog: an absent author's reviewed PR now
+  reliably reaches `changes-requested` within a reap cycle instead of stranding forever.
+- One more author-agnostic reconcile in reap — bounded, deterministic, DRY_RUN-inspectable.
+- A PR whose review flip *did* fire normally is a no-op (already `changes-requested`), so
+  the sweep is idempotent and cheap.
+- Honest limit: this routes work back to `changes-requested`; it does not make the
+  eventual rework *succeed*. If the adopting agent produces no fix, the issue re-cycles —
+  that is an agent-quality problem, not a routing one.
+
+## What would change this decision
+
+Evidence the reconcile flips issues that were legitimately mid-work (would tighten the
+`claimed` case or require no-PR-yet exclusion — though the canonical-PR + currency guards
+already gate that); reviews reliably flipping issues at post time across all actors (would
+make the sweep redundant); or a move to webhook-driven status routing (would replace the
+cron sweep).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,5 +57,6 @@ routine fixes, copy changes, or web styling.
 | [0018](0018-mirror-backed-runner-reads.md) | Runner queue reads come from the fleet server's mirror, not GitHub | Proposed |
 | [0019](0019-orchestrated-review-dispatch.md) | The fleet server dispatches PR reviews to enrolled reviewers (kind: review) | Proposed |
 | [0020](0020-adopt-stale-rework.md) | A stale changes-requested PR is adopted by a different worker (kind: rework) | Proposed |
+| [0021](0021-author-agnostic-rework-reconcile.md) | reap routes ANY unaddressed change-request back to changes-requested, regardless of author | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/scripts/reap.sh
+++ b/scripts/reap.sh
@@ -22,12 +22,20 @@
 #     can push its rework, so it can never be adopted). Opt out with
 #     CLOSE_FORK_REWORKS=0.
 #
-# Env: CLAIM_TTL REWORK_TTL CLOSE_FORK_REWORKS DRY_RUN FOR_GOOD_REPO REPO_DIR
+#   - Any open PR carrying a CURRENT change-request whose worked (research/
+#     ideate/build) issue is still `status: in-review`/`claimed` → the issue is
+#     flipped to `status: changes-requested` (ADR-0021). This is start_work.sh's
+#     ADR-0008 reconcile made author-agnostic: it's what lets an ABSENT author's
+#     reviewed work re-enter the queue so ADR-0020 adoption can route it. Opt
+#     out with RECONCILE_UNROUTED=0.
+#
+# Env: CLAIM_TTL REWORK_TTL CLOSE_FORK_REWORKS RECONCILE_UNROUTED DRY_RUN FOR_GOOD_REPO REPO_DIR
 set -euo pipefail
 cd "$(dirname "$0")/.."
 source "scripts/fg-common.sh"
 DRY_RUN="${DRY_RUN:-0}"
 CLOSE_FORK_REWORKS="${CLOSE_FORK_REWORKS:-1}"   # 1 = close fork-origin changes-requested PRs + release the issue (ADR-0020 §5)
+RECONCILE_UNROUTED="${RECONCILE_UNROUTED:-1}"   # 1 = flip ANY current-change-requested PR's work issue → changes-requested (ADR-0021)
 
 hrs() { echo $(( ${1:-0} / 3600 )); }
 
@@ -110,7 +118,54 @@ reap_synthesis_claims() {
   done
 }
 
-# 5) A changes-requested PR that lives on a FORK can never be adopted (only its
+# 5) Author-agnostic rework reconcile (ADR-0021): any open PR whose CURRENT
+#    review decision is CHANGES_REQUESTED (no commit landed after the last such
+#    review) whose worked issue is still `status: in-review`/`claimed` gets that
+#    issue flipped to `status: changes-requested`. start_work.sh's reconcile
+#    (ADR-0008) only does the RUNNING identity's own PRs, so an absent author's
+#    reviewed work never reaches changes-requested and ADR-0020 adoption can't
+#    see it — this closes that gap. Fails closed: work issues only (never a
+#    stream root / discover), skips synthesis/framing PRs and human-only/
+#    do-not-automate, currency- and canonical-PR-guarded. Flips status only
+#    (keeps the assignee — reap_reworks/adoption handle absence); runs BEFORE
+#    the fork sweep so a flipped fork issue is closed in the same pass.
+reap_unrouted_reworks() {
+  [ "$RECONCILE_UNROUTED" = 1 ] || return 0
+  local pr branch labels lastcr headdate iss ilabels stage
+  for pr in $(gh pr list --repo "$REPO" --state open --json number,reviewDecision \
+      --jq '.[] | select(.reviewDecision=="CHANGES_REQUESTED") | .number' --limit 100); do
+    branch="$(gh pr view "$pr" --repo "$REPO" --json headRefName --jq .headRefName 2>/dev/null || true)"
+    # Synthesis/framing rework routes elsewhere (ADR-0011 / ADR-0014).
+    case "$branch" in synthesis/*|discover/*) continue ;; esac
+    labels="$(gh pr view "$pr" --repo "$REPO" --json labels --jq '[.labels[].name]|join(",")' 2>/dev/null || true)"
+    case ",$labels," in *",review: human-only,"*) continue ;; esac
+    # Currency: a commit after the last change-request means it's awaiting
+    # RE-review, not rework — leave it. ISO-8601 timestamps compare lexically.
+    lastcr="$(gh pr view "$pr" --repo "$REPO" --json reviews --jq '[.reviews[]|select(.state=="CHANGES_REQUESTED")]|last|.submittedAt // ""' 2>/dev/null || true)"
+    [ -z "$lastcr" ] && continue
+    headdate="$(gh pr view "$pr" --repo "$REPO" --json commits --jq '.commits[-1].committedDate // ""' 2>/dev/null || true)"
+    [ -n "$headdate" ] && [[ "$headdate" > "$lastcr" ]] && continue
+    iss="$(issue_addressed_by_pr "$pr" || true)"; [ -z "$iss" ] && continue
+    # A stale sibling PR must never route the issue (the #305/#307 protection).
+    [ "$(pr_for_issue "$iss" || true)" = "$pr" ] || continue
+    ilabels="$(issue_labels "$iss" 2>/dev/null || true)"
+    case ",$ilabels," in *",do-not-automate,"*) continue ;; esac
+    # WORK issues only — never a stream root / discover (their statuses differ).
+    stage="$(label_field "$ilabels" "stage: ")"
+    case "$stage" in research|ideate|build) : ;; *) continue ;; esac
+    case ",$ilabels," in
+      *",status: changes-requested,"*) continue ;;   # already routed — no-op
+      *",status: in-review,"*|*",status: claimed,"*)
+        if [ "$DRY_RUN" = 1 ]; then info "[dry-run] would reconcile #$iss ($stage) → changes-requested (unrouted change-request on PR #$pr)"; continue; fi
+        set_status_label "$iss" "changes-requested" "in-review" "claimed" 2>/dev/null || true
+        gh issue comment "$iss" --repo "$REPO" --body "🔁 PR #$pr carries an unaddressed change-request but this issue wasn't routed back to rework — flipping to **changes-requested** so the author's loop, any worker's \`start_work.sh\`, or ADR-0020 adoption can pick it up. (Automated reconcile — ADR-0021.)" >/dev/null 2>&1 || true
+        ok "Reconciled #$iss → changes-requested (unrouted change-request on PR #$pr)"
+        ;;
+    esac
+  done
+}
+
+# 6) A changes-requested PR that lives on a FORK can never be adopted (only its
 #    author can push its branch) and — per the maintainer's direction (#656) —
 #    we are not taking outside fork branches into the automated pipeline for
 #    now. Close the PR with an explanatory comment and release the issue to
@@ -155,11 +210,12 @@ reap_fork_reworks() {
 
 main() {
   preflight
-  info "reap.sh · repo=$REPO · claim-ttl=$(hrs "$CLAIM_TTL")h · rework-ttl=$(hrs "$REWORK_TTL")h$([ "$CLOSE_FORK_REWORKS" = 1 ] && printf " · close-fork-reworks")$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"
+  info "reap.sh · repo=$REPO · claim-ttl=$(hrs "$CLAIM_TTL")h · rework-ttl=$(hrs "$REWORK_TTL")h$([ "$RECONCILE_UNROUTED" = 1 ] && printf " · reconcile-unrouted")$([ "$CLOSE_FORK_REWORKS" = 1 ] && printf " · close-fork-reworks")$([ "$DRY_RUN" = 1 ] && printf " · DRY_RUN")"
   reap_claims
   reap_reworks
   reap_status_conflicts
   reap_synthesis_claims
+  reap_unrouted_reworks    # ADR-0021: route absent-authors' unaddressed change-requests → changes-requested (before the fork sweep)
   reap_fork_reworks
   ok "Reap complete."
 }


### PR DESCRIPTION
## The gap that kept the queue stuck

ADR-0020 adoption only *sees* a PR whose worked issue is `status: changes-requested`. But most sent-back PRs from **absent authors** never reached that state — their issues stranded in `in-review`/`claimed`, because the only things that flip the label are:
- `review_work.sh` when it posts NEEDS_WORK, and
- `start_work.sh`'s reconcile — which by design only touches the **running identity's own** authored PRs (ADR-0008).

So a review posted for an absent author's PR (or a reviewer crash after posting, or a human/bot review) left the issue invisible to adoption **forever**. Live symptom: a backlog of PRs with `CHANGES_REQUESTED` reviews whose issues sat in `in-review`/`claimed`, which no worker and no adoption could route.

## Fix

`reap.sh` gains an **author-agnostic reconcile** (`reap_unrouted_reworks`, ADR-0021) — `start_work.sh`'s ADR-0008 reconcile minus the "only my own PRs" restriction. Each run, any open PR whose **current** review is `CHANGES_REQUESTED` (no commit after it) whose worked **research/ideate/build** issue is still `in-review`/`claimed` gets flipped to `changes-requested`, so adoption / `take_unassigned_rework` / the author's own loop can all route it.

Fails closed: work issues only (never a stream root/discover), skips `synthesis/*`/`discover/*` PRs + `review: human-only` + `do-not-automate`, currency- and canonical-PR-guarded. Flips **status only** (keeps the assignee — `REWORK_TTL` unassign and adoption handle absence). Runs **before** the fork sweep so a flipped fork issue is closed same pass. `RECONCILE_UNROUTED=0` to disable.

## Verified (DRY_RUN, live repo)

```
▸ would reconcile #639 (research) → changes-requested (unrouted change-request on PR #647)
▸ would reconcile #517 (research) → changes-requested (unrouted change-request on PR #606)
▸ would reconcile #516 (research) → changes-requested (unrouted change-request on PR #605)
! #434's fork PR #449 is a discover branch on a fork — leaving it for a human
```
Correctly targets the stuck ones; leaves currency-fresh (#164, author re-pushed) and framing (#434) alone. `bash -n` + `npm run validate` clean.

## Honest limit

This fixes **routing** — it does not make the rework *succeed*. Separately, the codex adopt agent has been adopting issues (#644/#517) and pushing no fix, so they re-cycle; that's an agent-quality problem to watch, not a routing one.

New ADR-0021 (amends ADR-0008, enables ADR-0020). `review: human-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)