### PR TITLE
security: make codex OS sandbox opt-in — it broke the fleet server (#713)

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -607,14 +607,14 @@ collective keeps itself unblocked.
 
 - The agent runs with your local CLI auth (your subscription/tokens). Default
   sandbox/permission modes (ADR-0005, implemented by ADR-0022), all overridable:
-  - `codex` — on **Linux**, the native OS sandbox
-    `--sandbox workspace-write` with network re-enabled
-    (`-c sandbox_workspace_write.network_access=true`) and the worktree's git
-    common dir added as writable; on **macOS**, seatbelt disables network in
-    workspace-write ([openai/codex#10390](https://github.com/openai/codex/issues/10390))
-    so it stays on `--dangerously-bypass-approvals-and-sandbox` (unchanged) with
-    a one-line warning — the real macOS isolation is the Linux container.
-    Override with `CODEX_FLAGS`.
+  - `codex` — `--dangerously-bypass-approvals-and-sandbox` (unchanged default).
+    Codex's native OS sandbox is **opt-in** via `FG_CODEX_SANDBOX=1` on a
+    bare-Linux host with a sandbox-capable kernel — it is *not* on by default
+    because it can't create user namespaces inside the unprivileged fleet
+    container (`bwrap: setting up uid map`, #713) and disables network on macOS
+    ([openai/codex#10390](https://github.com/openai/codex/issues/10390)). The
+    isolation boundary is the container itself (ADR-0005), not a nested OS
+    sandbox. Override with `CODEX_FLAGS`.
   - `claude` — `--permission-mode auto` (an injection-aware classifier that
     blocks actions driven by hostile content, keeps network, and doesn't hang
     headless). Override with `CLAUDE_PERMISSION_MODE`; use `bypassPermissions`

--- a/docs/adr/0022-worker-injection-hardening-and-sandbox-defaults.md
+++ b/docs/adr/0022-worker-injection-hardening-and-sandbox-defaults.md
@@ -49,26 +49,27 @@ brings the high-privilege worker up to at least the reviewer's bar and is free.
 **2. Implement ADR-0005's host sandbox defaults in `run_agent`**, both
 overridable via the existing env hooks:
 
-- **Codex** → native OS sandbox in `workspace-write` mode (was
-  `--dangerously-bypass-approvals-and-sandbox`), verified against codex-cli
-  0.142.5. Three corrections to ADR-0005's sketch, each confirmed on the CLI:
-  - ADR-0005 wrote `--ask-for-approval never`, but **`codex exec` has no such
-    flag** (it lives on the top-level command; passing it to `exec` exits 2).
-    `exec` is already non-interactive, so we drop it.
-  - `workspace-write` disables network by default, so we re-enable it with
-    `-c sandbox_workspace_write.network_access=true` — the config key ADR-0005
-    omitted, without which every research/citation fetch fails.
-  - Workers run in a **git worktree** whose real `.git` is in the main clone,
-    *outside* the worktree; `workspace-write` confines writes to the worktree, so
-    `git commit`/`push` would fail. We add the git common dir
-    (`git rev-parse --path-format=absolute --git-common-dir`) via `--add-dir`.
-  - **Platform gate:** on **macOS**, the seatbelt sandbox unconditionally
-    disables network in `workspace-write` (openai/codex#10390), so sandbox and
-    network cannot coexist on a macOS host. Since research *and* review both need
-    network, macOS keeps the full-access default (behaviour unchanged) with a
-    one-line warning pointing to the Linux container; only **Linux** gets the
-    real sandbox by default. Override either with `CODEX_FLAGS=`. Hook trust
-    (`--dangerously-bypass-hook-trust`, ADR-0016) is separate and unchanged.
+- **Codex** → the native OS sandbox (`--sandbox workspace-write`) is **opt-in
+  (`FG_CODEX_SANDBOX=1`, Linux only), NOT the default.** The default stays
+  `--dangerously-bypass-approvals-and-sandbox`. This is a deliberate walk-back
+  from the first cut of this ADR, which defaulted Linux to the sandbox and
+  **broke the fleet in production**: the fleet server runs codex inside an
+  *unprivileged container*, where workspace-write's sandbox helper cannot create
+  user namespaces (`bwrap: setting up uid map: Permission denied`), so every
+  shell command failed before it ran and the worker couldn't even create a
+  branch (issue #713). On macOS the seatbelt path separately disables network in
+  workspace-write (openai/codex#10390), breaking research fetches. The lesson:
+  **the container is the isolation boundary (ADR-0005); an OS sandbox nested
+  inside it is redundant and broken.** So we default to full-access and expose
+  the OS sandbox only to a bare-Linux host with a sandbox-capable kernel that
+  opts in. When enabled, the flags are (verified against codex-cli 0.142.5):
+  `--sandbox workspace-write -c sandbox_workspace_write.network_access=true`
+  (network is off in workspace-write by default) plus `--add-dir <git common
+  dir>` (the worktree's real `.git` is in the main clone, outside the worktree,
+  so commits fail without it). Note `codex exec` has **no** `--ask-for-approval`
+  flag — an earlier draft copied it from ADR-0005 and it exits 2. `CODEX_FLAGS=`
+  overrides everything; hook trust (`--dangerously-bypass-hook-trust`, ADR-0016)
+  is separate and unchanged.
 - **Claude** → `--permission-mode auto` (was `bypassPermissions`). `auto` was
   the maintainer's originally stated intent in ADR-0005's discussion ("we should
   be running on auto mode"); it was unavailable/unreliable then, so 0005 landed
@@ -89,9 +90,10 @@ documented in-container override, where blast radius is the throwaway container.
   from public text; every privileged prompt across `start_work.sh`,
   `frame_work.sh`, `synthesize_work.sh`, and `review_work.sh` now carries the
   same untrusted-data boundary.
-- On Linux, an injected Codex worker can no longer write outside the worktree
-  (+ its `.git`) or run unsandboxed; on every platform an injected Claude worker
-  is checked by the `auto` classifier. Research network egress still works.
+- On every platform an injected Claude worker is checked by the `auto`
+  classifier (no OS-sandbox dependency, so it works everywhere including the
+  container). The codex OS sandbox is available (opt-in) for bare-Linux hosts
+  but is explicitly NOT relied on as the boundary — the container is.
 - Implements a decision (ADR-0005) that had been accepted but not shipped, and
   corrects three flag/config errors in it that would have broken `codex exec`.
 
@@ -102,17 +104,20 @@ documented in-container override, where blast radius is the throwaway container.
   that.
 - `auto` mode is fail-closed: it may occasionally block a legitimate action,
   reducing task completion. It's overridable per run.
-- The Codex flag strings and config key are verified against codex-cli 0.142.5
-  (arg parsing, and the `workspace-write`/`network_access` docs), and Claude
-  `auto` is confirmed to run headless. What is **not** yet validated end-to-end:
-  a full Linux `codex exec` task completing under `workspace-write` with the
-  `.git` writable root (the authoring machine is macOS, which takes the
-  full-access path). Smoke-test one Linux worker before trusting the Linux
-  default fleet-wide; `CODEX_FLAGS=` is the fallback.
+- The codex OS sandbox default was shipped, broke the fleet (#713), and was
+  reverted to opt-in within hours — a reminder that a sandbox change must be
+  smoke-tested in the *actual* runtime (unprivileged container), not just
+  arg-parsed. `FG_CODEX_SANDBOX=1` remains available but is now the contributor's
+  explicit choice on a host they've confirmed supports it.
+- The net security gain that stands unconditionally is the prompt fencing (all
+  workers) and Claude `auto`. Codex-worker isolation is deferred to the container
+  (#686). `auto` mode is fail-closed and may occasionally block a legitimate
+  action; it's overridable per run.
 
 **Tripwire** — revisit if `auto` mode blocks enough legitimate work that
 contributors routinely set `CLAUDE_PERMISSION_MODE=bypassPermissions` outside a
-container (defeating the purpose), or if the Codex network config key changes.
+container (defeating the purpose); or when the container work (#686) lands, at
+which point the codex OS sandbox opt-in can likely be retired entirely.
 
 ## Follow-ups (tracked in #686, not here)
 

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -807,35 +807,35 @@ run_agent() {
       # checkout actually carries the repo hook config.
       local hook_trust=""
       [ -f "$dir/.codex/hooks.json" ] && hook_trust="--dangerously-bypass-hook-trust"
-      # Sandbox (ADR-0005, implemented by ADR-0022). Codex's OS sandbox in
-      # workspace-write mode confines writes to the workspace + tmp. Two facts
-      # verified against codex-cli 0.142.5 shape how we apply it:
-      #   * `codex exec` is non-interactive and has NO --ask-for-approval flag
-      #     (that lives on the top-level command; passing it to `exec` errors).
-      #     So we do not pass it — exec simply runs sandboxed without prompting.
-      #   * Research and review both need network. workspace-write disables it by
-      #     default, so we re-enable it (sandbox_workspace_write.network_access) —
-      #     BUT on macOS the seatbelt sandbox unconditionally disables network in
-      #     workspace-write (openai/codex#10390), so there sandbox+network can't
-      #     coexist; we fall back to full-access and leave real isolation to the
-      #     Linux container (ADR-0005). Override either way with CODEX_FLAGS=.
-      #   * Workers run in a git worktree whose real .git lives in the MAIN clone,
-      #     OUTSIDE the worktree — so we add the git common dir to the writable
-      #     roots, else git commit/push fail under the sandbox.
+      # Sandbox (ADR-0005 / ADR-0022). Codex's OS sandbox is OPT-IN, not the
+      # default — because it does not work in the environments the fleet actually
+      # runs in:
+      #   * The fleet server runs codex inside an UNPRIVILEGED container, where
+      #     workspace-write's sandbox helper can't create user namespaces —
+      #     "bwrap: setting up uid map: Permission denied" — so EVERY shell
+      #     command fails before it starts and the worker can't even make a branch
+      #     (this broke real work: #713).
+      #   * On macOS the seatbelt path disables network in workspace-write
+      #     (openai/codex#10390), breaking research fetches.
+      # The real isolation boundary is the container itself (ADR-0005), so nesting
+      # an OS sandbox inside it is both redundant and broken. We therefore default
+      # to full-access and expose the sandbox only to a bare-Linux host with a
+      # sandbox-capable kernel that sets FG_CODEX_SANDBOX=1. CODEX_FLAGS= still
+      # overrides everything. Verified against codex-cli 0.142.5: `codex exec` has
+      # no --ask-for-approval flag; workspace-write disables network unless
+      # network_access=true; and our worktree's real .git lives in the MAIN clone
+      # (outside the worktree), so it must be added to the writable roots or
+      # git commit/push fail.
       local -a codex_args
       if [ -n "${CODEX_FLAGS:-}" ]; then
         read -r -a codex_args <<< "$CODEX_FLAGS"
-      elif [ "$(uname -s)" = "Linux" ]; then
+      elif [ "${FG_CODEX_SANDBOX:-0}" = 1 ] && [ "$(uname -s)" = "Linux" ]; then
         codex_args=(--sandbox workspace-write -c sandbox_workspace_write.network_access=true)
         local gitcommon
         gitcommon="$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
         [ -n "$gitcommon" ] && codex_args+=(--add-dir "$gitcommon")
       else
         codex_args=(--dangerously-bypass-approvals-and-sandbox)
-        if [ -z "${FG_CODEX_SANDBOX_WARNED:-}" ]; then
-          printf 'fg: codex host sandbox unavailable on %s — workspace-write disables network here (openai/codex#10390), breaking research fetches; running full-access. Use the Linux container for isolation, or set CODEX_FLAGS=.\n' "$(uname -s)" >&2
-          export FG_CODEX_SANDBOX_WARNED=1
-        fi
       fi
       if [ -n "${FLEET_SERVER:-}" ] && [ "${CODEX_JSON_TELEMETRY:-1}" = 1 ]; then
         $tmo codex exec --json --cd "$dir" --skip-git-repo-check $hook_trust \


### PR DESCRIPTION
## What / why

Follow-up to #689. The Linux-default codex sandbox it introduced **broke the fleet in production within hours of merging**, on issue #713.

The fleet server runs codex inside an **unprivileged container**. codex's `workspace-write` sandbox tries to set up user namespaces via bubblewrap, which the container can't allow:

```
bwrap: setting up uid map: Permission denied
Local command execution is still failing at the sandbox setup layer, not at any project command.
```

So every shell command failed *before running*, the worker couldn't read its worktree or create a branch, and no PR was opened (`#713 released (no PR opened)`).

## Fix

- **Default reverts to `--dangerously-bypass-approvals-and-sandbox`** (the working behaviour).
- codex's OS sandbox is now **opt-in via `FG_CODEX_SANDBOX=1`, Linux only** — for a bare-metal host whose kernel supports user namespaces. `CODEX_FLAGS=` still overrides everything.
- **Prompt fencing (all workers) and Claude `auto` are untouched** — those are the security gains that stand unconditionally. Codex-worker isolation is deferred to the container (#686), which is the real boundary per ADR-0005.

## The lesson (recorded in ADR-0022)
The container *is* the isolation boundary; nesting an OS sandbox inside an unprivileged container is redundant and, here, broken. A sandbox change has to be smoke-tested in the **actual runtime** (unprivileged container), not just arg-parsed — #689 was verified on the CLI but not in the container, and that's exactly the gap that bit.

## Immediate mitigation (already possible without this PR)
Set `CODEX_FLAGS=--dangerously-bypass-approvals-and-sandbox` (or `CODEX_FLAGS=` to any working value) in the fleet server env to unblock codex workers right now; this PR makes that the default so no env override is needed.

## Verification
`bash -n` clean; `scripts/test-fg-common-queue.sh` passes; `npm run validate` passes. #713's claim was auto-released, so it re-queues once this lands.

Closes nothing (tracking stays in #686); fixes the regression from #689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBqAcHfJxoJXHHPbHcn8Jq