### PR TITLE
fix(fleet): dedup /live rows via stable client session id

### DIFF
--- a/server/clients/claude-code-hook.mjs
+++ b/server/clients/claude-code-hook.mjs
@@ -61,6 +61,9 @@ const hello = {
 async function send(heartbeat) {
   const resp = await post("/api/v1/telemetry", {
     ...(state.agentId ? { agentId: state.agentId } : {}),
+    // Stable per-session key: lets the server dedup our first/raced posts to one
+    // record before our agentId round-trips back and gets saved (#398).
+    session: sessionKey,
     ...hello,
     ...(heartbeat ? { heartbeat } : {}),
   });

--- a/server/clients/codex-hook.mjs
+++ b/server/clients/codex-hook.mjs
@@ -74,6 +74,8 @@ const hello = {
 async function send(heartbeat) {
   const resp = await post("/api/v1/telemetry", {
     ...(state.agentId ? { agentId: state.agentId } : {}),
+    // Stable per-session key so the server dedups first/raced posts (#398).
+    session: sessionKey,
     ...hello,
     ...(heartbeat ? { heartbeat } : {}),
   });

--- a/server/clients/codex-notify.mjs
+++ b/server/clients/codex-notify.mjs
@@ -48,6 +48,8 @@ const hello = {
 // Hello-only upsert: refreshes presence without a no-op heartbeat frame.
 const resp = await post("/api/v1/telemetry", {
   ...(state.agentId ? { agentId: state.agentId } : {}),
+  // Stable per-session key so the server dedups first/raced posts (#398).
+  session: sessionKey,
   ...hello,
 });
 if (resp?.agentId) state.agentId = resp.agentId;

--- a/server/scripts/simulate.mjs
+++ b/server/scripts/simulate.mjs
@@ -69,7 +69,7 @@ function startAgent(i) {
   let timer;
 
   ws.addEventListener("open", () => {
-    ws.send(JSON.stringify({ type: "hello", handle, harness, model, task: pick(TASKS), location, version: "sim-0.1" }));
+    ws.send(JSON.stringify({ type: "hello", handle, harness, model, task: pick(TASKS), location, version: "sim-0.1", session: `sim-${i}` }));
     console.log(`[sim] ${handle} online (${harness} · ${model})`);
     timer = setInterval(() => {
       // A plausible working rhythm: bursts of tokens, occasional milestones.

--- a/server/src/agent-ws.ts
+++ b/server/src/agent-ws.ts
@@ -15,7 +15,7 @@ import { renewLeasesForHandle } from "./orchestrator/dispatch.js";
 import type { Orchestrator } from "./orchestrator/stores.js";
 import { agentMessageSchema } from "./protocol.js";
 import { redactLines } from "./redact.js";
-import type { FleetStore } from "./state.js";
+import { sessionAgentId, type FleetStore } from "./state.js";
 
 const HELLO_TIMEOUT_MS = 10_000;
 const PING_INTERVAL_MS = 25_000;
@@ -110,7 +110,11 @@ export function registerAgentSocket(app: FastifyInstance, store: FleetStore, orc
         case "hello": {
           // City-level only; req.ip is read once here and never stored (#398).
           const location = config.watcherGeo ? roughLocate(req.ip) : null;
-          const id = store.upsertAgent(msg, "ws", agentId ?? undefined, location);
+          // Reuse this socket's id if it re-hello'd; otherwise, a stable session
+          // id makes a dropped-and-reconnected socket land on the same record
+          // instead of a fresh one lingering to TTL beside the live one (#398).
+          const stableId = agentId ?? (msg.session ? sessionAgentId(msg.handle, msg.session) : undefined);
+          const id = store.upsertAgent(msg, "ws", stableId, location);
           if (!id) {
             socket.send(JSON.stringify({ type: "error", error: "fleet full" }));
             socket.close(1013, "fleet full");

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -11,7 +11,7 @@ import { renewLeasesForHandle } from "./orchestrator/dispatch.js";
 import type { Orchestrator } from "./orchestrator/stores.js";
 import { logPostSchema, telemetryPostSchema, type FleetCommand } from "./protocol.js";
 import { redactLines } from "./redact.js";
-import type { FleetStore } from "./state.js";
+import { sessionAgentId, type FleetStore } from "./state.js";
 
 /**
  * Orchestration side-channel on the telemetry heartbeat: when the POST
@@ -86,11 +86,16 @@ export function registerHttpRoutes(app: FastifyInstance, store: FleetStore, orch
     if (!parsed.success) {
       return reply.code(400).send({ ok: false, error: parsed.error.issues[0]?.message ?? "invalid body" });
     }
-    const { agentId, heartbeat, ...hello } = parsed.data;
+    const { agentId, heartbeat, session, ...hello } = parsed.data;
     // Unknown/expired agentId (e.g. server restarted): fall through to a fresh
     // session rather than erroring the worker.
     const knownId = agentId && store.getAgent(agentId) ? agentId : undefined;
-    const id = store.upsertAgent({ type: "hello", ...hello }, "http", knownId);
+    // Prefer the echoed id; else, when the worker sent a stable session id,
+    // derive a deterministic id so a not-yet-saved / raced first post lands on
+    // one record instead of spawning a duplicate (#398). Only fully identity-less
+    // posts still mint a random id.
+    const stableId = knownId ?? (session ? sessionAgentId(hello.handle, session) : undefined);
+    const id = store.upsertAgent({ type: "hello", ...hello }, "http", stableId);
     if (!id) return reply.code(503).send({ ok: false, error: "fleet full" });
     if (heartbeat) store.applyHeartbeat(id, heartbeat);
     // Token-authed posts additionally renew leases and drain pending

--- a/server/src/protocol.ts
+++ b/server/src/protocol.ts
@@ -53,6 +53,12 @@ export const helloSchema = z.object({
   model: z.string().min(1).max(128),
   task: taskInfoSchema.optional(),
   version: z.string().max(64).optional(),
+  /** Stable client-side session id (e.g. the harness session_id). When present
+   *  the server derives a DETERMINISTIC agent id from (handle, session) instead
+   *  of minting a random one, so concurrent first-contact posts from one logical
+   *  session converge on a single record rather than each spawning a duplicate
+   *  (the session-start race that filled /live with repeat rows — #398). */
+  session: z.string().min(1).max(128).optional(),
   /** Optional fallback location (used only if IP geo fails). See schema note. */
   location: roughLocationSchema.optional(),
 });
@@ -122,6 +128,10 @@ export const telemetryPostSchema = z.object({
   harness: z.string().min(1).max(32),
   model: z.string().min(1).max(128),
   version: z.string().max(64).optional(),
+  /** Stable client session id — see helloSchema.session. Lets a one-shot hook
+   *  worker whose saved agentId hasn't landed yet (or raced with a sibling
+   *  hook) resolve to the same record instead of minting a duplicate. */
+  session: z.string().min(1).max(128).optional(),
   task: taskInfoSchema.optional(),
   heartbeat: heartbeatSchema.omit({ type: true }).optional(),
 });

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -12,7 +12,7 @@
  * implementation behind the same interface; nothing else needs to change.
  */
 import { EventEmitter } from "node:events";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { readFileSync, renameSync, writeFileSync } from "node:fs";
 import { config } from "./config.js";
 import type { HistoryStore } from "./history.js";
@@ -67,6 +67,21 @@ interface PersistedState {
   events: EventItem[];
   lastTps?: number;
   lastTpsAt?: string | null;
+}
+
+/** Deterministic v5-style UUID from a stable seed (handle + the client's own
+ *  session id). Concurrent first-contact posts from ONE logical session all
+ *  hash to the SAME id, so they upsert one record instead of each minting a
+ *  fresh random UUID — the session-start race that duplicated the same worker
+ *  on the same task all over /live (#398). Valid UUID shape, so it satisfies
+ *  the same schema as a minted id (logs/response echo). */
+export function sessionAgentId(handle: string, session: string): string {
+  const h = createHash("sha1").update(`fleet-agent\n${handle}\n${session}`).digest();
+  const b = h.subarray(0, 16);
+  b[6] = ((b[6] ?? 0) & 0x0f) | 0x50; // version 5
+  b[8] = ((b[8] ?? 0) & 0x3f) | 0x80; // RFC 4122 variant
+  const hex = b.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 }
 
 function sampleTps(tokens: number, elapsedMs: number): number {

--- a/server/test/dedup.test.mjs
+++ b/server/test/dedup.test.mjs
@@ -1,0 +1,72 @@
+/**
+ * Session-dedup tests (#398): a worker that sends a stable `session` id must
+ * land on ONE agent record even when its first posts race (the session-start
+ * duplicate that filled /live with the same worker on the same task). No
+ * docker/orchestration needed — this is pure telemetry over Fastify inject.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+delete process.env.GITHUB_TOKEN;
+delete process.env.STATE_FILE;
+delete process.env.HISTORY_DB_FILE;
+delete process.env.REDIS_URL;
+delete process.env.MONGO_URL;
+
+const Fastify = (await import("fastify")).default;
+const { FleetStore, sessionAgentId } = await import("../dist/state.js");
+const { registerHttpRoutes } = await import("../dist/http.js");
+
+function bootApp() {
+  const store = new FleetStore();
+  const app = Fastify();
+  registerHttpRoutes(app, store);
+  return { app, store };
+}
+
+const HELLO = { handle: "race-worker", harness: "claude", model: "claude-opus-4-8", task: { kind: "work", ref: "#123", title: "Do a thing" } };
+
+test("sessionAgentId is deterministic per (handle, session) and a valid UUID", () => {
+  const a = sessionAgentId("alice", "sess-1");
+  const b = sessionAgentId("alice", "sess-1");
+  const c = sessionAgentId("alice", "sess-2");
+  const d = sessionAgentId("bob", "sess-1");
+  assert.equal(a, b, "same inputs → same id");
+  assert.notEqual(a, c, "different session → different id");
+  assert.notEqual(a, d, "different handle → different id");
+  assert.match(a, /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/, "RFC-4122 v5 shape");
+});
+
+test("concurrent session-less first posts race → duplicate records (the bug)", async () => {
+  const { app } = bootApp();
+  const posts = Array.from({ length: 5 }, () =>
+    app.inject({ method: "POST", url: "/api/v1/telemetry", payload: HELLO }),
+  );
+  const ids = (await Promise.all(posts)).map((r) => r.json().agentId);
+  assert.equal(new Set(ids).size, 5, "without a session, each raced post mints its own id");
+  await app.close();
+});
+
+test("concurrent posts sharing a session collapse to ONE record (the fix)", async () => {
+  const { app, store } = bootApp();
+  const body = { ...HELLO, session: "claude-abc123" };
+  const posts = Array.from({ length: 5 }, () =>
+    app.inject({ method: "POST", url: "/api/v1/telemetry", payload: body }),
+  );
+  const ids = (await Promise.all(posts)).map((r) => r.json().agentId);
+  assert.equal(new Set(ids).size, 1, "all raced posts resolve to the same agentId");
+  assert.equal(ids[0], sessionAgentId(HELLO.handle, "claude-abc123"), "id is the deterministic session id");
+  assert.equal(store.listAgents().length, 1, "exactly one record on /live for this worker");
+  await app.close();
+});
+
+test("a saved agentId still wins over the session derivation (stable across restarts of the derivation)", async () => {
+  const { app, store } = bootApp();
+  const first = await app.inject({ method: "POST", url: "/api/v1/telemetry", payload: { ...HELLO, session: "s1" } });
+  const id = first.json().agentId;
+  // Subsequent post echoes the id it saved — must reuse the same record.
+  const second = await app.inject({ method: "POST", url: "/api/v1/telemetry", payload: { ...HELLO, session: "s1", agentId: id } });
+  assert.equal(second.json().agentId, id);
+  assert.equal(store.listAgents().length, 1);
+  await app.close();
+});


### PR DESCRIPTION
## Problem

The `/live` page keys each row on the server-minted `agentId`, and the fleet telemetry protocol carried **no stable session identity** — the server minted a fresh random UUID on any post without a *known* `agentId`, relying solely on the client echoing back an id it had saved to a temp file (`fleet-common.mjs`).

That races at session start: `SessionStart` posts (no id yet, ~3s round-trip) while the first `PostToolUse` hooks fire before that id is saved — each also posts with no id, so the server mints **new** records with the **same handle and same task**. The orphans linger the full 90s TTL, so `/live` shows many copies of one worker on one task. Half-open WebSocket reconnects had the same failure shape.

## Fix

Give the protocol a stable client `session` id so identity no longer depends on a round-trip:

- `protocol.ts` — optional `session` on `helloSchema` and `telemetryPostSchema`.
- `state.ts` — `sessionAgentId(handle, session)` derives a deterministic v5-style UUID (valid UUID shape, satisfies the same schemas as a minted id).
- `http.ts` / `agent-ws.ts` — resolve the record id as `echoed-id ?? sessionAgentId(...) ?? random`. Concurrent first-contacts with the same session converge on one record; WS reconnects reuse theirs.
- Clients (`claude-code-hook`, `codex-hook`, `codex-notify`) send their existing `sessionKey`; the simulator sends one too.

**Fully backward compatible** — a post with no `session` behaves exactly as before (mints a random id).

## Tests

New docker-free `test/dedup.test.mjs`: reproduces the race (5 session-less posts → 5 records) and verifies the fix (5 posts sharing a session → 1 record), plus deterministic-id and echoed-id-wins cases. Clean build; WS/redact tests pass.

Part of #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)