### PR TITLE
research: quantify delayed care costs in NZ (Closes #735)

### DIFF
--- a/research/findings/civic-transparency/delayed-care-costs-nz.md
+++ b/research/findings/civic-transparency/delayed-care-costs-nz.md
@@ -1,0 +1,150 @@
+---
+title: "Delayed ED, specialist-assessment and elective care in NZ has clear clinical harm, but only partial NZ mental-health and productivity costing"
+domain: "civic-transparency"
+issue: "#735"
+confidence: "Medium"
+author: "codex-agent"
+agent: "codex"
+model: "gpt-5"
+date: "2026-07-07"
+status: "draft"
+---
+
+# Delayed ED, specialist-assessment and elective care in NZ has clear clinical harm, but only partial NZ mental-health and productivity costing
+
+This finding answers one question: **what can currently be said, from public evidence, about the clinical, mental-health and productivity cost of delayed emergency-department (ED), first-specialist-assessment (FSA) and elective care in New Zealand?**
+
+## Executive answer
+
+- **Clinical harm is the strongest NZ-specific finding.** A New Zealand ED cohort study reported higher seven-day mortality when more than 10% of current ED patients had hospital access block, and an HRC summary of a national six-hour-target study says the target was associated with about 700 fewer ED deaths than predicted if pre-target trends had continued. [Jones & van der Werf, 2020/2021](https://www.researchgate.net/publication/347569522_Emergency_department_crowding_and_mortality_for_patients_presenting_to_emergency_departments_in_New_Zealand); [Health Research Council, 2016](https://www.hrc.govt.nz/news-and-events/fewer-deaths-eds-when-length-stay-reduced)
+- **FSA delay can cause serious patient harm, but the public NZ evidence found here is condition-specific rather than national.** HDC's commissioner-initiated investigation into Southern non-surgical cancer services says FSA delays from 2016 to 2022 led to detrimental physical and psychological outcomes, affected family/whanau, and caused patient harm from prolonged oncology FSA delays. [Health and Disability Commissioner, 2024](https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/)
+- **Elective-care delay has NZ evidence for hip arthroplasty costs and health deterioration.** A Wellington-based prospective cohort of 153 people waiting for total hip arthroplasty found a mean waiting time of 5.1 months, mean total waiting cost of NZ$4,305 per person in 2005 prices, higher mean cost for waits over six months, and poorer pre-operative physical function with longer waits. [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf)
+- **Mental-health cost is plausible and partly observed, but not nationally costed for NZ public-hospital waits.** NZ sources identify psychological outcomes in cancer-service delays and measure anxiety/depression in hip-arthroplasty waiting, while an Australian prospective joint-replacement study found psychological distress remained high while patients waited; however, I did not find a current NZ public estimate that converts delayed ED, FSA or elective care into a national mental-health burden. [Health and Disability Commissioner, 2024](https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/); [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf); [Ackerman et al., 2011](https://pmc.ncbi.nlm.nih.gov/articles/PMC3121657/)
+- **Productivity cost should be treated as a known gap, not as one national number.** NZ evidence shows hip-waiting costs, arthritis productivity loss, ACC weekly-compensation and return-to-work pressure around elective surgery, but I did not find a public NZ model that links Health NZ waitlists to tax, wage, welfare, ACC or employer productivity impacts in the way newer England work links elective waiting lists to HMRC pay data. [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf); [Deloitte Access Economics for Arthritis New Zealand, 2018](https://www.arthritis.org.nz/assets-prod/downloads/Research-Reports/Economic-cost-of-Arthritis-in-New-Zealand-2018.pdf); [ACC, secondary care, accessed 2026-07-07](https://www.acc.co.nz/for-providers/provider-news-and-events/health-sector-engagement/secondary-care); [NHS England/ONS, 2025](https://assets.kingsfund.org.uk/f/256914/x/6b673ca354/economicimpactnhswaitinglists_report_october2025.pdf)
+
+**Overall confidence:** Medium - high for ED mortality and hip-arthroplasty waiting costs, medium for FSA harm because the clearest source is oncology-specific, and low-to-medium for national mental-health and productivity cost because the strongest direct national estimate was not found.
+
+## Evidence
+
+### Scope and denominator
+
+New Zealand's current health-target framework includes three relevant access points: 95% of ED patients should be admitted, discharged or transferred within six hours; 95% of patients should wait less than four months for a first specialist assessment; and 95% should wait less than four months for elective treatment. [Health NZ, health targets](https://www.healthnz.govt.nz/about-us/what-we-do/planning-and-performance/health-targets); [Ministry of Health, health targets](https://www.health.govt.nz/monitoring-statistics/system-monitoring/health-targets)
+
+This finding does not restate the 2024-2026 baseline produced for sibling issue #732; it uses those measures only to define which delays are in scope. [Health NZ, health targets](https://www.healthnz.govt.nz/about-us/what-we-do/planning-and-performance/health-targets)
+
+### ED delay and crowding: clinical harm is strongly supported
+
+Jones and van der Werf's NZ retrospective cohort study of 25 acute hospitals and 5,793,767 ED visits reported that seven-day mortality was higher for patients arriving when more than 10% of current ED patients had hospital access block, with hazard ratio 1.10 and 95% confidence interval 1.05 to 1.17. [Jones & van der Werf, 2020/2021](https://www.researchgate.net/publication/347569522_Emergency_department_crowding_and_mortality_for_patients_presenting_to_emergency_departments_in_New_Zealand)
+
+The same abstract reported higher seven-day mortality when the ED was not complying with the four-hour emergency access target, with hazard ratio 1.07 and 95% confidence interval 1.01 to 1.12, and concluded that access block had the strongest association with seven-day mortality. [Jones & van der Werf, 2020/2021](https://www.researchgate.net/publication/347569522_Emergency_department_crowding_and_mortality_for_patients_presenting_to_emergency_departments_in_New_Zealand)
+
+The HRC summary of an HRC-funded study says New Zealand's six-hour ED target was introduced in June 2009, that 18 of 20 DHBs were studied over 2006-2012, and that the target was associated with reductions in ED crowding, ED stay, and patient mortality. [Health Research Council, 2016](https://www.hrc.govt.nz/news-and-events/fewer-deaths-eds-when-length-stay-reduced)
+
+The HRC summary says DHBs invested about NZ$52 million between 2008 and 2012 to make the target work, average hospital length of stay reduced by about seven hours, ED stays reduced by over an hour overall and by about three hours for admitted patients, and ED deaths were about 700 fewer than predicted if pre-target trends had continued. [Health Research Council, 2016](https://www.hrc.govt.nz/news-and-events/fewer-deaths-eds-when-length-stay-reduced)
+
+International emergency-medicine evidence is directionally consistent with the NZ ED finding: an International Federation for Emergency Medicine report states that delays to admission after ED care is complete are associated with mortality in high-acuity settings and longer overall hospital stays, while noting evidence quality varies by outcome. [IFEM, 2020](https://assets.nationbuilder.com/ifem/pages/270/attachments/original/1650595379/ED-Crowding-and-Access-Block-Report-Final-June-30-2020.pdf?1650595379=)
+
+**Per-claim confidence:** High that NZ ED access block is associated with higher short-term mortality; Medium that reducing ED length-of-stay targets caused all observed mortality improvement, because the HRC summary itself notes it could not assess what the NZ$52 million would otherwise have been used for. [Health Research Council, 2016](https://www.hrc.govt.nz/news-and-events/fewer-deaths-eds-when-length-stay-reduced)
+
+### First specialist assessment: NZ harm evidence is strongest for cancer
+
+HDC's 2024 commissioner-initiated investigation examined Te Whatu Ora Southern's non-surgical cancer services, including delays in patients obtaining FSAs from 2016 to 2022. [Health and Disability Commissioner, 2024](https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/)
+
+The HDC executive summary says the case was a reminder of detrimental physical and psychological outcomes for patients and impacts on family/whanau when timely cancer care is not provided. [Health and Disability Commissioner, 2024](https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/)
+
+HDC found that Te Whatu Ora Southern failed to recognise and respond to clinical risk created by lack of capacity, that concerns about increasing patient harm from delays could have been addressed earlier, and that harm was caused by capacity issues and prolonged FSA delays. [Health and Disability Commissioner, 2024](https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/)
+
+The same HDC report says a March 2021 presentation to Te Aho o Te Kahu, DHB leadership and the Ministry highlighted that cancer-care delays at Te Whatu Ora Southern were leading to poor outcomes, including increased mortality. [Health and Disability Commissioner, 2024](https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/)
+
+An NZMJ audit of symptomatic colorectal-cancer referrals in Bay of Plenty DHB found long delays for a significant number of patients between GP referral and specialist diagnosis, and warned that patients who missed urgent 14-day fast-track categorisation could wait four months or more for definitive diagnostic testing. [Gwynne-Jones et al., 2019](https://nzmj.org.nz/media/pages/journal/vol-132-no-1491/the-factors-that-lead-to-a-delay-between-general-practitioner-referral-of-symptomatic-patients-and-specialist-diagnosis-of-color/38cbdd6e44-1696472352/the-factors-that-lead-to-a-delay-between-general-practitioner-referral-of-symptomatic-patients-and-specialist-diagnosis-of-color.pdf)
+
+**Per-claim confidence:** Medium. The HDC source is official and direct for cancer-service delay, but it is not a national all-specialty FSA cost estimate; the colorectal-cancer audit supports a referral-to-diagnosis delay mechanism, but it is local and condition-specific. [Health and Disability Commissioner, 2024](https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/); [Gwynne-Jones et al., 2019](https://nzmj.org.nz/media/pages/journal/vol-132-no-1491/the-factors-that-lead-to-a-delay-between-general-practitioner-referral-of-symptomatic-patients-and-specialist-diagnosis-of-color/38cbdd6e44-1696472352/the-factors-that-lead-to-a-delay-between-general-practitioner-referral-of-symptomatic-patients-and-specialist-diagnosis-of-color.pdf)
+
+### Elective care: NZ evidence quantifies hip-waiting cost better than other procedures
+
+Fielden et al.'s Wellington-based prospective cohort followed 153 people waiting for total hip arthroplasty and collected monthly WOMAC, EQ-5D and cost-diary data before surgery and for six months after surgery. [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf)
+
+The study found mean total waiting cost of NZ$4,305 per person in 2005 prices, and waits longer than six months were associated with higher mean total cost than waits under six months. [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf)
+
+The study also found longer waits led to poorer pre-operative physical function, and concluded that longer waits for total hip arthroplasty incur greater economic costs and physical-function deterioration while waiting. [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf)
+
+A separate NZ elective-surgery waiting-list study of prostatectomy and hip/knee joint replacement patients found that most participants reported severe symptoms and poorer health-related quality of life on most dimensions than a general NZ population sample, and concluded that lengthy waiting was a burden because people lived with unrelieved severe symptoms and poor quality of life. [Derrett, Paul & Morris, 1999](https://academic.oup.com/intqhc/article-abstract/11/1/47/1837320)
+
+An NZMJ patient-record study found that 36% of studied patients with hip or knee osteoarthritis who were considered suitable for arthroplasty were declined surgery because of resource limits, which points to rationing before the formal treatment waitlist as well as waiting after acceptance. [Blackett et al., 2014](https://nzmj.org.nz/media/pages/journal/vol-127-no-1405/the-impact-of-the-6-month-waiting-target-for-elective-surgery-a-patient-record-study/6a28814e3f-1696475415/the-impact-of-the-6-month-waiting-target-for-elective-surgery-a-patient-record-study.pdf)
+
+**Per-claim confidence:** High that long hip-arthroplasty waits impose patient and societal costs in the cited NZ cohort; Medium for transferring that dollar value to today's full elective waitlist, because the study is dated, procedure-specific, and in 2005 prices. [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf)
+
+### Mental-health cost: visible in cases, not nationally estimated
+
+The most direct NZ public source found for mental-health harm from specialist delay is HDC's Southern cancer investigation, which explicitly names psychological outcomes for patients and family/whanau when timely cancer care is not provided. [Health and Disability Commissioner, 2024](https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/)
+
+Fielden et al. measured EQ-5D, including the anxiety/depression dimension, in people waiting for hip arthroplasty, but the headline waiting-period findings in the abstract and conclusion emphasise physical-function deterioration and economic cost rather than a national mental-health cost estimate. [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf)
+
+The closest transferable mental-health evidence found for elective orthopaedic waits is Australian, not NZ: Ackerman et al. followed public-hospital hip and knee replacement patients and reported that high psychological distress remained elevated before surgery while many participants waited at least six months. [Ackerman et al., 2011](https://pmc.ncbi.nlm.nih.gov/articles/PMC3121657/)
+
+The project's vendored `mental-health-data-nz` CLI found public mental-health KPI metadata, including a "Wait times" indicator for specialist mental-health and addiction services, but that indicator concerns waits for mental-health services rather than the mental-health impact of ED, FSA or elective-treatment delays. [MH&A KPI Programme, wait-times indicator](https://www.mhakpi.health.nz/indicators/wait-times/)
+
+**Per-claim confidence:** Medium that delayed specialist/elective care causes psychological burden in some NZ patients; Low that the national mental-health burden can be quantified from public NZ data right now.
+
+### Productivity cost: pieces exist, but no public NZ-wide model was found
+
+Fielden et al. defined societal costs of waiting for hip arthroplasty to include time off work or usual activity and reduced productivity at work or usual activity, and their cost diaries counted waiting-period costs rather than the cost of surgery itself. [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf)
+
+Deloitte Access Economics' report for Arthritis New Zealand estimated 2018 arthritis productivity costs of NZ$1.244 billion, comprising reduced employment, presenteeism and temporary absenteeism, but that is a disease-burden estimate for arthritis, not a waiting-time estimate for public hospital care. [Deloitte Access Economics for Arthritis New Zealand, 2018](https://www.arthritis.org.nz/assets-prod/downloads/Research-Reports/Economic-cost-of-Arthritis-in-New-Zealand-2018.pdf)
+
+ACC says some secondary-care clients experience delays, duplication or unnecessary steps before reaching the right assessment or treatment, and that costs are rising with elective surgery as a key driver, with more clients needing weekly compensation after surgery and taking longer to recover and return to work. [ACC, secondary care, accessed 2026-07-07](https://www.acc.co.nz/for-providers/provider-news-and-events/health-sector-engagement/secondary-care)
+
+ACC's weekly-compensation guidance says eligible injured people who cannot do their usual job may receive financial support to replace part of their income, usually from day eight after injury if they qualify. [ACC, weekly compensation, accessed 2026-07-07](https://www.acc.co.nz/im-injured/financial-support/weekly-compensation)
+
+The England comparator shows what a stronger productivity-cost method could look like: NHS England and ONS authors linked hospital and elective waiting-time data with HMRC PAYE data, modelled the pay impact of reducing waits, and described the linked data as covering most patients in England through pseudonymised hospital, waiting-list, tax and death-registration records. [NHS England/ONS, 2025](https://assets.kingsfund.org.uk/f/256914/x/6b673ca354/economicimpactnhswaitinglists_report_october2025.pdf)
+
+**Per-claim confidence:** Medium that delayed elective care has productivity costs in NZ, especially for orthopaedic and ACC-linked cases; Low for any national dollar figure, because no public NZ linked-data model was found.
+
+## Surprising or load-bearing claims
+
+| Claim | Source 1 | Source 2 | Confidence |
+|---|---|---|---|
+| NZ ED access block is associated with higher seven-day mortality. | [Jones & van der Werf, 2020/2021](https://www.researchgate.net/publication/347569522_Emergency_department_crowding_and_mortality_for_patients_presenting_to_emergency_departments_in_New_Zealand) | [Health Research Council, 2016](https://www.hrc.govt.nz/news-and-events/fewer-deaths-eds-when-length-stay-reduced) independently supports mortality relevance of reducing ED crowding and length of stay. | High |
+| The historical NZ six-hour ED target was associated with about 700 fewer ED deaths than predicted. | [Health Research Council, 2016](https://www.hrc.govt.nz/news-and-events/fewer-deaths-eds-when-length-stay-reduced) | [IFEM, 2020](https://assets.nationbuilder.com/ifem/pages/270/attachments/original/1650595379/ED-Crowding-and-Access-Block-Report-Final-June-30-2020.pdf?1650595379=) supports the general ED crowding and mortality mechanism, but not the 700 NZ estimate. | Medium - the exact figure is one NZ source. |
+| FSA delays can cause psychological and physical harm in NZ. | [HDC Southern cancer investigation, 2024](https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/) | [NZMJ colorectal-cancer referral audit, 2019](https://nzmj.org.nz/media/pages/journal/vol-132-no-1491/the-factors-that-lead-to-a-delay-between-general-practitioner-referral-of-symptomatic-patients-and-specialist-diagnosis-of-color/38cbdd6e44-1696472352/the-factors-that-lead-to-a-delay-between-general-practitioner-referral-of-symptomatic-patients-and-specialist-diagnosis-of-color.pdf) supports specialist-diagnosis delay mechanisms. | Medium - cancer-specific, not all FSA. |
+| Waiting for hip arthroplasty in NZ has measurable patient and societal cost. | [Fielden et al., 2005](https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf) | [Derrett, Paul & Morris, 1999](https://academic.oup.com/intqhc/article-abstract/11/1/47/1837320) supports poor quality-of-life burden among NZ elective waiters. | High for hip/elective burden; Medium for today's prices and wider procedure mix. |
+| There is no defensible public NZ-wide dollar estimate for the full ED/FSA/elective delay burden in the sources reviewed. | This finding searched official Health NZ, HDC, ACC, Treasury, Stats NZ/data.govt.nz skills and peer-reviewed sources cited here. | [NHS England/ONS, 2025](https://assets.kingsfund.org.uk/f/256914/x/6b673ca354/economicimpactnhswaitinglists_report_october2025.pdf) shows the kind of linked administrative model that was not found publicly for NZ. | Medium - absence claims can be overturned by unpublished or missed public analysis. |
+
+## What would change this conclusion
+
+- A Health NZ, Treasury, ACC, MSD or Stats NZ linked-data analysis connecting waitlist duration to mortality, hospital use, wages, tax, welfare receipt, ACC weekly compensation, caregiver time or patient-reported distress would change this from a "pieces of evidence" finding into a national cost estimate.
+- A current NZ patient-reported outcome survey for people waiting for FSA or elective treatment, especially one using K10/Kessler distress, EQ-5D anxiety/depression, work status and caregiver burden, would materially improve the mental-health conclusion.
+- A national specialty-level model that updates Fielden et al.'s hip-arthroplasty waiting-cost method to 2026 prices and applies it to orthopaedics, ophthalmology, ENT, plastic surgery and other high-wait specialties would strengthen the productivity conclusion.
+- A clinical review by emergency physicians, oncologists, surgeons, nurses, ACC return-to-work specialists and patient advocates could identify harms this desktop review missed, especially for people who deteriorate before making it onto a formal waitlist.
+
+Could not verify:
+
+- I did not find a public NZ estimate that converts delayed ED, FSA and elective care into total annual QALYs lost, psychological-distress cases, wage loss, tax loss, welfare cost, ACC cost or employer cost.
+- I did not access unpublished Health NZ, ACC, Treasury, MSD or hospital operational datasets.
+- The `data-govt-nz` CLI search for hospital waiting and productivity data returned a non-JSON catalogue response in this environment, so it did not provide usable dataset evidence.
+- PubMed pages for several biomedical articles returned a reCAPTCHA page in the built-in web tool; where possible, I used publisher, ResearchGate, PMC or official report pages instead and treated the PubMed blockage as tooling, not a dead citation.
+
+## Open follow-up questions
+
+- What would an NZ linked-data design need to estimate productivity loss from Health NZ waitlists without exposing personal information?
+- Which specialties account for the largest share of probable work loss and caregiver burden, rather than just the largest overdue patient counts?
+- Are people declined before entering a formal elective waitlist experiencing comparable health, mental-health and productivity harms to people accepted onto the waitlist?
+
+## Sources
+
+1. Health NZ, "Health targets," last updated 2 December 2025. https://www.healthnz.govt.nz/about-us/what-we-do/planning-and-performance/health-targets (accessed 2026-07-07)
+2. Ministry of Health, "Health targets," last updated 2 July 2026. https://www.health.govt.nz/monitoring-statistics/system-monitoring/health-targets (accessed 2026-07-07)
+3. Peter Jones and Bert van der Werf, "Emergency department crowding and mortality for patients presenting to emergency departments in New Zealand," *Emergency Medicine Australasia* 33(4), 2020/2021, DOI 10.1111/1742-6723.13699; abstract/full-text preview fetched via ResearchGate because PubMed returned reCAPTCHA in this environment. https://www.researchgate.net/publication/347569522_Emergency_department_crowding_and_mortality_for_patients_presenting_to_emergency_departments_in_New_Zealand
+4. Health Research Council of New Zealand, "Fewer deaths in EDs when length of stay reduced," 21 November 2016. https://www.hrc.govt.nz/news-and-events/fewer-deaths-eds-when-length-stay-reduced (accessed 2026-07-07)
+5. International Federation for Emergency Medicine, "Report from the Emergency Department Crowding and Access Block Task Force," June 2020. https://assets.nationbuilder.com/ifem/pages/270/attachments/original/1650595379/ED-Crowding-and-Access-Block-Report-Final-June-30-2020.pdf?1650595379= (accessed 2026-07-07)
+6. Health and Disability Commissioner, "Commissioner-Initiated Investigation into delays in provision of non-surgical cancer services," 22HDC01310, 22 February 2024. https://www.hdc.org.nz/decisions/search-decisions/2023/22hdc01310/ (accessed 2026-07-07)
+7. Jann M. Fielden et al., "Waiting for Hip Arthroplasty: Economic Costs and Health Outcomes," *Journal of Arthroplasty* 20(8):990-997, 2005, DOI 10.1016/j.arth.2004.12.060; fetched via author-uploaded ResearchGate PDF. https://www.researchgate.net/profile/Jann-Fielden/publication/7395502_Waiting_for_Hip_Arthroplasty_Economic_Costs_and_Health_Outcomes/links/5bdf6c84299bf1124fbb7a00/Waiting-for-Hip-Arthroplasty-Economic-Costs-and-Health-Outcomes.pdf (accessed 2026-07-07)
+8. S. Derrett, C. Paul and J.M. Morris, "Waiting for elective surgery: effects on health-related quality of life," *International Journal for Quality in Health Care* 11(1):47-57, 1999. https://academic.oup.com/intqhc/article-abstract/11/1/47/1837320 (accessed 2026-07-07)
+9. James Blackett, Alex Carslaw, David Lees, Sophie Fargher, Sudhindra Rao and Margy Pohl, "The impact of the 6-month waiting target for elective surgery: a patient record study," *New Zealand Medical Journal* 127(1405), 2014. https://nzmj.org.nz/media/pages/journal/vol-127-no-1405/the-impact-of-the-6-month-waiting-target-for-elective-surgery-a-patient-record-study/6a28814e3f-1696475415/the-impact-of-the-6-month-waiting-target-for-elective-surgery-a-patient-record-study.pdf (accessed 2026-07-07)
+10. Gwynne-Jones et al., "The factors that lead to a delay between general practitioner referral of symptomatic patients and specialist diagnosis of colorectal cancer," *New Zealand Medical Journal* 132(1491), 2019. https://nzmj.org.nz/media/pages/journal/vol-132-no-1491/the-factors-that-lead-to-a-delay-between-general-practitioner-referral-of-symptomatic-patients-and-specialist-diagnosis-of-color/38cbdd6e44-1696472352/the-factors-that-lead-to-a-delay-between-general-practitioner-referral-of-symptomatic-patients-and-specialist-diagnosis-of-color.pdf (accessed 2026-07-07)
+11. Ilana N. Ackerman, Kim L. Bennell and Richard H. Osborne, "Decline in Health-Related Quality of Life reported by more than half of those waiting for joint replacement surgery: a prospective cohort study," *BMC Musculoskeletal Disorders* 12:108, 2011. https://pmc.ncbi.nlm.nih.gov/articles/PMC3121657/ (accessed 2026-07-07)
+12. MH&A KPI Programme, "Wait times" indicator metadata. https://www.mhakpi.health.nz/indicators/wait-times/ (accessed via vendored `mental-health-data-nz` CLI and web, 2026-07-07)
+13. Deloitte Access Economics for Arthritis New Zealand, "The economic cost of arthritis in New Zealand in 2018." https://www.arthritis.org.nz/assets-prod/downloads/Research-Reports/Economic-cost-of-Arthritis-in-New-Zealand-2018.pdf (accessed 2026-07-07)
+14. ACC, "Secondary care," provider engagement page. https://www.acc.co.nz/for-providers/provider-news-and-events/health-sector-engagement/secondary-care (accessed 2026-07-07)
+15. ACC, "Weekly compensation." https://www.acc.co.nz/im-injured/financial-support/weekly-compensation (accessed 2026-07-07)
+16. NHS England and Office for National Statistics authors, "Assessing the economic impact of tackling elective waiting times," hosted by The King's Fund, 6 October 2025. https://assets.kingsfund.org.uk/f/256914/x/6b673ca354/economicimpactnhswaitinglists_report_october2025.pdf (accessed 2026-07-07)


### PR DESCRIPTION
Closes #735. Stream: #434. Adds a cited NZ-first finding on clinical, mental-health and productivity costs of delayed ED, FSA and elective care.