### PR TITLE
feat(autopilot): review without REVIEW_GITHUB_TOKEN (as the local gh identity)

### DIFF
--- a/autopilot.sh
+++ b/autopilot.sh
@@ -16,16 +16,20 @@
 # those scripts, unchanged. See docs/adr/0015-autopilot-alternates-review-and-work.md.
 #
 # THE INTEGRITY RULE STILL HOLDS: an adversarial review may not be by the PR's
-# author. So run the REVIEW side under a DISTINCT identity via REVIEW_GITHUB_TOKEN
-# (a second account / bot PAT with write) — work runs as your normal gh identity,
-# review runs as the token's identity. Without REVIEW_GITHUB_TOKEN it runs
-# WORK-ONLY and warns (reviewing your own PRs is a no-op the gate rejects).
+# author. For FULL coverage run the REVIEW side under a DISTINCT identity via
+# REVIEW_GITHUB_TOKEN (a second account / bot PAT with write) — work runs as your
+# normal gh identity, review as the token's identity, so even your own work PRs
+# get reviewed. WITHOUT REVIEW_GITHUB_TOKEN it still reviews — as your local gh
+# identity — it just skips PRs you authored (which then need a separate
+# reviewer). Either way a loop helps drain the review queue; opt out with
+# REVIEW_PER_WORK=0.
 #
 # Usage:
-#   REVIEW_GITHUB_TOKEN=<bot-pat> ./autopilot.sh            # balanced (claude)
+#   REVIEW_GITHUB_TOKEN=<bot-pat> ./autopilot.sh            # full coverage (claude)
 #   REVIEW_GITHUB_TOKEN=<bot-pat> ./autopilot.sh codex      # use codex
 #   REVIEW_GITHUB_TOKEN=<bot-pat> REVIEW_PER_WORK=3 ./autopilot.sh
-#   ./autopilot.sh                                          # work-only (no token)
+#   ./autopilot.sh                                          # reviews as your gh user (skips your own PRs)
+#   REVIEW_PER_WORK=0 ./autopilot.sh                        # work-only, no reviewing
 #   MAX_CYCLES=5 ./autopilot.sh                             # stop after 5 cycles
 #   PULL=0 ./autopilot.sh                                   # don't auto-pull main
 #
@@ -62,8 +66,8 @@ SELF_HASH="$(self_hash)"
 trap 'rule; warn "autopilot stopping."; fleet_cleanup_run_dir; exit 130' INT TERM
 
 if [ -z "${REVIEW_GITHUB_TOKEN:-}" ]; then
-  warn "REVIEW_GITHUB_TOKEN is not set — running WORK-ONLY (no review passes)."
-  warn "To balance the queue, set REVIEW_GITHUB_TOKEN to a DISTINCT GitHub identity with write access."
+  warn "REVIEW_GITHUB_TOKEN is not set — reviewing as your LOCAL gh identity (PRs you authored are skipped)."
+  warn "For full coverage (incl. your own work PRs), set REVIEW_GITHUB_TOKEN to a DISTINCT GitHub identity with write access. Opt out of reviewing with REVIEW_PER_WORK=0."
 fi
 
 # Fleet telemetry (#398) — ON by default against the project's mission-control
@@ -282,7 +286,6 @@ run_pass() {  # $1 = task kind, rest = command to run
 }
 
 cycle=0
-review_disabled_reported=0
 while :; do
   cycle=$((cycle + 1))
   rule; info "${c_bold}autopilot cycle $cycle${c_reset}  (review×${REVIEW_PER_WORK} → frame×${FRAME_PER_WORK} → work×1)"
@@ -315,17 +318,17 @@ while :; do
 
   did_something=0
 
