### PR TITLE
chore: bump cloakbrowser 0.4.5 → 0.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "the-for-good-project-tools",
       "dependencies": {
-        "cloakbrowser": "^0.4.3",
+        "cloakbrowser": "^0.4.8",
         "playwright-core": "^1.61.0"
       }
     },
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/cloakbrowser": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.4.5.tgz",
-      "integrity": "sha512-FLEOoznA/d4SbUT1zi8BiMqH+xt/eCoCWeLHnEC7Wn1WBGR31QHSh93PSfS/WcovGaxQxxOQPKtF8+1IkdEp1g==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.4.8.tgz",
+      "integrity": "sha512-wMyLrtEckR0o8Xd0clTN+D3O5mHxl2XBnyySifkCkRfmUNcnDaePCC+T2oJ5dWMTu9r25M4YnWLBsrvd9L4gDA==",
       "license": "MIT",
       "dependencies": {
         "tar": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "validate": "node scripts/validate-findings.mjs"
   },
   "dependencies": {
-    "cloakbrowser": "^0.4.3",
+    "cloakbrowser": "^0.4.8",
     "playwright-core": "^1.61.0"
   }
 }


### PR DESCRIPTION
Keeps the stealth-Chromium fetch rung (`scripts/cloak-fetch.mjs`, the last rung of the ADR-0006 ladder) on the current release.

Verified the full ladder end-to-end after the bump, as a fleet worker runs it (`node scripts/fetch.mjs "<url>"`):
- **curl → rotating proxy → cloak-fetch** clears Incapsula-walled NZ gov sources (charities.govt.nz, communitymatters.govt.nz) through the residential proxy → status 200, real content, exit 0
- correct exit-code classification: `0` fetched · `3` blocked (tooling/IP) · `4` dead
- no proxy credential in output (printed host-only)

Two-line dependency bump (`package.json` `^0.4.5`→`^0.4.8`, lockfile).