### PR TITLE
fix(web): finding pages overflow on mobile (responsive tables/code/long strings)

### DIFF
--- a/web/src/components/shared/Markdown.tsx
+++ b/web/src/components/shared/Markdown.tsx
@@ -1,27 +1,40 @@
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { resolveDocHref } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 export function Markdown({ children, className, linkBase }: { children: string; className?: string; linkBase?: string }) {
-  return (
-    <div className={cn(
-      "text-sm leading-relaxed text-foreground/90 [&_a]:text-brand-cyan-dark [&_a]:underline [&_a]:underline-offset-2",
-      "[&_h1]:mt-4 [&_h1]:mb-2 [&_h1]:text-xl [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-lg [&_h3]:mt-3 [&_h3]:mb-1.5 [&_h3]:text-base",
-      "[&_p]:my-2 [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-0.5",
-      "[&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs",
-      "[&_table]:my-3 [&_table]:w-full [&_th]:border-b [&_th]:p-2 [&_th]:text-left [&_td]:border-b [&_td]:border-border/50 [&_td]:p-2",
-      "[&_blockquote]:border-l-2 [&_blockquote]:border-brand-cyan [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground",
-      className
-    )}>
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={linkBase ? {
+  const components: Components = {
+    // Wide markdown tables scroll within the page instead of pushing the layout wider than the viewport.
+    table: ({ children: tableChildren, ...props }) => (
+      <div className="my-3 max-w-full overflow-x-auto">
+        <table {...props}>{tableChildren}</table>
+      </div>
+    ),
+    // Code blocks scroll horizontally rather than forcing the column to grow.
+    pre: ({ children: preChildren, ...props }) => (
+      <pre {...props} className="max-w-full overflow-x-auto">{preChildren}</pre>
+    ),
+    ...(linkBase
+      ? {
           a: ({ href, children: linkChildren, ...props }) => (
             <a {...props} href={resolveDocHref(href, linkBase)} target="_blank" rel="noreferrer">{linkChildren}</a>
           ),
-        } : undefined}
-      >
+        }
+      : {}),
+  };
+
+  return (
+    <div className={cn(
+      "min-w-0 max-w-full text-sm leading-relaxed text-foreground/90 [&_a]:text-brand-cyan-dark [&_a]:underline [&_a]:underline-offset-2 [&_a]:break-words",
+      "[&_h1]:mt-4 [&_h1]:mb-2 [&_h1]:text-xl [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-lg [&_h3]:mt-3 [&_h3]:mb-1.5 [&_h3]:text-base",
+      "[&_p]:my-2 [&_p]:break-words [&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-5 [&_li]:my-0.5 [&_li]:break-words",
+      "[&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs [&_code]:break-words",
+      "[&_table]:w-full [&_th]:whitespace-nowrap [&_th]:border-b [&_th]:p-2 [&_th]:text-left [&_td]:border-b [&_td]:border-border/50 [&_td]:p-2",
+      "[&_blockquote]:border-l-2 [&_blockquote]:border-brand-cyan [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground",
+      className
+    )}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {children}
       </ReactMarkdown>
     </div>

--- a/web/src/pages/FindingDetail.tsx
+++ b/web/src/pages/FindingDetail.tsx
@@ -62,9 +62,9 @@ export default function FindingDetail() {
       <Separator className="my-6" />
 
       <div className="grid gap-6 md:grid-cols-3">
-        <div className="md:col-span-2">
-          <Card>
-            <CardContent className="pt-6">
+        <div className="min-w-0 md:col-span-2">
+          <Card className="overflow-hidden">
+            <CardContent className="min-w-0 pt-6">
               {finding.body ? <Markdown>{finding.body}</Markdown> : <p className="text-sm text-muted-foreground">No content in this finding.</p>}
             </CardContent>
           </Card>


### PR DESCRIPTION
## Problem

The finding-detail page overflowed the mobile viewport — rendered-markdown content ran off the right edge so text and cards were cut off. Reproduced on the deployed page `/findings/civic-transparency/rural-emergency-comms-exposure-ranking` and confirmed on other findings with wide ranking tables.

## Root cause

Finding bodies are rendered as markdown by the shared `web/src/components/shared/Markdown.tsx`. Some content can't shrink to fit a narrow screen:

- **Wide GFM tables** (rankings tables are common in findings) had `table { width: 100% }` but no scroll wrapper, so a table with many columns rendered ~1400px wide.
- **Long unbroken strings/URLs** and inline code had no `break-words`.
- **`<pre>`/code blocks** weren't horizontally scrollable.

Because the markdown container had no `min-w-0`, the unshrinkable table forced the whole content column wider than the viewport. An ancestor clipped the horizontal overflow (so there was no page scrollbar), which is exactly why content was *cut off* rather than scrollable.

## Fix (global — applies to every finding)

In `Markdown.tsx`:
- Wrap every markdown `<table>` in a `max-w-full overflow-x-auto` container, so wide tables scroll within the page instead of widening the layout.
- Make `<pre>`/code blocks `overflow-x-auto`.
- Add `break-words` to paragraphs, list items, inline code and links (long URLs/tokens now wrap).
- Give the markdown root `min-w-0 max-w-full`.

In `FindingDetail.tsx`:
- Add `min-w-0` to the finding content column and `CardContent`, and `overflow-hidden` on the `Card`, so a wide child can't force the grid column past the viewport.

Because the fix lives in the shared renderer, **every** finding-detail page is now mobile-safe, not just the reported one.

## Verification

Build: `cd web && npm run build` passes (only the pre-existing large-chunk warning).

Headless (system chromium `/usr/bin/chromium`, `puppeteer-core`, viewport width **390px**), on the wide-table finding `/findings/civic-transparency/council-spending-data-census`:

| | `documentElement.scrollWidth` | `window.innerWidth` | markdown table container | genuinely-clipped elements |
|---|---|---|---|---|
| **Before** | 390 (clipped, no scrollbar) | 390 | table 1416px, container right=**1465px** (off-screen) | **412** |
| **After** | **390** | **390** | table in `overflow-x-auto` wrapper, clientWidth 292px, right=341px (scrolls internally) | **0** |

`document.documentElement.scrollWidth (390) <= window.innerWidth (390) + 2` holds after the fix, and no element overflows the viewport outside of a proper scroll container. Verified clean on three wide-table findings (`council-spending-data-census`, `nz-grant-source-map`, `small-credit-disclosures`). Screenshots at 390px confirm content now fits with margins and wraps cleanly.

Note: the target finding `rural-emergency-comms-exposure-ranking` is not in the local `web/public/data/snapshot.json`, so verification used equivalent wide-table findings that are — the fix is global and covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)