-  # Review side (distinct identity), review-first so we drain before adding.
-  if [ -n "${REVIEW_GITHUB_TOKEN:-}" ]; then
-    for _ in $(seq 1 "$REVIEW_PER_WORK"); do
-      fleet_handle_commands || break 2
-      info "review pass…"
-      run_pass review env MAX=1 POLL_SECONDS=0 ./scripts/review_work.sh "$@" && did_something=1
-    done
-  elif [ "$review_disabled_reported" = 0 ]; then
-    fleet_send "idle" "" "review disabled: REVIEW_GITHUB_TOKEN missing" 0 0 0 0 0 0 0
-    review_disabled_reported=1
-  fi
+  # Review side, review-first so we drain before adding. With REVIEW_GITHUB_TOKEN
+  # the review is posted by a DISTINCT identity (can review everyone, including
+  # your own work PRs). WITHOUT one, review_work.sh still reviews — as your local
+  # gh identity — it just skips PRs you authored (which then need a separate
+  # reviewer). Either way we run the review passes, so a work-only loop still
+  # helps drain the review queue instead of idling. Opt out with REVIEW_PER_WORK=0.
+  for _ in $(seq 1 "$REVIEW_PER_WORK"); do
+    fleet_handle_commands || break 2
+    info "review pass…"
+    run_pass review env MAX=1 POLL_SECONDS=0 ./scripts/review_work.sh "$@" && did_something=1
+  done
 
   # Framing side: discover roots and sent-back discover/framing PRs are not
   # claimable by start_work.sh (ADR-0014). Without this pass autopilot can look

--- a/docs/adr/0015-autopilot-alternates-review-and-work.md
+++ b/docs/adr/0015-autopilot-alternates-review-and-work.md
@@ -47,9 +47,15 @@ command:
    fires on a real change — no exec loop), so autopilot-level improvements apply
    with no manual restart. `PULL=0` disables the per-cycle pull.
 5. **Preserve the integrity rule.** The review side runs under a **distinct
-   identity** via `REVIEW_GITHUB_TOKEN`; the work side runs as the operator's
-   normal `gh` identity. Without the token, autopilot runs **work-only and
-   warns** — it never reviews as the author, which the gate would reject anyway.
+   identity** via `REVIEW_GITHUB_TOKEN` (a second account / bot PAT) for **full
+   coverage** — that way even the operator's own work PRs get an independent
+   review. Without the token, autopilot **still reviews — as the operator's own
+   `gh` identity** — it just skips PRs that identity authored (`review_work.sh`
+   refuses to review its own author, which the merge gate would reject anyway),
+   so those still need a separate reviewer. Either way a loop helps drain the
+   review queue instead of idling; `REVIEW_PER_WORK=0` opts out of reviewing
+   entirely. *(Amended 2026-07-07: a token-less loop used to run work-only; it
+   now reviews as the local identity so bare work loops still pitch in.)*
 
 ## Consequences
 


### PR DESCRIPTION
## Problem

`autopilot.sh` gated its **review pass** behind `REVIEW_GITHUB_TOKEN`:
```
if [ -n "${REVIEW_GITHUB_TOKEN:-}" ]; then  # review
elif ...; fleet_send "review disabled: REVIEW_GITHUB_TOKEN missing"
```
So a work-only loop (no token) **never reviewed** — even though `review_work.sh` reviews perfectly well as the local `gh` user (it just skips PRs you authored; the docs already document this). Live impact: idle work-only loops sitting next to a backlog of PRs waiting on review.

## Change

The review pass now **always runs** (unless `REVIEW_PER_WORK=0`):
- **With** `REVIEW_GITHUB_TOKEN` → reviews from a **distinct identity** (full coverage, incl. your own work PRs) — the recommended setup, unchanged.
- **Without** it → reviews as your **local `gh` identity**, skipping PRs you authored (those still need a separate reviewer).

**Integrity rule intact:** `review_work.sh` still refuses to review its own author, and the merge gate still requires a non-author verdict — so a loop reviewing as its own identity can only add valid non-author reviews.

Updates the header comment + startup warning, and amends **ADR-0015** (autopilot review behavior) to reflect the token-less fallback.

`review: human-only` (autopilot/pipeline change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)