### PR TITLE
feat(fetch): add Jina reader (r.jina.ai) rung to the fetch ladder (ADR-0006)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,11 +130,12 @@ rather than waiting.
      cached or alternate copy of a blocked page.
   3. **Browser rungs — one command:**
      ```
-     node scripts/fetch.mjs "<url>"            # plain HTTP → rotating proxy → stealth Chromium (cloak-fetch)
+     node scripts/fetch.mjs "<url>"            # plain HTTP → rotating proxy → r.jina.ai → stealth Chromium (cloak-fetch)
      node scripts/fetch.mjs --archive "<url>"  # also capture a Wayback snapshot on success
      ```
-     It retries `curl` first, then (if `FETCH_PROXY` is set) a rotating-proxy retry, then a
-     stealth browser — until one returns the real page. It prints **how** it fetched, and
+     It retries `curl` first, then (if `FETCH_PROXY` is set) a rotating-proxy retry, then the
+     Jina reader, then a stealth browser — until one returns the real page. It prints **how**
+     it fetched, and
      classifies any failure the way the review gate
      must: exit `4` = genuinely DEAD (404 even in a real browser), exit `3` = BLOCKED
      (403 / bot-challenge / timeout — tooling or IP, **not** a citation defect). One-time
@@ -150,6 +151,15 @@ rather than waiting.
      proxy URL in a finding, comment, commit, or PR. `PROXY_ALL=1 ./autopilot.sh` also
      routes **all** `curl` + Python `urllib` (every `.skills` CLI) through it — handy but
      metered, so off by default.
