### PR TITLE
docs(ideas): Idea Records (IRs) — an ADR-style home for sparks

### DIFF
--- a/docs/ideas/0001-sme-review-via-guided-ai-interviewer.md
+++ b/docs/ideas/0001-sme-review-via-guided-ai-interviewer.md
@@ -1,0 +1,70 @@
+# IR-0001: SME review via a guided (voice-optional) AI interviewer
+
+- **Status:** exploring
+- **Date:** 2026-07-09
+- **Champions:** Matt (raised it), Adam (voice-driven adaptive questionnaire), Joe Sutheran (custom-GPT interviewer with a shareable transcript)
+- **Discussion:** For Good WhatsApp thread, 2026-07-09 (during the first live SME review of the #442 aged-care funding guide)
+- **Relates to:** stream [#442](https://github.com/thecolab-ai/the-for-good-project/issues/442); the SME expertise network ([#878](https://github.com/thecolab-ai/the-for-good-project/issues/878), [#883](https://github.com/thecolab-ai/the-for-good-project/issues/883)); the WhatsApp→Clawd→stream feedback loop ([#38](https://github.com/thecolab-ai/the-for-good-project/issues/38))
+
+## The spark
+
+We just ran the project's first real expert review: a contributor drafted the
+aged-care funding guide via the "Open with…" no-code loop, and it went to an
+SME (an aged-care banker) as a clean PDF, with corrections coming back in
+plain WhatsApp. That works — but it leans on the SME reading a document and
+writing freeform feedback. **Experts have the gold and often the least time
+and, sometimes, the least technical patience.** How do we make giving that
+expertise as effortless as possible — even for a busy or non-technical SME?
+
+## The idea
+
+A **guided AI interviewer**: a purpose-built assistant (a Custom GPT, or a
+Claude/ChatGPT link, ideally voice-enabled) that is pre-loaded with:
+
+1. **exactly what needs verifying** — the specific claims, numbers and
+   confidence tags from the draft (e.g. the "numbers to verify" box); and
+2. **how to ask good questions** — so it draws out the *useful* answer, not a
+   generic one, and **adapts the next question based on the last answer**
+   (Adam's voice-questionnaire pattern).
+
+The SME just talks or types. At the end it produces a **structured, citable
+transcript of corrections and context**, which comes back into the stream —
+either posted automatically, or shared by the SME via a link (Joe's pattern).
+
+## Why it could be great
+
+- **Meets the SME where they are** — voice or chat, no GitHub, no markdown, no
+  forms. The lowest-friction way to give expertise yet.
+- **Adaptive beats a static form** — it follows the thread of what the expert
+  actually knows, and can gently probe ("you said the cap's wrong — what's the
+  right figure, and where would a family see it?").
+- **Structured output** — turns a conversation into a tidy, attributable set of
+  corrections a human steward can fold straight in.
+- **Scales the expertise network** — the same pattern powers every future SME
+  interaction, and the transcripts become part of the consented record
+  (#878/#883).
+
+## Open questions
+
+- **Where does the transcript land?** Auto-posted to the stream, or SME shares
+  a link? Consent and attribution rules (per the partner-network ADR) apply.
+- **Voice tooling** — what's the simplest voice-in/voice-out path that doesn't
+  need the SME to install anything?
+- **Staying aligned** — how do we keep the interviewer pinned to the *actual*
+  verification list so it doesn't wander or lead the witness?
+- **Privacy** — no personal/identifying data captured; the expert's identity is
+  handled at their consent level, never in the public repo.
+- **Build vs. reuse** — Custom GPT is quickest to prototype but locks to one
+  vendor; a model-agnostic version fits the project's ethos better.
+
+## Cheapest experiment
+
+Build **one** interviewer for the review that's live *right now*: pre-load a
+Custom GPT (or a single well-crafted prompt) with the #442 guide's "numbers to
+verify" box, have it walk Jay through the figures one at a time — by voice if
+he likes — and output a clean correction list. If Jay finds it easier than
+red-penning the PDF, the idea's real. Total cost: an afternoon.
+
+---
+*This is an idea, not a commitment. It records thinking so it isn't lost — a
+human decides if and when it graduates to an issue or an ADR.*

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -1,0 +1,58 @@
+# Idea Records (IRs)
+
+Good ideas turn up in a WhatsApp thread at 11pm and are gone by morning. ADRs
+capture **decisions we've made**; this directory captures **ideas we haven't —
+yet.** A small, numbered home for sparks worth keeping, so they can be found,
+built on, and either graduated into real work or honestly parked.
+
+Think of it as the layer *before* an ADR: an idea gets explored here; if it
+becomes how the project works, it graduates to an [ADR](../adr/README.md); if
+it becomes something to build, it graduates to an issue.
+
+## When to write an Idea Record
+
+Write one when someone floats something that:
+
+- could change how contributors, experts, or the pipeline work, and is worth
+  more than a passing message;
+- you want other people to be able to find, react to, and improve;
+- isn't a decision yet — so it doesn't belong in an ADR, and isn't scoped
+  enough to be an issue.
+
+Not for: routine tasks (open an issue), settled decisions (write an ADR), or
+individual findings (the research method covers those).
+
+## Lifecycle
+
+An idea moves through states — recorded in the file's `Status:` line:
+
+- **proposed** — captured, not yet discussed much.
+- **exploring** — people are actively kicking it around / running a cheap test.
+- **adopted** — we're doing it; link the issue(s) and/or ADR it graduated to.
+- **parked** — good, but not now; say what would un-park it.
+- **superseded** — replaced by a better idea; link it.
+
+## The rules
+
+1. **Numbered.** `NNNN-short-slug.md`, next number in sequence. The number is
+   stable; the content can evolve (unlike an ADR, an idea is allowed to change
+   as we learn — that's the point).
+2. **Short and honest.** The spark, the idea, why it could be great, the open
+   questions, and the *cheapest experiment* that would tell us if it's real.
+   Explicitly note it's an idea, not a commitment.
+3. **Credit the humans.** List who floated it and who's keen — ideas are
+   people, and momentum follows names.
+4. **Proposed via PR** like everything else, and linked to its discussion.
+
+## Index
+
+| IR | Title | Status | Champions |
+|---|---|---|---|
+| [0001](0001-sme-review-via-guided-ai-interviewer.md) | SME review via a guided (voice-optional) AI interviewer | Exploring | Matt, Adam, Joe |
+
+## See also
+
+- [ADRs](../adr/README.md) — decisions already made.
+- The consented **SME expertise network** ideas already in flight as issues
+  [#878](https://github.com/thecolab-ai/the-for-good-project/issues/878) and
+  [#883](https://github.com/thecolab-ai/the-for-good-project/issues/883).

--- a/docs/ideas/TEMPLATE.md
+++ b/docs/ideas/TEMPLATE.md
@@ -1,0 +1,35 @@
+# IR-NNNN: <short title>
+
+- **Status:** proposed  <!-- proposed | exploring | adopted | parked | superseded -->
+- **Date:** YYYY-MM-DD
+- **Champions:** <who floated it, who's keen>
+- **Discussion:** <link to the chat/issue/PR where it came up>
+- **Relates to:** <issues / ADRs / streams it touches>
+
+## The spark
+
+The problem or opportunity in a few plain sentences — what made someone say
+"we should…". Keep it concrete.
+
+## The idea
+
+What we'd actually do. Enough that a reader gets it, not so much that it reads
+like a spec — it isn't one yet.
+
+## Why it could be great
+
+The upside, honestly stated. Who's better off, and how.
+
+## Open questions
+
+The things we don't know, the risks, and where it could go wrong. An idea with
+no open questions is either finished or lying.
+
+## Cheapest experiment
+
+The smallest, fastest thing we could do to learn whether this is real — before
+committing to build it.
+
+---
+*This is an idea, not a commitment. It records thinking so it isn't lost — a
+human decides if and when it graduates to an issue or an ADR.*


### PR DESCRIPTION
Requested by @adam91holt. ADRs capture decisions; **Idea Records** capture ideas we haven't decided yet — numbered, indexed, PR-reviewed, so good sparks from chat don't vanish. They graduate to an issue (build) or an ADR (decision), or get parked. Seeded with **IR-0001: SME review via a guided voice-optional AI interviewer** (from tonight's Matt/Adam/Joe thread). Adds `docs/ideas/` (README, TEMPLATE, 0001) only.