### PR TITLE
research: clarify NZ peptide classifications in force (Closes #819)

### DIFF
--- a/research/findings/other/nz-peptide-classifications-in-force.md
+++ b/research/findings/other/nz-peptide-classifications-in-force.md
@@ -1,0 +1,110 @@
+---
+title: "New Zealand's December 2025 Gazette notice made Medsafe's proposed peptide group classifications prescription medicines"
+domain: "other"
+issue: "#819"
+confidence: "High"
+author: "codex"
+agent: "codex"
+model: "gpt-5-codex"
+date: "2026-07-08"
+status: "draft"
+---
+
+# New Zealand's December 2025 Gazette notice made Medsafe's proposed peptide group classifications prescription medicines
+
+## Executive answer
+
+- **The June 2025 proposal is no longer just deferred: the key peptide entries are legally in force as prescription medicines.** The 74th Medicines Classification Committee (MCC) deferred Medsafe's peptide-groups proposal in July 2025 pending more information, but the New Zealand Gazette notice published on 19 December 2025 declares the relevant peptide groups and named peptides to be prescription medicines under section 106(1) of the Medicines Act 1981. [Medsafe 74th MCC minutes](https://www.medsafe.govt.nz/profs/class/Minutes/2021-2025/74mccMin23July2025.htm); [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397)
+- **Medsafe's live Classification Database independently confirms the change.** The database says it was updated on 13 March 2026 and can be used to check active-ingredient classifications; searches now return prescription entries for the peptide groups and named peptides listed below. [Medsafe Classification Database](https://www.medsafe.govt.nz/profs/class/classintro.asp)
+- **The enforceable Schedule 1 prescription entries now include all ten group entries proposed in June 2025 and the six individually named peptides, with one name normalised.** The Gazette lists: thymic peptide hormones and analogues; body protective compound 157 and analogues; adrenocorticotropic hormone analogues; pineal gland peptides and analogues; anti-microbial peptides and precursors; myostatin modulator peptides; mitochondria-derived peptides and analogues; erythropoietin and analogues; tuftsin and analogues; kisspeptins; plus AICAR, B7-33, larazotide, PNC-27, PTD-DBM and elamipretide, which corresponds to the proposed SS-31 entry. [Medsafe June 2025 peptide submission](https://medsafe.govt.nz/profs/class/Agendas/Agen74/5.7Peptides.pdf); [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397)
+- **Some other peptide-related entries are also prescription medicines, but they should not be conflated with the June 2025 proposal.** Medsafe's database separately lists growth hormone releasing peptides, growth hormone releasing peptide-6, thymosin beta-4, AOD-9604, glucagon-like peptide-1 receptor agonists, tirzepatide and retatrutide as prescription entries. [Medsafe Classification Database](https://www.medsafe.govt.nz/profs/class/classintro.asp); [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397)
+- **Implication for the stream:** the synthesis should treat unauthorised import/possession of these listed entries as a prescription-medicine compliance issue, not as the earlier "unscheduled peptide" seizure gap. The general seizure gap may still matter for peptide-like substances outside these group entries, but it is no longer accurate for the listed groups and named peptides. [Medicines Act 1981, s43](https://www.legislation.govt.nz/act/public/1981/0118/latest/DLM55462.html); [Medsafe June 2025 peptide submission](https://medsafe.govt.nz/profs/class/Agendas/Agen74/5.7Peptides.pdf)
+
+**Overall confidence:** High - the conclusion rests on two current primary sources: the 19 December 2025 New Zealand Gazette notice and Medsafe's Classification Database updated on 13 March 2026. The main limit is that Medsafe's own "Recent Gazette Notices" page is stale and still stops at August 2025, so it should not be used as the controlling source for post-August 2025 status. [Medsafe Recent Gazette Notices](https://www.medsafe.govt.nz/profs/class/recent.asp); [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397)
+
+## Evidence
+
+### What changed between the July 2025 deferral and December 2025 action
+
+Medsafe's June 2025 submission asked the MCC to introduce ten group entries for "unscheduled peptides" intercepted at the border and to classify them as prescription medicines; it also proposed six individual prescription entries: larazotide, PTD-DBM, AICAR, B7-33, PNC-27 and SS-31. [Medsafe June 2025 peptide submission](https://medsafe.govt.nz/profs/class/Agendas/Agen74/5.7Peptides.pdf)
+
+At the 74th MCC meeting, the Committee agreed classification would reduce risk, but deferred the decision because it wanted more information about possible legitimate external uses, including cosmetics-industry uses; the minutes' Secretariat's Note says Medsafe later consulted cosmetics professional bodies, no issues were raised, and Medsafe therefore recommended classifying the peptides as prescription medicines. [Medsafe 74th MCC minutes](https://www.medsafe.govt.nz/profs/class/Minutes/2021-2025/74mccMin23July2025.htm)
+
+The next public MCC minutes, for the 75th meeting on 19 November 2025, did not list a fresh peptide agenda item; they recorded only objections to two 74th-meeting recommendations, lithium and vitamin D, under "matters arising". [Medsafe 75th MCC minutes](https://www.medsafe.govt.nz/profs/class/Minutes/2021-2025/75mccMin19Nov2025.htm)
+
+That absence does not mean the legal change never happened, because the operative act is the Gazette notice. On 19 December 2025, the New Zealand Gazette published notice 2025-go7397; it says that, pursuant to section 106(1) of the Medicines Act 1981, Chris James of Medsafe declares the medicines in Schedule 1 to be prescription medicines. [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397)
+
+Medsafe's Classification Database corroborates the Gazette notice. The database says it was updated on 13 March 2026, explains that there are group entries that may capture active ingredients not specified individually, and says users can check classification either through the database or by referring to the latest Medicines Regulations amendments and subsequent New Zealand Gazette notices. [Medsafe Classification Database](https://www.medsafe.govt.nz/profs/class/classintro.asp)
+
+### The peptide classifications now in force
+
+| Entry now listed as prescription | Proposed in June 2025 as | Current-source check | Confidence |
+|---|---|---|---|
+| Thymic peptide hormones and their analogues | Group entry | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Body protective compound 157 and its analogues | Group entry for BPC-157 and analogues | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Adrenocorticotropic hormone analogues | Group entry | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Pineal gland peptides and their analogues | Group entry | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Anti-microbial peptides and their precursors | Group entry | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Myostatin modulator peptides | Group entry | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Mitochondria-derived peptides and their analogues | Group entry | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Erythropoietin and its analogues | Group entry | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Tuftsin and its analogues | Group entry | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Kisspeptins | Group entry | Listed in Gazette Schedule 1 and Medsafe database | High |
+| AICAR | Individual peptide | Listed in Gazette Schedule 1 and Medsafe database | High |
+| B7-33 | Individual peptide | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Larazotide | Individual peptide | Listed in Gazette Schedule 1 and Medsafe database | High |
+| PNC-27 | Individual peptide | Listed in Gazette Schedule 1 and Medsafe database | High |
+| PTD-DBM | Individual peptide | Listed in Gazette Schedule 1 and Medsafe database | High |
+| Elamipretide | Individual peptide; the June proposal used the synonym SS-31 | Listed in Gazette Schedule 1 and Medsafe database as elamipretide | High |
+
+The 19 December 2025 notice also lists "retatrutide" as a prescription medicine, and Medsafe's database returns "Retatrutide | Prescription"; this is important for the stream's grey-market weight-loss discussion, but retatrutide was not one of the ten peptide group entries or six individually named peptides in the June 2025 proposal. [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397); [Medsafe Classification Database](https://www.medsafe.govt.nz/profs/class/classintro.asp)
+
+Medsafe's database also returns prescription entries for growth hormone releasing peptides, growth hormone releasing peptide-6, thymosin beta-4 and AOD-9604; those entries resolve part of the earlier uncertainty about growth-hormone secretagogues and thymosin beta-4 status, but they are not evidence that every named peptide sold online is captured unless it falls within an entry's wording or another Schedule 1 entry. [Medsafe Classification Database](https://www.medsafe.govt.nz/profs/class/classintro.asp)
+
+### Legal effect for import, possession and seizure framing
+
+The June 2025 Medsafe submission said that, while many intercepted peptides were unscheduled, Medsafe did not have Medicines Act grounds to seize them and instead released them to importers with a high-risk medicine letter; it also said classifying the substances as prescription medicines would mean importation without a prescription would not be permitted. [Medsafe June 2025 peptide submission](https://medsafe.govt.nz/profs/class/Agendas/Agen74/5.7Peptides.pdf)
+
+Section 43 of the Medicines Act 1981 makes it an offence, without reasonable excuse, to import, procure, receive, store, use or otherwise possess any prescription medicine, so the 19 December 2025 prescription classifications materially change the enforcement footing for the listed peptide entries. [Medicines Act 1981, s43](https://www.legislation.govt.nz/act/public/1981/0118/latest/DLM55462.html)
+
+Section 106 of the Medicines Act is the Gazette-notice mechanism used here: the 19 December 2025 Gazette notice expressly invokes section 106(1), and says that where the notice is inconsistent with regulations made under section 105(1)(j), those regulatory provisions cease to have effect while the notice remains in force. [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397)
+
+### Why earlier findings conflicted
+
+The earlier stream finding `research/findings/other/nz-peptide-classification-status.md` correctly read the 74th and 75th MCC records available in the repository at the time, but it relied partly on Medsafe's "Recent Gazette Notices" page, which is marked "Revised: 4 September 2025" and still stops at 29 August 2025; that page does not show the later 19 December 2025 Gazette notice. [Medsafe Recent Gazette Notices](https://www.medsafe.govt.nz/profs/class/recent.asp); [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397)
+
+For current legal status, the Gazette notice and Medsafe's updated Classification Database should override the stale Medsafe recent-notices index. The practical reconciliation is: **deferred in July 2025; listed by Gazette on 19 December 2025; reflected in the Medsafe database by 13 March 2026.** [Medsafe 74th MCC minutes](https://www.medsafe.govt.nz/profs/class/Minutes/2021-2025/74mccMin23July2025.htm); [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397); [Medsafe Classification Database](https://www.medsafe.govt.nz/profs/class/classintro.asp)
+
+## Surprising or load-bearing claims
+
+| Claim | Source 1 | Source 2 | Confidence |
+|---|---|---|---|
+| The June 2025 peptide group proposal was not still merely deferred after December 2025; the proposed peptide group entries and individual peptides were declared prescription medicines on 19 December 2025. | [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397) | [Medsafe Classification Database](https://www.medsafe.govt.nz/profs/class/classintro.asp) | High |
+| The 74th MCC deferred the peptide item in July 2025, but the later Secretariat's Note records that Medsafe consulted cosmetics bodies and still recommended prescription classification. | [Medsafe 74th MCC minutes](https://www.medsafe.govt.nz/profs/class/Minutes/2021-2025/74mccMin23July2025.htm) | [Medsafe June 2025 peptide submission](https://medsafe.govt.nz/profs/class/Agendas/Agen74/5.7Peptides.pdf) for the proposal being considered | High |
+| Medsafe's "Recent Gazette Notices" page is stale for this question and omits the December 2025 notice. | [Medsafe Recent Gazette Notices](https://www.medsafe.govt.nz/profs/class/recent.asp) | [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397) | High |
+| The enforcement footing changes because prescription-medicine status triggers Medicines Act s43 import/possession restrictions. | [Medicines Act 1981, s43](https://www.legislation.govt.nz/act/public/1981/0118/latest/DLM55462.html) | [Medsafe June 2025 peptide submission](https://medsafe.govt.nz/profs/class/Agendas/Agen74/5.7Peptides.pdf) | High |
+| Elamipretide is the enacted entry corresponding to the proposal's SS-31 entry. | [Medsafe June 2025 peptide submission](https://medsafe.govt.nz/profs/class/Agendas/Agen74/5.7Peptides.pdf) names "SS-31 (Elamipretide)" in the proposed individual entries | [New Zealand Gazette, 2025-go7397](https://gazette.govt.nz/notice/id/2025-go7397) lists "Elamipretide" | High |
+
+## What would change this conclusion
+
+- A later Gazette notice revoking, replacing or narrowing notice 2025-go7397 would change the current enforceable list; I found no such later notice during this research.
+- A Medsafe legal interpretation saying a particular marketed product falls outside a group-entry wording would change product-specific enforcement conclusions, even though the group entries themselves are in force.
+- A court decision on Medicines Act section 106 or section 43 as applied to peptide imports could change the enforcement-risk analysis; this finding is not legal advice.
+- I could not verify the exact internal process by which the July 2025 deferral moved to the December 2025 Gazette notice, because the public 75th MCC minutes do not record a fresh peptide decision item. The legal status itself is still clear from the Gazette notice and Medsafe database.
+- I did not test every peptide name sold in the grey market. This finding answers the classification status of the June 2025 proposed entries and closely related peptide entries visible in the current database, not every possible peptide analogue.
+
+## Open follow-up questions
+
+- Which currently marketed "research chemical" peptide products fall outside the enacted group entries, if any, and how does Medsafe interpret borderline analogues?
+- Does Medsafe now have seizure or prosecution statistics after the 19 December 2025 notice that show whether the new entries changed border outcomes?
+- Why does Medsafe's own recent-Gazette index remain stale after August 2025 while the Classification Database has been updated to March 2026?
+
+## Sources
+
+1. Medsafe, "Classification of Unscheduled Peptides", submission to the 74th Medicines Classification Committee, June 2025. Fetched by direct HTTP on 8 July 2026. https://medsafe.govt.nz/profs/class/Agendas/Agen74/5.7Peptides.pdf
+2. Medsafe, "Minutes of the 74th meeting of the Medicines Classification Committee", 23 July 2025. Fetched by direct HTTP on 8 July 2026. https://www.medsafe.govt.nz/profs/class/Minutes/2021-2025/74mccMin23July2025.htm
+3. Medsafe, "Minutes of the 75th meeting of the Medicines Classification Committee", 19 November 2025. Fetched by direct HTTP on 8 July 2026. https://www.medsafe.govt.nz/profs/class/Minutes/2021-2025/75mccMin19Nov2025.htm
+4. New Zealand Gazette, "Classification of Medicines", notice 2025-go7397, published 19 December 2025. Fetched through built-in web search/open and direct HTTP on 8 July 2026. https://gazette.govt.nz/notice/id/2025-go7397
+5. Medsafe, "Classification Database", database updated 13 March 2026. Fetched by direct HTTP/POST searches on 8 July 2026. https://www.medsafe.govt.nz/profs/class/classintro.asp
+6. Medsafe, "Recent New Zealand Gazette Notices Relating to Classification", revised 4 September 2025. Fetched by direct HTTP on 8 July 2026. https://www.medsafe.govt.nz/profs/class/recent.asp
+7. Medicines Act 1981, section 43, "Restrictions on possession of prescription medicines". Accessed 8 July 2026. https://www.legislation.govt.nz/act/public/1981/0118/latest/DLM55462.html


### PR DESCRIPTION
Closes #819. Stream: #709. Finds that the 19 Dec 2025 Gazette notice and 13 Mar 2026 Medsafe database update put the proposed peptide group classifications legally in force as prescription medicines.