+
+     **Jina reader (r.jina.ai).** As a lighter rung before the stealth browser, `fetch.mjs`
+     tries the hosted [Jina reader](https://r.jina.ai) — it fetches the URL from **its own
+     reputable egress**, renders JS, and returns clean text, clearing many of the same
+     IP-reputation / JS-challenge walls without a local browser. You can also hit it directly:
+     `WebFetch` (or `curl`) `https://r.jina.ai/<url>`. It's an **external service** — send it
+     **public URLs only**, never a URL carrying a token/session. Set `JINA_API_KEY` for higher
+     rate limits (Bearer header, never printed); `NO_JINA=1` skips the rung. A Jina failure is
+     **tooling**, never proof a citation is dead — only a real browser rung concludes DEAD.
   4. Still blocked? Capture / reuse a web-archive snapshot with `node scripts/archive-cite.mjs "<url>"` and cite that, or verify in a normal browser — rather than flagging it dead. A 403/bot-challenge is tooling, not a dead link; always say *how* you fetched.
 
   To drive the stealth browser directly instead of via `fetch.mjs`:

--- a/docs/adr/0006-fetch-proxy-browser-management.md
+++ b/docs/adr/0006-fetch-proxy-browser-management.md
@@ -125,9 +125,19 @@ changes are adopted, not an agent self-adoption.*
   `start_work.sh` / `review_work.sh` and [`AGENTS.md`](../../AGENTS.md) now point
   at this command and require stating how a source was fetched.
 - **Ladder order** — curl → the harness's built-in WebFetch/WebSearch tool →
-  `scripts/fetch.mjs` (stealth Chromium) → archive snapshot. The
-  WebFetch rung is called by the agent, not by `fetch.mjs` (a subprocess can't
-  invoke a harness tool), so it lives in the prompt guidance.
+  `scripts/fetch.mjs` (rotating proxy → Jina reader → stealth Chromium) → archive
+  snapshot. The WebFetch rung is called by the agent, not by `fetch.mjs` (a
+  subprocess can't invoke a harness tool), so it lives in the prompt guidance.
+- **Jina reader rung (added 2026-07-08)** — `fetch.mjs` tries the hosted
+  [Jina reader](https://r.jina.ai) (`https://r.jina.ai/<url>`) between the rotating
+  proxy and stealth Chromium: it fetches from its own reputable egress and renders
+  JS, clearing many IP-reputation / JS-challenge walls without a local browser, and
+  works even where CloakBrowser isn't installed. Agents can also call it directly
+  (WebFetch/curl on the `r.jina.ai/` URL). It is an **external service**, so only
+  public URLs go to it (never a credential-bearing URL); `JINA_API_KEY` raises the
+  rate limit and `NO_JINA=1` disables it. Because it's a proxy, a Jina failure is
+  classified **BLOCKED (tooling)**, never DEAD — only a real browser rung concludes a
+  link is dead (§2 preserved).
 - **Archive on cite (§3)** — [`scripts/archive-cite.mjs`](../../scripts/archive-cite.mjs)
   finds a recent Wayback snapshot (CDX API) or captures a fresh one and prints
   the snapshot URL; `fetch.mjs --archive` snapshots on success.

--- a/scripts/fetch.mjs
+++ b/scripts/fetch.mjs
@@ -9,7 +9,11 @@
 //   1. plain HTTP        (fast; a browser-shaped User-Agent)
 //   2. rotating proxy    (retry through FETCH_PROXY — a fresh IP per try clears
 //                         IP-reputation blocks; only runs if FETCH_PROXY is set)
-//   3. cloak-fetch.mjs   (stealth Chromium, JS + cookies + WAFs, also through
+//   3. jina reader       (r.jina.ai — a hosted reader that fetches from its own
+//                         egress, renders JS, and returns clean text; a light,
+//                         no-local-browser way past many IP/JS walls. External
+//                         service, public URLs only; NO_JINA=1 disables it)
+//   4. cloak-fetch.mjs   (stealth Chromium, JS + cookies + WAFs, also through
 //                         FETCH_PROXY — the gates the others can't clear)
 //
 // If your agent harness has a built-in WebFetch/WebSearch tool, try THAT between
@@ -128,7 +132,40 @@ function proxiedRung() {
   return { ok: false, status: lastStatus || undefined, blocked: true, note: `${tries} rotated IPs, still blocked/challenged` };
 }
 
-// ---- Rung 3: cloak-fetch.mjs (stealth Chromium — through the proxy too) -----
+// ---- Rung 3: Jina Reader (r.jina.ai) ---------------------------------------
+// A hosted reader proxy: it fetches the URL from its OWN reputable egress,
+// renders JS, and hands back clean text/markdown. A fresh third-party IP + real
+// rendering clears many of the IP-reputation and JS-challenge walls
+// (Incapsula/Cloudflare) that block us — without spinning up a local browser, so
+// it's a lighter rung to try before stealth Chromium.
+//
+// It's an EXTERNAL service: only ever send it PUBLIC URLs — never a URL carrying
+// a token/credential/session (that would leak it to a third party). Set
+// JINA_API_KEY for higher rate limits (sent as a Bearer header, never printed);
+// NO_JINA=1 skips this rung entirely.
+async function jinaRung() {
+  if (process.env.NO_JINA) return { ok: false, unavailable: true, note: "disabled (NO_JINA)" };
+  const headers = { "User-Agent": UA, Accept: "text/plain, text/markdown, */*" };
+  if (process.env.JINA_API_KEY) headers.Authorization = `Bearer ${process.env.JINA_API_KEY}`;
+  try {
+    const res = await fetch("https://r.jina.ai/" + url, {
+      redirect: "follow",
+      headers,
+      signal: AbortSignal.timeout(45000),
+    });
+    const body = await res.text();
+    if (res.ok && looksReal(body) && !looksNotFound(body))
+      return { ok: true, status: res.status, text: body };
+    // Jina is a PROXY, not the origin: a non-200 (or a rendered not-found) here is
+    // a reader/tooling failure, NEVER proof the citation is dead. Only a real
+    // browser rung is allowed to conclude DEAD (ADR-0006), so never set `dead`.
+    return { ok: false, status: res.status, blocked: true };
+  } catch (e) {
+    return { ok: false, status: 0, blocked: true, note: e?.name || String(e) };
+  }
+}
+
+// ---- Rung 4: cloak-fetch.mjs (stealth Chromium — through the proxy too) -----
 function cloakRung() {
   const r = spawnSync("node", [path.join(here, "cloak-fetch.mjs"), url], {
     encoding: "utf8",
@@ -162,6 +199,7 @@ function snapshot() {
 const ladder = [
   ["plain HTTP", httpRung, false],
   ["rotating proxy (retry)", proxiedRung, false],
+  ["jina reader (r.jina.ai)", jinaRung, false],
   ["cloak-fetch (stealth Chromium)", cloakRung, true],
 ];
 

--- a/scripts/frame_work.sh
+++ b/scripts/frame_work.sh
@@ -204,11 +204,15 @@ Fetching sources — escalate fast → heavy (ADR-0006; details in AGENTS.md):
 2. Your built-in WebFetch/WebSearch tool — more capable than curl, no browser; try it
    before reaching for a browser (WebSearch can also find a cached/alternate copy).
 3. Browser rungs, one command:
-     node scripts/fetch.mjs "<url>"            # real Chrome → stealth Chromium
+     node scripts/fetch.mjs "<url>"            # HTTP → proxy → r.jina.ai → stealth Chromium
      node scripts/fetch.mjs --archive "<url>"  # also snapshot to Wayback on success
    Prints HOW it fetched; exit 4 = genuinely DEAD (404 even in a browser), exit 3 =
    BLOCKED (403/bot-challenge/timeout — TOOLING or IP, NOT a dead link). It can't call
    your WebFetch tool (it's a subprocess), so run that yourself at step 2.
+   Still blocked, or no browser? Try the Jina reader directly — WebFetch (or curl)
+   \`https://r.jina.ai/<url>\`: it fetches from its own egress and renders JS, clearing
+   many IP/bot walls. Public URLs only (external service); a Jina failure is tooling,
+   never a dead link.
 4. For a fragile or date-stamped source, run  node scripts/archive-cite.mjs "<url>"  and
    cite the snapshot beside the live link.
 Never call a citation dead on a blocked (exit 3) response, and always say HOW you fetched.

--- a/scripts/review_work.sh
+++ b/scripts/review_work.sh
@@ -285,12 +285,15 @@ FETCH LADDER (ADR-0006) — before flagging ANY citation as dead or unverifiable
 you MUST have escalated fast → heavy:
 1. curl / quick HTTP.
 2. Your built-in WebFetch/WebSearch tool — more capable than curl, no browser.
-3. Browser rungs: node scripts/fetch.mjs "<url>"  (real Chrome → stealth Chromium).
-It prints HOW it fetched and exits 4 = genuinely DEAD (404 even in a real browser),
-exit 3 = BLOCKED (403 / bot-challenge / timeout — likely tooling or IP, NOT a citation
-defect). Only an exit-4 DEAD result justifies flagging a link dead; on exit 3, try
+3. Browser rungs: node scripts/fetch.mjs "<url>"  (HTTP → proxy → r.jina.ai → stealth
+Chromium). It prints HOW it fetched and exits 4 = genuinely DEAD (404 even in a real
+browser), exit 3 = BLOCKED (403 / bot-challenge / timeout — likely tooling or IP, NOT a
+citation defect). Only an exit-4 DEAD result justifies flagging a link dead; on exit 3, try
   node scripts/archive-cite.mjs "<url>"  for a Wayback snapshot before you conclude.
 fetch.mjs can't call your WebFetch tool (subprocess), so run that yourself at step 2.
+Still blocked, or no browser in your env? WebFetch \`https://r.jina.ai/<url>\` directly —
+the Jina reader fetches from its own egress and renders JS, clearing many IP/bot walls
+(public URLs only; a Jina failure is tooling, never the author's dead link).
 If a browser rung is unavailable in YOUR environment, that is YOUR tooling gap,
 never the author's defect — say "could not verify (reviewer tooling)" instead of
 failing the citation. Your review must state HOW you fetched.
@@ -358,12 +361,13 @@ Judge it on:
 
 FETCH LADDER (ADR-0006) — before flagging ANY link as dead you MUST have escalated
 fast → heavy: 1) curl; 2) your built-in WebFetch/WebSearch tool (more capable than
-curl, no browser); 3) the browser rungs via  node scripts/fetch.mjs "<url>"  (real
-Chrome → stealth Chromium). fetch.mjs prints HOW it fetched: exit 4 = genuinely DEAD
-(404 even in a browser), exit 3 = BLOCKED (403/bot-challenge/timeout — tooling, NOT a
-defect). On exit 3, try node scripts/archive-cite.mjs "<url>" before concluding. A
-browser rung missing from YOUR environment is your tooling gap, never the author's
-defect. State HOW you fetched.
+curl, no browser); 3) the browser rungs via  node scripts/fetch.mjs "<url>"  (HTTP →
+proxy → r.jina.ai → stealth Chromium). fetch.mjs prints HOW it fetched: exit 4 = genuinely
+DEAD (404 even in a browser), exit 3 = BLOCKED (403/bot-challenge/timeout — tooling, NOT a
+defect). On exit 3, try node scripts/archive-cite.mjs "<url>" before concluding. No browser
+in your env? WebFetch \`https://r.jina.ai/<url>\` directly — it renders JS from its own
+egress and clears many IP/bot walls (public URLs only). A browser rung missing from YOUR
+environment is your tooling gap, never the author's defect. State HOW you fetched.
 
 SCOPE: judge ONLY what this PR changes — pre-existing repo state is not this
 author's defect (one out-of-scope note is fine; a failed verdict for it is not).

--- a/scripts/start_work.sh
+++ b/scripts/start_work.sh
@@ -187,11 +187,15 @@ Fetching sources — escalate fast → heavy (ADR-0006; details in AGENTS.md):
 2. Your built-in WebFetch/WebSearch tool — more capable than curl, no browser; try it
    before reaching for a browser (WebSearch can also find a cached/alternate copy).
 3. Browser rungs, one command:
-     node scripts/fetch.mjs "<url>"            # real Chrome → stealth Chromium
+     node scripts/fetch.mjs "<url>"            # HTTP → proxy → r.jina.ai → stealth Chromium
      node scripts/fetch.mjs --archive "<url>"  # also snapshot to Wayback on success
    Prints HOW it fetched; exit 4 = genuinely DEAD (404 even in a browser), exit 3 =
    BLOCKED (403/bot-challenge/timeout — TOOLING or IP, NOT a dead link). It can't call
    your WebFetch tool (it's a subprocess), so run that yourself at step 2.
+   Still blocked, or no browser? Try the Jina reader directly — WebFetch (or curl)
+   \`https://r.jina.ai/<url>\`: it fetches from its own egress and renders JS, clearing
+   many IP/bot walls. Public URLs only (external service); a Jina failure is tooling,
+   never a dead link.
 4. For a fragile or date-stamped source, run  node scripts/archive-cite.mjs "<url>"  and
    cite the snapshot beside the live link.
 Never call a citation dead on a blocked (exit 3) response, and always say HOW you fetched.


### PR DESCRIPTION
## What

Adds a **Jina reader (`r.jina.ai`)** rung to the ADR-0006 fetch ladder, slotted between the rotating proxy and stealth Chromium:

```
plain HTTP → rotating proxy → r.jina.ai → cloak-fetch (stealth Chromium)
```

`fetch.mjs` now tries `https://r.jina.ai/<url>` — a hosted reader that fetches the page from **its own reputable egress** and renders JS, clearing many of the same IP-reputation / bot-challenge walls (Incapsula/Cloudflare) **without a local browser**. It's a lighter rung than stealth Chromium and works even where CloakBrowser isn't installed — useful for the review gate in browser-less environments.

## Why

Some official/paywalled NZ sources still block our other rungs by IP or JS challenge. Jina's reader hops those cheaply. Motivating example (an nzherald.co.nz article) prompted this. Verified against `charities.govt.nz` — a site ADR-0006 explicitly calls out as 403-ing plain clients — `r.jina.ai` returns HTTP 200 with real content.

## Design (consistent with ADR-0006)

- **Classification preserved** — a Jina failure is **BLOCKED (tooling)**, never DEAD. Only a real browser rung concludes a link is dead (§2).
- **External-service safety** — public URLs only (it's a third party; never send a credential-bearing URL). `JINA_API_KEY` raises the rate limit (Bearer header, never printed); `NO_JINA=1` disables the rung.

## Changes

- `scripts/fetch.mjs` — new `jinaRung()` + ladder entry + header docs.
- `scripts/start_work.sh`, `scripts/frame_work.sh`, `scripts/review_work.sh` — fetch-ladder guidance mentions Jina, including hitting `WebFetch https://r.jina.ai/<url>` directly when an env has no browser.
- `AGENTS.md` — Jina note alongside the rotating-proxy note.
- `docs/adr/0006-fetch-proxy-browser-management.md` — records the new rung (2026-07-08).

## Verification

- `node --check scripts/fetch.mjs` and `bash -n` on all three prompt scripts: clean.
- Ran the full ladder end-to-end on the example URL (resolved via plain HTTP here, returning before Jina).
- `curl https://r.jina.ai/https://www.charities.govt.nz/` → HTTP 200, real content — confirms URL format + that the rung clears a documented WAF wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)