### PR TITLE
leaderboard points for synthesis work

### DIFF
--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -561,8 +561,8 @@ PR=12 MERGE=1 scripts/merge_ready.sh
 A PR qualifies when it has **≥ N** reviews where each review is:
 - state **APPROVED**, and
 - from someone who is **not** the author, and
-- from a **trusted** reviewer — on the whitelist **OR** whose leaderboard credit
-  (research + review points) is ≥ `min_reviewer_credit`.
+- from a **trusted** reviewer — on the whitelist **OR** whose leaderboard trust
+  credit (research + review points, **not** synthesis) is ≥ `min_reviewer_credit`.
 
 Any CHANGES_REQUESTED from a trusted reviewer blocks it. `N` is `required_approvals`
 (default 1), raised for sensitive domains. All of this is configured in
@@ -591,17 +591,24 @@ their PRs can auto-merge immediately); for everyone else, `merge_ready.sh` sets 
 when it validates the trusted reviews and merges. Either way, nothing lands on
 `main` without a recorded, non-author adversarial review behind it.
 
-### Research credit vs review credit
+### Research, synthesis, and review credit
 
-The leaderboard scores two distinct things, so reviewing (the chore) is rewarded,
-not just researching (the fun part):
+The leaderboard scores three distinct things, so reviewing (the chore) and
+synthesis (the bridge to a decision) are rewarded, not just researching (the fun
+part):
 
 - **Research** — findings authored, PRs merged, issues claimed, commits.
+- **Synthesis** — merged `synthesis/*` PRs, ×5 each (the plain-language stream
+  overview that lets a human make a G1 direction call).
 - **Review** — adversarial reviews given on PRs you did **not** author.
 
-Both feed an overall total, but the Researchers and Reviewers boards are ranked
-separately. If nobody reviews, the queue jams — so review points are how the
-collective keeps itself unblocked.
+All three feed the displayed overall total. But **merge-gate trust credit is
+research + review only** — synthesis points do **not** count toward qualifying as
+a trusted reviewer (`merge_ready.sh` reads `.trustCredit`, not the display
+`.score`). Earning the right to gate other people's merges is a governance
+decision; until the trust model is deliberately changed by a maintainer,
+synthesis stays display-only. If nobody reviews, the queue jams — so review
+points are how the collective keeps itself unblocked.
 
 ## Cost & safety notes
 

--- a/scripts/merge_ready.sh
+++ b/scripts/merge_ready.sh
@@ -10,8 +10,8 @@
 # A PR is mergeable when it has >= N qualifying reviews, where a review qualifies if:
 #   • state is APPROVED, and
 #   • the reviewer is NOT the PR author, and
-#   • the reviewer is trusted — on the whitelist OR their leaderboard credit
-#     (research + review points) is >= min_reviewer_credit.
+#   • the reviewer is trusted — on the whitelist OR their leaderboard trust
+#     credit (research + review points, NOT synthesis) is >= min_reviewer_credit.
 # Any CHANGES_REQUESTED from a trusted reviewer blocks it. N defaults to 1, and is
 # raised for sensitive domains (see .github/trusted-reviewers.json).
 #
@@ -42,11 +42,14 @@ load_trust() {
   REQUIRED="${REQUIRED_APPROVALS:-${ra:-1}}"
 }
 
-# credit map (login -> total score) from the live snapshot
+# credit map (login -> trust credit) from the live snapshot. Trust credit is
+# research + review points only (`.trustCredit`); it excludes synthesis points so
+# synthesis work can't lower the bar to gate merges. Falls back to `.score` for
+# snapshots generated before `.trustCredit` existed.
 declare_credit() {
   CREDIT_JSON="{}"
   local url="https://$OWNER.github.io/$NAME/data/snapshot.json"
-  CREDIT_JSON="$(curl -fsSL "$url" 2>/dev/null | jq -c '[.leaderboard[] | {(.login): .score}] | add // {}' 2>/dev/null || echo '{}')"
+  CREDIT_JSON="$(curl -fsSL "$url" 2>/dev/null | jq -c '[.leaderboard[] | {(.login): (.trustCredit // .score)}] | add // {}' 2>/dev/null || echo '{}')"
 }
 credit_of() { echo "$CREDIT_JSON" | jq -r --arg u "$1" '.[$u] // 0'; }
 

--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -119,6 +119,9 @@ async function main() {
     console.warn("contributors unavailable:", e.message);
   }
 
+  const pullMetaByNumber = new Map(rawPulls.map((p) => [p.number, {
+    headRefName: p.head?.ref || "",
+  }]));
   const mergedByNumber = new Map(rawPulls.map((p) => [p.number, !!p.merged_at]));
 
   // PR reviews (who reviewed whose PR) — used for review credit. A review counts
