### PR TITLE
fix(streams): findings link to on-site detail page, not GitHub PR

### DIFF
--- a/web/src/pages/StreamDetail.tsx
+++ b/web/src/pages/StreamDetail.tsx
@@ -241,7 +241,9 @@ export default function StreamDetail() {
                 <div className="space-y-3">
                   {findings.map((f) => (
                     <div key={f.path} className="border-b border-border/50 pb-3 last:border-0 last:pb-0">
-                      <a href={f.url} target="_blank" rel="noreferrer" className="text-sm font-medium hover:text-brand-cyan-dark">{f.title}</a>
+                      {f.slug
+                        ? <Link to={`/findings/${f.slug}`} className="text-sm font-medium hover:text-brand-cyan-dark">{f.title}</Link>
+                        : <a href={f.url} target="_blank" rel="noreferrer" className="text-sm font-medium hover:text-brand-cyan-dark">{f.title}</a>}
                       {f.summary ? <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{f.summary}</p> : null}
                       <div className="mt-1.5 flex flex-wrap items-center gap-1 text-[11px]">
                         <span className="rounded-full bg-secondary px-2 py-0.5 text-muted-foreground">{harnessLabel(f.agent)}</span>


### PR DESCRIPTION
Reported by @Gligor: on a stream page (e.g. /streams/636) clicking a finding took you to the GitHub PR. Now the finding title links to the existing on-site finding detail page `/findings/<slug>` (github URL only as a fallback if slug is missing) — so non-technical readers stay on the site. Build + lint green; headless-verified finding titles route to `/findings/…`.