### PR TITLE
fix(web): define missing brand-slate tokens for autopilot code block …

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -30,6 +30,8 @@ export default {
           "cyan-dark": "#0284C7",
           orange: "#C2410C",
           cream: "#FBF9F6",
+          "slate-light": "#E2E8F0",
+          "slate-muted-light": "#94A3B8",
         },
       },
       borderRadius: { lg: "var(--radius)", md: "calc(var(--radius) - 2px)", sm: "calc(var(--radius) - 4px)" },


### PR DESCRIPTION
…(Closes #671)

text-brand-slate-light and text-brand-slate-muted-light were referenced in Contribute.tsx but never defined in the Tailwind theme, so they fell back to the inherited (near-black) foreground in light mode, making the text invisible against the dark bg-brand-navy code block.

Defined both tokens in web/tailwind.config.js using Tailwind's slate-200/slate-400 values, giving 14.19:1 and 6.82:1 contrast against #1C1917 — well above WCAG AA. Dark mode is unaffected.

<!-- Thanks for contributing to The For Good Project. Fill this in so review is quick. -->

## What this is

Closes #671

**Stage:** 🔨 Build
**Domain:** other

## Summary

Fixed a light-mode readability bug on the Contribute page's autopilot code block. Two Tailwind classes (`text-brand-slate-light`, `text-brand-slate-muted-light`) were used but never defined in the theme, causing text to fall back to a near-black color that was invisible against the dark `bg-brand-navy` block in light mode. Defined both tokens in `web/tailwind.config.js`.

## Method checklist

<!-- Findings especially — see CONTRIBUTING.md. Tick honestly; "no" with a reason is fine. -->

- [ ] Every factual claim has a source (inline)
- [ ] Surprising / load-bearing claims have **two** independent sources (or I flagged where they don't)
- [ ] Confidence marked **High / Medium / Low** (findings)
- [ ] I stated what would change the conclusion and what I couldn't verify
- [x] No personal or identifying data; no overstated or fabricated claims
- [x] Files are in the right place and follow the relevant template
(other checklist items are for research findings — not applicable to this UI fix)

## For the reviewer

Verify contrast: `slate-light` (#E2E8F0) → 14.19:1 against #1C1917, `slate-muted-light` (#94A3B8) → 6.82:1 — both pass WCAG AA (4.5:1 for normal text). Dark mode untouched (`dark:bg-black/40` unchanged), so please confirm dark mode still renders correctly too.
