### PR TITLE
chore(automation): raise MAX_ACTIVE_STREAMS default 5 → 25

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -178,7 +178,7 @@ default off.)
 Two bounds shape what gets picked up (#292 / #293, ADR-0013):
 
 - **Active-streams cap.** A `stage: discover` root is only claimed while
-  fewer than `MAX_ACTIVE_STREAMS` (default 5) streams are active (open child
+  fewer than `MAX_ACTIVE_STREAMS` (default 25) streams are active (open child
   work, or a root being worked). Roots beyond the cap stay
   `status: available` in the backlog and are picked up as streams drain —
   so ten approved streams *sequence* through the pipeline instead of all

--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -133,7 +133,7 @@ Streams all drain onto a **single human synthesis gate**: producer capacity
 scales with agents, the steward's judgement does not. So concurrency is
 bounded (#292 / ADR-0013):
 
-- **At most `MAX_ACTIVE_STREAMS` (default 5) streams are worked at a time.**
+- **At most `MAX_ACTIVE_STREAMS` (default 25) streams are worked at a time.**
   A stream is *active* while it has open child issues or its root is being
   worked (`claimed` / `in-review` / `changes-requested`). A G0-approved root
   that is merely `status: available` is a stream **waiting in the backlog**:

--- a/docs/adr/0013-pipeline-guardrails.md
+++ b/docs/adr/0013-pipeline-guardrails.md
@@ -46,7 +46,7 @@ We will bound every agent loop and enforce every human lever:
 5. **Fan-out children link the stream root** (`Part of #<root>`), with
    `Split from #<issue>` carrying the spawn edge; depth (≤2) is computed
    along the spawn chain, and `stream-sync.yml` flags mislinked children.
-6. **At most `MAX_ACTIVE_STREAMS` (default 5) streams are worked
+6. **At most `MAX_ACTIVE_STREAMS` (default 25; originally 5) streams are worked
    concurrently**; further G0-approved roots queue in the backlog. Drained
    streams always reach G1 pre-drafted (`synthesize_work.sh`), and the
    synthesis queue depth is published in the site snapshot.

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -11,7 +11,7 @@ PROVIDER="${PROVIDER:-}"                 # optional provider override (Hermes on
 HERMES_PROFILE="${HERMES_PROFILE:-}"     # optional Hermes profile override
 AGENT_TIMEOUT="${AGENT_TIMEOUT:-2400}"   # seconds per agent run (0 = none)
 CLAIM_TTL="${CLAIM_TTL:-7200}"           # secs a claimed-but-undelivered issue is held before reap.sh frees it
-MAX_ACTIVE_STREAMS="${MAX_ACTIVE_STREAMS:-5}"  # streams worked concurrently before new roots wait in the backlog (#292)
+MAX_ACTIVE_STREAMS="${MAX_ACTIVE_STREAMS:-25}"  # streams worked concurrently before new roots wait in the backlog (#292)
 HIGH_PRIORITY_CAP="${HIGH_PRIORITY_CAP:-5}"    # max STREAMS whose 'priority: high' items jump the queue (#293)
 CLAIM_SETTLE="${CLAIM_SETTLE:-8}"        # base secs to let racing claimants' assignments settle before the tie-break
 REWORK_TTL="${REWORK_TTL:-7200}"         # secs a sent-back rework is held for its author before reap.sh frees it


### PR DESCRIPTION
Raises the concurrent-stream cap default from **5 → 25**, so more `stage: discover` streams can be worked at once before new G0-approved roots wait in the backlog (#292).

## What changed
- `scripts/fg-common.sh` — `MAX_ACTIVE_STREAMS` default `5` → `25` (still env-overridable).
- `docs/STREAMS.md`, `docs/AUTOMATION.md` — quoted default updated to 25.
- `docs/adr/0013-pipeline-guardrails.md` — point 6 updated to `(default 25; originally 5)`.

## ADR note
ADR-0013 point 6 records this cap. This PR **retunes the parameter, not the decision** — the backlog gate still exists and still bounds concurrency; only the number moves. I treated that as a tuning change rather than authoring a superseding ADR. Happy to add one if you'd rather record it formally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)