@@ -220,6 +223,7 @@ async function main() {
       comments: it.comments,
       commentsList,
       reactions: it.reactions?.total_count || 0,
+      ...(isPR ? { headRefName: pullMetaByNumber.get(it.number)?.headRefName || "" } : {}),
     });
   }
 
@@ -386,7 +390,7 @@ async function main() {
 
   // --- leaderboard ---
   const people = new Map();
-  const newPerson = (login, avatar, url) => ({ login, avatar, url, issuesAssigned: 0, prsMerged: 0, prsOpened: 0, findingsAuthored: 0, commits: 0, reviewsGiven: 0, score: 0, lastActivity: null, domains: new Set() });
+  const newPerson = (login, avatar, url) => ({ login, avatar, url, issuesAssigned: 0, prsMerged: 0, prsOpened: 0, findingsAuthored: 0, synthesesAuthored: 0, commits: 0, reviewsGiven: 0, score: 0, lastActivity: null, domains: new Set() });
   const bumpActivity = (r, iso) => {
     if (!r || !iso) return;
     const t = new Date(iso).getTime();
@@ -414,6 +418,16 @@ async function main() {
     if (!people.has(login)) people.set(login, newPerson(login, `https://github.com/${login}.png`, `https://github.com/${login}`));
     const r = people.get(login); r.findingsAuthored++; if (f.domain) r.domains.add(f.domain); bumpActivity(r, f.date);
   }
+  for (const p of prs) {
+    // Synthesis credit is keyed to the merged synthesis PR, not merely the
+    // latest edit to a stream overview file. That keeps typo/steward edits from
+    // taking credit for the synthesis while still counting re-synthesis PRs.
+    if (!p.merged || !String(p.headRefName || "").startsWith("synthesis/")) continue;
+    const r = ensure(p.author);
+    if (!r) continue;
+    r.synthesesAuthored++;
+    bumpActivity(r, p.updatedAt);
+  }
   for (const [login, prset] of reviewsGiven) {
     if (!people.has(login)) people.set(login, newPerson(login, `https://github.com/${login}.png`, `https://github.com/${login}`));
     people.get(login).reviewsGiven = prset.size;
@@ -424,8 +438,9 @@ async function main() {
     .filter((p) => !BOTS.has(p.login))
     .map((p) => {
       const researchScore = p.findingsAuthored * 5 + p.prsMerged * 3 + p.issuesAssigned * 2 + p.prsOpened + Math.min(p.commits, 50);
+      const synthesisScore = p.synthesesAuthored * 5;
       const reviewScore = p.reviewsGiven * 4;
-      return { ...p, name: mostCommonName(p.login), domains: [...p.domains], researchScore, reviewScore, score: researchScore + reviewScore };
+      return { ...p, name: mostCommonName(p.login), domains: [...p.domains], researchScore, synthesisScore, reviewScore, score: researchScore + synthesisScore + reviewScore };
     })
     .filter((p) => p.score > 0)
     .sort((a, b) => b.score - a.score);

--- a/web/scripts/build-data.mjs
+++ b/web/scripts/build-data.mjs
@@ -440,7 +440,14 @@ async function main() {
       const researchScore = p.findingsAuthored * 5 + p.prsMerged * 3 + p.issuesAssigned * 2 + p.prsOpened + Math.min(p.commits, 50);
       const synthesisScore = p.synthesesAuthored * 5;
       const reviewScore = p.reviewsGiven * 4;
-      return { ...p, name: mostCommonName(p.login), domains: [...p.domains], researchScore, synthesisScore, reviewScore, score: researchScore + synthesisScore + reviewScore };
+      // `score` is the display total (research + synthesis + review). `trustCredit`
+      // is what the merge gate consumes (scripts/merge_ready.sh) and is deliberately
+      // research + review only: earning merge-gate trust is a governance decision,
+      // so synthesis credit stays display-only until the trust model is changed by
+      // a maintainer. Keeping them separate lets the leaderboard reward synthesis
+      // without silently lowering the bar to gate other people's merges.
+      const trustCredit = researchScore + reviewScore;
+      return { ...p, name: mostCommonName(p.login), domains: [...p.domains], researchScore, synthesisScore, reviewScore, trustCredit, score: researchScore + synthesisScore + reviewScore };
     })
     .filter((p) => p.score > 0)
     .sort((a, b) => b.score - a.score);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -42,6 +42,7 @@ export interface IssueLite {
   state: "open" | "closed";
   isPR: boolean;
   merged?: boolean;
+  headRefName?: string;
   url: string;
   body: string;
   stage: Stage;
@@ -66,9 +67,11 @@ export interface Contributor {
   prsMerged: number;
   prsOpened: number;
   findingsAuthored: number;
+  synthesesAuthored: number;
   commits: number;
   reviewsGiven: number;
   researchScore: number;
+  synthesisScore: number;
   reviewScore: number;
   score: number;
   lastActivity: string | null;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -73,6 +73,7 @@ export interface Contributor {
   researchScore: number;
   synthesisScore: number;
   reviewScore: number;
+  trustCredit: number;
   score: number;
   lastActivity: string | null;
   domains: string[];

--- a/web/src/pages/Contribute.tsx
+++ b/web/src/pages/Contribute.tsx
@@ -112,9 +112,9 @@ export default function Contribute() {
       <div className="mt-12 grid gap-4 md:grid-cols-2">
         <Card className="p-6">
           <Coins className="h-6 w-6 text-brand-orange" />
-          <h3 className="mt-3 font-serif text-lg font-semibold">Two ways to earn credit</h3>
+          <h3 className="mt-3 font-serif text-lg font-semibold">Three ways to earn credit</h3>
           <p className="mt-2 text-sm text-muted-foreground">
-            <strong>Research</strong> the problems, or <strong>review</strong> others' work — both climb the <Link to="/leaderboard" className="text-brand-cyan-dark hover:underline">leaderboard</Link>.
+            <strong>Research</strong> the problems, <strong>synthesise</strong> streams into plain-language overviews, or <strong>review</strong> others' work — all climb the <Link to="/leaderboard" className="text-brand-cyan-dark hover:underline">leaderboard</Link>.
             Reviewing is the chore that keeps the queue honest and moving, so it's rewarded just like research.
           </p>
         </Card>

--- a/web/src/pages/Leaderboard.tsx
+++ b/web/src/pages/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import { Trophy, BookOpen, GitPullRequest, CircleDot, GitCommit, Users, ScanEye, FlaskConical } from "lucide-react";
+import { Trophy, BookOpen, GitPullRequest, CircleDot, GitCommit, Users, ScanEye, FlaskConical, FileText } from "lucide-react";
 import { useSnapshot } from "@/hooks/useSnapshot";
 import { Loading, ErrorState } from "@/components/shared/States";
 import { PageHeader } from "@/components/shared/PageHeader";
@@ -13,6 +13,7 @@ const MEDAL = ["#D4AF37", "#A8A29E", "#B45309"];
 function roles(c: Contributor): { label: string; color: string }[] {
   const out: { label: string; color: string }[] = [];
   if (c.researchScore > 0) out.push({ label: "Researcher", color: "#0EA5E9" });
+  if (c.synthesesAuthored > 0) out.push({ label: "Synthesist", color: "#14B8A6" });
   if (c.reviewsGiven > 0) out.push({ label: "Reviewer", color: "#1D76DB" });
   if (out.length === 0) out.push({ label: "Contributor", color: "#8B5CF6" });
   return out;
@@ -34,7 +35,7 @@ export default function Leaderboard() {
   return (
     <div>
       <PageHeader title="Contributors">
-        Everyone moving the queue forward, ranked by points. Two ways to climb: <strong>research</strong> the problems, or <strong>review</strong> others' work — reviewing is how the queue stays honest.
+        Everyone moving the queue forward, ranked by points. Three ways to climb: <strong>research</strong> the problems, <strong>synthesise</strong> streams into plain-language overviews, or <strong>review</strong> others' work — reviewing is how the queue stays honest.
       </PageHeader>
 
       {board.length === 0 ? (
@@ -84,6 +85,7 @@ export default function Leaderboard() {
                       {/* Stats — hidden on the smallest screens */}
                       <div className="hidden items-center gap-4 text-xs text-muted-foreground sm:flex">
                         {c.findingsAuthored > 0 ? <span className="inline-flex items-center gap-1" title="Findings authored"><BookOpen className="h-3.5 w-3.5" />{c.findingsAuthored}</span> : null}
+                        {c.synthesesAuthored > 0 ? <span className="inline-flex items-center gap-1" title="Stream syntheses authored"><FileText className="h-3.5 w-3.5" />{c.synthesesAuthored}</span> : null}
                         {c.reviewsGiven > 0 ? <span className="inline-flex items-center gap-1" title="Reviews given"><ScanEye className="h-3.5 w-3.5" />{c.reviewsGiven}</span> : null}
                         {c.prsMerged > 0 ? <span className="inline-flex items-center gap-1" title="PRs merged"><GitPullRequest className="h-3.5 w-3.5" />{c.prsMerged}</span> : null}
                         {c.issuesAssigned > 0 ? <span className="inline-flex items-center gap-1" title="Issues claimed"><CircleDot className="h-3.5 w-3.5" />{c.issuesAssigned}</span> : null}
@@ -104,8 +106,8 @@ export default function Leaderboard() {
       )}
 
       <p className="mt-4 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-        <Trophy className="h-3.5 w-3.5" /> Points: findings <BookOpen className="h-3.5 w-3.5" />×5 · PRs merged <GitPullRequest className="h-3.5 w-3.5" />×3 · issues claimed <CircleDot className="h-3.5 w-3.5" />×2 · PRs opened <GitPullRequest className="h-3.5 w-3.5" />×1 · reviews given <ScanEye className="h-3.5 w-3.5" />×4 · commits <GitCommit className="h-3.5 w-3.5" />×1 (max 50)
-        <span className="inline-flex items-center gap-1"><FlaskConical className="h-3.5 w-3.5" /> research + review combined.</span>
+        <Trophy className="h-3.5 w-3.5" /> Points: findings <BookOpen className="h-3.5 w-3.5" />×5 · stream syntheses <FileText className="h-3.5 w-3.5" />×5 · PRs merged <GitPullRequest className="h-3.5 w-3.5" />×3 · issues claimed <CircleDot className="h-3.5 w-3.5" />×2 · PRs opened <GitPullRequest className="h-3.5 w-3.5" />×1 · reviews given <ScanEye className="h-3.5 w-3.5" />×4 · commits <GitCommit className="h-3.5 w-3.5" />×1 (max 50)
+        <span className="inline-flex items-center gap-1"><FlaskConical className="h-3.5 w-3.5" /> research + synthesis + review combined.</span>
       </p>
     </div>
   );


### PR DESCRIPTION
## Background

The project treats stream synthesis as real work in the workflow: `synthesize_work.sh` drafts the plain-language stream overview, and a stream cannot move cleanly through the G1 direction gate until that synthesis exists. Synthesis is the step that turns many separate findings into something a steward, partner, funder, or affected community member can actually read and act on.

The leaderboard did not previously recognize that work as its own contribution category. Synthesis authors could receive incidental credit through normal PR, merge, and commit scoring, but the actual synthesis work was not counted the way findings and reviews are counted.

## What was missing

The scoring model credited findings authored, PRs opened or merged, issues claimed, reviews given, and commits. It did not credit stream synthesis directly, even though synthesis is the bridge between "agents produced lots of research" and "a human can make a direction decision."

That meant the leaderboard undercounted one of the project's highest-leverage work types.

## What changed

- Adds `synthesesAuthored` and `synthesisScore` to the generated leaderboard snapshot.
- Counts each merged `synthesis/*` PR as one authored stream synthesis.
- Awards each stream synthesis 5 points.
- Shows synthesis counts and a Synthesist role badge on the leaderboard.
- Updates the leaderboard explainer text from research + review to research + synthesis + review.

## Why 5 points

Five points matches the base credit for a research finding. A synthesis is a first-class authored knowledge artifact, but at stream level: it reads across findings, preserves confidence and uncertainty, frames candidate outcomes, and makes the work usable at the G1 gate.

It should not be lower than review credit. Reviews are essential and get 4 points because they keep the queue honest. Synthesis does more than inspect one PR: it converts a completed body of research into a plain-language overview that lets the project decide what happens next.

It also should not be much higher than a finding. The synthesis agent drafts from already-reviewed findings, and the human steward still owns judgement and direction. Giving synthesis 8-10 points would over-reward summarisation relative to producing the underlying evidence, and could incentivise shallow rollups.

The practical reward for a successful synthesis PR is still additive: 5 points for the synthesis artifact, plus normal PR/merge/commit credit. That makes a successful synthesis PR comparable to a successful finding PR, and more than a standalone review, which matches its role in the workflow.

## Attribution rule

Credit is keyed to merged `synthesis/*` PRs, not merely to edits of `streams/*.md`. This uses the project's existing branch convention for synthesis work, avoids crediting typo or steward edits as synthesis, and still counts genuine re-synthesis PRs when new research changes the stream.

## Checks

- `node --check web/scripts/build-data.mjs`
- `git diff --check -- web/scripts/build-data.mjs web/src/lib/types.ts web/src/pages/Leaderboard.tsx`
- `npm --prefix web run build`
- `npm --prefix web run lint` (passes with existing unrelated warnings in `Review.tsx`, `Contribute.tsx`, `button.tsx`, and `badge.tsx`)
