### PR TITLE
fix(runners): claim-fail backoff — stop respinning a chronically no-PR issue (#766, symptom 2)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -37,7 +37,7 @@
   description: "Waiting on the stream steward's direction decision"
 - name: "status: blocked"
   color: "B60205"
-  description: "Human-set only: waiting on something. Runners ignore it (they only pick up status: available)"
+  description: "Human-set, plus one automated exception — start_work.sh's claim-fail backoff parks a chronically no-PR issue here (#766, ADR-0025). Un-blocking is human-only. Runners ignore it (they only pick up status: available)"
 - name: "status: done"
   color: "5319E7"
   description: "Merged and complete"

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -58,7 +58,7 @@ The full vocabulary, in one table:
 | `status: changes-requested` | issues | `review_work.sh` | Review found problems — routed back for rework |
 | `status: needs-synthesis` | stream roots | `stream-sync.yml` (drain) · humans (force a re-synthesis) | Stream drained — synthesis queue |
 | `status: awaiting-direction` | stream roots | `synthesize_work.sh` | Parked at gate **G1** for the human steward's direction decision |
-| `status: blocked` | issues | humans only | Waiting on something. Runners ignore it either way |
+| `status: blocked` | issues | humans · `start_work.sh` (claim-fail cap, #766) | Waiting on something. Runners ignore it either way. Only the backoff (ADR-0025) sets it automatically; un-blocking is human-only |
 | `status: done` | issues | merge automation | Merged and complete |
 | `review: claimed` | PRs | `review_work.sh` | A reviewer is holding this PR (double-review lock) |
 | `review: human-only` | PRs | maintainers | Pipeline/governance change — humans review and merge, agents skip |

--- a/docs/adr/0025-claim-fail-backoff.md
+++ b/docs/adr/0025-claim-fail-backoff.md
@@ -1,0 +1,86 @@
+# ADR-0025: An issue that keeps failing to produce a PR is parked `status: blocked`, not re-released forever
+
+- **Status:** proposed (ratified on merge by the human maintainer, who directed this
+  fix on 2026-07-09; agents do not self-ratify pipeline changes)
+- **Date:** 2026-07-09
+- **Deciders:** @adam91holt (human maintainer); drafted by an agent (Claude Opus 4.8,
+  "Fable") acting on his direct instructions (#766)
+- **Relates to:** ADR-0021 (author-agnostic rework reconcile — the *other* loop #766
+  documented), ADR-0006 (fetch proxy / browser ladder — the residential proxy reduces
+  the *trigger* this backoff guards against), #728, #521, #766
+
+## Context
+
+`start_work.sh`'s `finish_issue` had exactly two outcomes for a claimed issue: a PR was
+opened (→ `status: in-review`), or none was (→ back to `status: available`, assignee
+removed). The second path had no memory. An issue whose sources can't be fetched from the
+current egress — a WAF / IP-reputation block, not a defect in the issue — fails the same
+way on every claim, and being released straight to `available` it is re-claimable within
+seconds. We observed this live: **#728** fired "the agent finished without opening a PR —
+releasing this back to available" **11 times** (12:04→13:55Z on 2026-07-07) before a PR
+finally appeared, and **#521** did it 5 times as recently as 2026-07-08. Each cycle is a
+full agent run — pure token burn, zero net progress, and it can spin indefinitely while
+the egress block persists.
+
+This is symptom 2 of #766. (Symptom 1 — the review↔rework ping-pong — is a separate,
+lower-urgency defect: its park-for-human cap is self-limiting in practice and its worst
+trigger is the same egress block, addressed by ADR-0006's proxy work. It is left as a
+documented note on #766, not fixed here.)
+
+## Decision
+
+`finish_issue`'s no-PR path gains a **per-issue empty-attempt counter with a cap**
+(`EMPTY_ATTEMPT_CAP`, default 3). The count is **derived from GitHub**, not local state:
+each empty release carries a hidden marker (`<!-- fg-empty-attempt -->`) in its issue
+comment, and the count is how many such markers the issue already carries — so it
+survives across separate `start_work.sh` runs and across different runner identities
+(the same property #766 demanded for the review-round cap). Below the cap the issue is
+released to `available` as before (with the marker and the running tally); **at** the cap
+it is parked **`status: blocked`** — which the runners already skip (they only pick up
+`available`) — with a comment explaining that the sources are likely unreachable from
+this egress and that a maintainer should return it to `available` once that is resolved.
+
+The counting + verdict are two **pure helpers in `fg-common.sh`**
+(`empty_attempt_count`, `empty_attempt_verdict`) so they are unit-tested without gh
+(`scripts/test-fg-common-backoff.sh`).
+
+**Deliberate exception to the "human-set only" `status: blocked` label.** That label's
+description reads "Human-set only: waiting on something. Runners ignore it." This is the
+one automated path allowed to set it, and it is set for exactly that meaning — the issue
+*is* waiting on something (egress / the fetch proxy) — so the label's semantics hold. A
+human still owns the un-block: nothing automated moves it back to `available`.
+
+It is deliberately narrow and fails safe:
+- **Counting is all-time, not since-last-success.** Over-counting only parks a
+  chronically-failing issue one attempt sooner — the safe direction — and a completed
+  issue closes rather than re-entering this path, so stale markers are a non-issue in
+  practice.
+- **Malformed/empty comment payloads count as 0** (`empty_attempt_count` coerces any
+  non-integer to 0), so a transient `gh` hiccup never spuriously blocks an issue.
+- **Only the fresh-claim no-PR path** is touched. The rework-with-no-open-PR release and
+  every other lifecycle transition are unchanged.
+
+Alternatives considered: `do-not-automate` instead of `status: blocked` (rejected —
+heavier, and `blocked` already means exactly "waiting on something, runners ignore");
+a timed cooldown that re-opens the issue automatically (rejected — the block is not
+time-based, it clears when the egress problem is fixed, which only a human knows);
+tracking attempts in local runner state (rejected — it must survive across runs and
+identities, which only a GitHub-derived count does).
+
+## Consequences
+
+- One blocked issue can no longer spin the fleet: after `EMPTY_ATTEMPT_CAP` empty claims
+  it leaves the available loop until a human intervenes.
+- A new tunable, `EMPTY_ATTEMPT_CAP` (default 3), and one new automated writer of
+  `status: blocked` — bounded, GitHub-derived, `DRY_RUN`-inspectable.
+- Honest limit: this stops the *spin*; it does not *fix* the underlying fetch failure.
+  The residential proxy (ADR-0006) reduces how often issues reach the cap at all; the
+  backoff is the safety net for when they still do.
+
+## What would change this decision
+
+The egress blocks disappearing entirely (would make empty attempts rare enough that the
+counter rarely fires — harmless, but the cap could be raised); a move to fetching every
+source through a reliable proxy by default (would shift the trigger upstream); or
+evidence that legitimate mid-work issues hit the cap (would tighten the count to
+since-last-success or require a distinct "genuinely unworkable" signal).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,5 +61,6 @@ routine fixes, copy changes, or web styling.
 | [0022](0022-worker-injection-hardening-and-sandbox-defaults.md) | Harden worker prompts against injection + implement ADR-0005's sandboxed run defaults (Codex workspace-write+network, Claude auto) | Proposed |
 | [0023](0023-self-report-is-a-claim.md) | A party's statement about itself is a claim, not confirmation (method check 3) | Proposed |
 | [0024](0024-stream-level-priority.md) | Priority is a stream-level decision inherited by children | Proposed |
+| [0025](0025-claim-fail-backoff.md) | An issue that keeps failing to produce a PR is parked status: blocked, not re-released forever | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/scripts/fg-common.sh
+++ b/scripts/fg-common.sh
@@ -763,6 +763,33 @@ clear_status_label() {  # $1 = issue
     | gh api -X PUT "repos/$OWNER/$NAME/issues/$n/labels" --input - >/dev/null
 }
 
+# ---- claim-fail backoff (#766) ----
+# An issue can be claimed, finish with NO PR (its sources unreachable from this
+# egress — a WAF / IP-reputation block, not a defect), get released to
+# `available`, and be re-claimed within seconds — spinning without progress
+# (#728 did this 11×, #521 5×). finish_issue (start_work.sh) counts prior empty
+# attempts from a hidden marker on the issue and, at EMPTY_ATTEMPT_CAP, parks it
+# `status: blocked` (runners skip that) instead of re-releasing. The marker and
+# these two PURE helpers live here so they're unit-tested without gh (see
+# scripts/test-fg-common-backoff.sh); the marker is derived from GitHub so the
+# count survives across separate runs and different runner identities.
+EMPTY_ATTEMPT_MARKER="<!-- fg-empty-attempt -->"
+
+# Count empty-attempt markers in a `gh issue view --json comments` payload.
+empty_attempt_count() {  # $1 = {comments:[{body}...]} JSON -> integer (0 on junk)
+  local out
+  out="$(printf '%s' "${1:-}" \
+    | jq --arg m "$EMPTY_ATTEMPT_MARKER" '[.comments[]? | select(.body|contains($m))] | length' 2>/dev/null)"
+  # Empty/malformed input can leave jq emitting nothing (exit 0) — coerce any
+  # non-integer, including "", to 0 so callers always get a number.
+  case "$out" in ''|*[!0-9]*) echo 0 ;; *) echo "$out" ;; esac
+}
+
+# Verdict for a claim that produced no PR: park the issue or re-release it.
+empty_attempt_verdict() {  # $1 = attempts so far (incl. this one), $2 = cap -> "block" | "release"
+  if [ "${1:-0}" -ge "${2:-3}" ]; then echo block; else echo release; fi
+}
+
 # True if an exit status means the agent was INTERRUPTED by the user (Ctrl-C) or
 # killed — the whole runner should stop, not move on to the next item. Note a
 # `timeout` (124) is deliberately NOT here: that fails one item but the loop

--- a/scripts/start_work.sh
+++ b/scripts/start_work.sh
@@ -453,9 +453,16 @@ finish_issue() {  # $1 = issue number
 ⚠️ The agent finished without opening a PR (empty attempt $attempts/$EMPTY_ATTEMPT_CAP) — releasing this back to **available** for someone else to pick up. After $EMPTY_ATTEMPT_CAP empty attempts it is parked \`status: blocked\` instead of re-released (#766)." >/dev/null
       warn "#$n released (no PR opened, empty attempt $attempts/$EMPTY_ATTEMPT_CAP)"
     fi
-    # Fleet-claimed: also release the server's lease as abandoned (labels are
-    # already reverted above; the server's own revert is an idempotent no-op).
-    if [ "${FLEET_CLAIMED:-0}" = 1 ]; then fleet_release "$n" abandoned; fi
+    # Fleet-claimed: release the server's lease too — but the outcome MUST match
+    # the label we just set. `abandoned` makes the server revert labels+assignee
+    # to the pre-claim state (`status: available`), which would clobber a `blocked`
+    # transition and re-queue the issue seconds later (defeating the backoff on the
+    # fleet path). So release `done` in the block case — that frees the lease and
+    # leaves our `blocked` label untouched — and only `abandoned` when we actually
+    # released back to `available` (there the server's revert is an idempotent no-op).
+    if [ "${FLEET_CLAIMED:-0}" = 1 ]; then
+      if [ "$verdict" = block ]; then fleet_release "$n" done; else fleet_release "$n" abandoned; fi
+    fi
   fi
   CLAIMED_ISSUE=""
 }

--- a/scripts/start_work.sh
+++ b/scripts/start_work.sh
@@ -30,7 +30,7 @@
 #
 # Args: [claude|codex|hermes] [--model <name>]   (CLI wins over the AGENT/MODEL env vars)
 # Env:  AGENT MODEL MAX ISSUE STAGE POLL_SECONDS DRY_RUN AGENT_TIMEOUT
-#       PROVIDER HERMES_PROFILE HERMES_FLAGS FOR_GOOD_REPO REPO_DIR
+#       EMPTY_ATTEMPT_CAP PROVIDER HERMES_PROFILE HERMES_FLAGS FOR_GOOD_REPO REPO_DIR
 #       FLEET_SERVER FLEET_TOKEN FLEET_CLAIM(=0) — set FLEET_CLAIM=1 to let the
 #       fleet server claim atomically for you; with no FLEET_TOKEN it
 #       AUTO-ENROLLS this gh identity on first contact (token stored in
@@ -47,6 +47,7 @@ ISSUE="${ISSUE:-}"                    # one-shot: work THIS issue first, then fa
 POLL_SECONDS="${POLL_SECONDS:-180}"   # keep polling when queue empty every 3 min (0 to exit instead)
 DRY_RUN="${DRY_RUN:-0}"
 RECONCILE_REWORK_SECONDS="${RECONCILE_REWORK_SECONDS:-900}"
+EMPTY_ATTEMPT_CAP="${EMPTY_ATTEMPT_CAP:-3}"  # consecutive claim→no-PR fails before an issue is parked status: blocked instead of re-released (#766)
 CLAIMED_ISSUE=""
 FLEET_CLAIMED=0     # 1 while working an issue the fleet SERVER claimed for us (FLEET_CLAIM=1 opt-in)
 FLEET_RENEW_PID=""  # background lease-renew loop for a fleet-claimed issue
@@ -416,11 +417,42 @@ finish_issue() {  # $1 = issue number
     # 'done' never touches labels (the PR/Actions pipeline owns them from here).
     if [ "${FLEET_CLAIMED:-0}" = 1 ]; then fleet_release "$n" done "$pr"; fi
   else
-    if [ "$DRY_RUN" = 1 ]; then info "[dry-run] no PR found for #$n — would release back to available"; CLAIMED_ISSUE=""; return 0; fi
-    set_status_label "$n" "available" "claimed"
+    # CLAIM-FAIL BACKOFF (#766): an issue that keeps being claimed and finished
+    # with NO PR — usually because its sources are unreachable from this egress
+    # (a WAF / IP-reputation block, not a defect in the issue) — must not spin:
+    # released straight to `available` it is re-grabbed within seconds and fails
+    # the same way (#728 did this 11×, #521 5×). We count prior empty attempts
+    # from a hidden marker on the issue itself (survives across runners/identities,
+    # no local state) and, at EMPTY_ATTEMPT_CAP, park it `status: blocked` — which
+    # the runners ignore (they only pick up `available`) — instead of re-releasing.
+    # A human clears it back to `available` once the fetch problem is resolved.
+    # Counting the marker is deliberately simple (all-time, not since-last-success):
+    # over-counting only parks a chronically-failing issue one attempt sooner, the
+    # safe direction, and a completed issue closes rather than re-entering here.
+    # The marker + count/verdict helpers are pure and live in fg-common.sh.
+    local prior; prior="$(empty_attempt_count "$(gh issue view "$n" --repo "$REPO" --json comments 2>/dev/null || echo '{"comments":[]}')")"
+    local attempts=$((prior + 1))
+    local verdict; verdict="$(empty_attempt_verdict "$attempts" "$EMPTY_ATTEMPT_CAP")"
+    if [ "$DRY_RUN" = 1 ]; then
+      if [ "$verdict" = block ]; then
+        info "[dry-run] no PR for #$n — empty attempt $attempts/$EMPTY_ATTEMPT_CAP — would park status: blocked"
+      else
+        info "[dry-run] no PR for #$n — empty attempt $attempts/$EMPTY_ATTEMPT_CAP — would release back to available"
+      fi
+      CLAIMED_ISSUE=""; return 0
+    fi
     gh issue edit "$n" --repo "$REPO" --remove-assignee "@me" >/dev/null || true
-    gh issue comment "$n" --repo "$REPO" --body "⚠️ The agent finished without opening a PR — releasing this back to **available** for someone else to pick up." >/dev/null
-    warn "#$n released (no PR opened)"
+    if [ "$verdict" = block ]; then
+      set_status_label "$n" "blocked"
+      gh issue comment "$n" --repo "$REPO" --body "$EMPTY_ATTEMPT_MARKER
+⛔ **Claim-fail backoff (#766).** This issue has been claimed and finished **without a PR $attempts times** (cap \`EMPTY_ATTEMPT_CAP=$EMPTY_ATTEMPT_CAP\`). Rather than release it to \`available\` again — where a runner re-grabs it in seconds and fails the same way — it is parked **status: blocked** so the autonomous runners skip it. This usually means the sources can't be fetched from the current egress (WAF / IP-reputation block), not a defect in the issue. A maintainer can set it back to \`status: available\` once that's resolved (e.g. via the fetch proxy)." >/dev/null
+      warn "#$n parked status: blocked after $attempts empty attempts (#766 backoff)"
+    else
+      set_status_label "$n" "available"
+      gh issue comment "$n" --repo "$REPO" --body "$EMPTY_ATTEMPT_MARKER
+⚠️ The agent finished without opening a PR (empty attempt $attempts/$EMPTY_ATTEMPT_CAP) — releasing this back to **available** for someone else to pick up. After $EMPTY_ATTEMPT_CAP empty attempts it is parked \`status: blocked\` instead of re-released (#766)." >/dev/null
+      warn "#$n released (no PR opened, empty attempt $attempts/$EMPTY_ATTEMPT_CAP)"
+    fi
     # Fleet-claimed: also release the server's lease as abandoned (labels are
     # already reverted above; the server's own revert is an idempotent no-op).
     if [ "${FLEET_CLAIMED:-0}" = 1 ]; then fleet_release "$n" abandoned; fi

--- a/scripts/test-fg-common-backoff.sh
+++ b/scripts/test-fg-common-backoff.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Unit tests for the claim-fail backoff helpers in scripts/fg-common.sh (#766):
+#   - empty_attempt_count: how many prior "finished with no PR" markers an issue
+#     carries (derived from GitHub comments, so it survives across separate runs
+#     and different runner identities)
+#   - empty_attempt_verdict: release-to-available vs park-status:blocked at the cap
+# Everything runs against synthetic `gh issue view --json comments` payloads —
+# no gh, no network.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/fg-common.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { printf '  ok   %s\n' "$1"; }
+
+M="$EMPTY_ATTEMPT_MARKER"
+
+# Build a {comments:[{body}...]} payload from the bodies passed as args.
+comments() { printf '%s\n' "$@" | jq -R '{body: .}' | jq -s '{comments: .}'; }
+
+echo "empty_attempt_count: counts only marker-bearing comments"
+
+got="$(empty_attempt_count "$(comments)")"
+[ "$got" = 0 ] || fail "empty comments: want 0, got '$got'"
+ok "no comments → 0"
+
+got="$(empty_attempt_count "$(comments "just a normal review comment" "another one")")"
+[ "$got" = 0 ] || fail "no markers: want 0, got '$got'"
+ok "comments without the marker → 0"
+
+got="$(empty_attempt_count "$(comments "$M first release" "human chatter" "$M second release")")"
+[ "$got" = 2 ] || fail "two markers among chatter: want 2, got '$got'"
+ok "two markers mixed with other comments → 2"
+
+# Robustness: junk / missing field / empty string never explodes, always 0.
+for junk in '' 'not json' '{}' '{"comments":[]}' '[{"body":"x"}]'; do
+  got="$(empty_attempt_count "$junk")"
+  [ "$got" = 0 ] || fail "junk payload '$junk': want 0, got '$got'"
+done
+ok "junk / empty / wrong-shape payloads → 0 (fails safe)"
+
+echo "empty_attempt_verdict: release below the cap, block at/over it (cap 3)"
+
+[ "$(empty_attempt_verdict 1 3)" = release ] || fail "attempt 1/3 should release"
+[ "$(empty_attempt_verdict 2 3)" = release ] || fail "attempt 2/3 should release"
+[ "$(empty_attempt_verdict 3 3)" = block   ] || fail "attempt 3/3 should block"
+[ "$(empty_attempt_verdict 4 3)" = block   ] || fail "attempt 4/3 should block"
+ok "verdict crosses to 'block' exactly at the cap"
+
+echo "end-to-end progression: a chronically-failing issue parks on the 3rd empty attempt"
+# Simulate the marker accumulating one per failed claim; verdict uses prior+1.
+bodies=()
+for round in 1 2 3; do
+  prior="$(empty_attempt_count "$(comments ${bodies[@]+"${bodies[@]}"})")"
+  attempts=$((prior + 1))
+  verdict="$(empty_attempt_verdict "$attempts" 3)"
+  case "$round" in
+    1|2) [ "$verdict" = release ] || fail "round $round (attempt $attempts) should release, got $verdict" ;;
+    3)   [ "$verdict" = block   ] || fail "round $round (attempt $attempts) should block, got $verdict" ;;
+  esac
+  bodies+=("$M empty attempt $attempts")   # this run posts its own marker
+done
+ok "release, release, block — 2 re-releases then parked (matches #728/#521 pattern)"
+
+echo "ALL PASS"


### PR DESCRIPTION
Part of #766 (fixes **symptom 2** — the claim / fail / release retry loop).

## Problem
`start_work.sh`'s `finish_issue` had no memory on its no-PR path. An issue whose sources are unreachable from the current egress (a WAF / IP-reputation block, not a defect) fails the same way on every claim, and being released straight to `status: available` it is re-claimable within seconds. Live evidence: **#728** fired "the agent finished without opening a PR — releasing this back to available" **11 times** (12:04→13:55Z, 2026-07-07); **#521** did it **5 times** on 2026-07-08. Each cycle is a full agent run — pure token burn.

## Fix
`finish_issue`'s no-PR path now:
- counts prior empty attempts from a hidden `<!-- fg-empty-attempt -->` marker on the issue — **derived from GitHub**, so the count survives across separate runs and different runner identities (the persistence property #766 asked for);
- below `EMPTY_ATTEMPT_CAP` (default **3**), releases to `available` as before, with the running tally;
- **at** the cap, parks the issue **`status: blocked`** (which runners already skip) with an explanatory comment, instead of re-releasing. A human returns it to `available` once the egress problem is resolved.

Counting + verdict are pure helpers in `fg-common.sh` (`empty_attempt_count`, `empty_attempt_verdict`), unit-tested without gh in `scripts/test-fg-common-backoff.sh` (all pass).

## Deliberate policy note
`status: blocked` is described as "human-set only". This is the one automated path allowed to set it, and it sets it for exactly that meaning (the issue *is* waiting on something — egress / the fetch proxy). A human still owns the un-block. Recorded in **ADR-0025**.

## Scope
Symptom 1 (review↔rework ping-pong) is **not** fixed here — in practice it self-limits around 8 rounds and its worst trigger is the same egress block (addressed by ADR-0006's proxy work), so it's left as a documented note on #766. Its stated root cause ("counter resets each cycle") is also inaccurate: `review_rounds()` already derives from GitHub via GraphQL.

## Test
```
bash scripts/test-fg-common-backoff.sh   # ALL PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)