### PR TITLE
ADR-0026: Implement the Paper Round (steward-mediated email review)

### DIFF
--- a/.claude/skills/draft-review-sheet/SKILL.md
+++ b/.claude/skills/draft-review-sheet/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: draft-review-sheet
+description: Use when a steward asks for a review sheet (a Paper Round pack) for a stream — drafts the SME-facing email from the stream overview using streams/REVIEW-SHEET.md, quoting 5–8 claims verbatim with confidence tags, bounded to factual verification plus two judgement questions. The steward edits, approves, and sends; the agent never contacts a reviewer and never files feedback itself.
+---
+
+# Draft a review sheet (steward approves, agent drafts)
+
+You draft the email a non-technical domain expert receives in a review round
+([ADR-0026](../../../docs/adr/0026-human-review-paper-round.md), SOP:
+[docs/REVIEW-ROUND.md](../../../docs/REVIEW-ROUND.md)). Your output is a
+**draft for the steward to edit** — never send it, never file it, never put it
+anywhere but in front of the steward.
+
+## Inputs
+
+A stream number or overview path (`streams/<n>-<slug>.md`). Read the overview
+and, where a claim's origin matters, the linked findings in
+`research/findings/`. If the steward names the reviewer's domain (e.g. "he's a
+banker — funding claims only"), select claims accordingly.
+
+## What to produce
+
+Fill [`streams/REVIEW-SHEET.md`](../../../streams/REVIEW-SHEET.md) exactly:
+
+1. **5–8 claims, quoted verbatim** from the overview's "What we've learned so
+   far" (or the findings behind it), each with its **confidence tag carried
+   unchanged**. Prefer claims that are load-bearing, surprising, Low/Medium
+   confidence, or squarely inside this reviewer's expertise. Never paraphrase
+   a claim you're asking someone to verify.
+2. Each claim answerable **Right / Wrong / Can't say**, with the
+   what/why/where-would-we-check prompt when wrong. Factual verification only
+   — never ask for rewrites, never ask them to read the repo.
+3. **Exactly two judgement questions** at the end: "worth pursuing?" and a
+   choice between the overview's candidate outcomes (use its real options;
+   leave `TODO(steward)` if the overview has none yet).
+4. The attribution ask, unchanged from the template — role-only / org-named /
+   org-credited. **Never offer personal-name attribution; no consent tier
+   permits it** (ADR-0010).
+
+## Hard rules
+
+- **Neutral phrasing — don't lead the witness.** "Right / Wrong / Can't say",
+  never "we believe X, do you agree?".
+- **Plain language, under two screens on a phone.** No jargon, no issue
+  numbers, no links into GitHub.
+- **You draft; the human decides.** Do not edit `streams/` overview docs, do
+  not open issues, do not email anyone. Hand the draft to the steward and
+  state which claims you left out and why, so the steward can overrule you.
+- If the overview has fewer than 5 solid claims, say so and draft with what
+  exists rather than padding with weak ones.

--- a/.github/ISSUE_TEMPLATE/5-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/5-feedback.yml
@@ -1,0 +1,83 @@
+name: "💬 Stakeholder feedback (filed on a reviewer's behalf)"
+description: File a review round's feedback against a stream — used by the steward or whoever captured it. The reviewer never needs GitHub.
+title: "[Feedback] <stream topic> — review round"
+labels: ["feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This lands a non-GitHub reviewer's judgement in the repo (**[ADR-0026](../blob/main/docs/adr/0026-human-review-paper-round.md)**). Before filing, you must have followed the SOP in [`docs/REVIEW-ROUND.md`](../blob/main/docs/REVIEW-ROUND.md): sanitized the reply (no names, emails, phones — run `npm run redact-check`), read the transcription back to the reviewer, and recorded their consent in `partners/`. A validator checks this issue mechanically and fails closed with the exact fix if something's off.
+  - type: input
+    id: stream
+    attributes:
+      label: Stream
+      description: "The stream root this feedback is about — write it exactly as `Stream: #<number>` so the stream label propagates automatically."
+      placeholder: "Stream: #442"
+    validations:
+      required: true
+  - type: input
+    id: reviewer
+    attributes:
+      label: Reviewer (role + sector — never a name)
+      description: Who gave this feedback, described at their consent level. No personal name, ever.
+      placeholder: "an aged-care banker (15 yrs in the sector)"
+    validations:
+      required: true
+  - type: dropdown
+    id: consent
+    attributes:
+      label: Consent tier
+      description: What the reviewer agreed to (ADR-0010). When in doubt, private.
+      options:
+        - private — role + sector only, no organisation named (default)
+        - org-named — the organisation may be named in this feedback
+        - public — the organisation is openly credited as a reviewer
+    validations:
+      required: true
+  - type: input
+    id: organisation
+    attributes:
+      label: Organisation (only if tier is org-named or public)
+      description: Must match a `partners/` record whose recorded consent allows it. Leave empty for private.
+    validations:
+      required: false
+  - type: textarea
+    id: verdicts
+    attributes:
+      label: What the reviewer said — verdicts on the sheet
+      description: Their words (sanitized), one row per claim from the review sheet.
+      placeholder: |
+        | # | Claim (short) | Verdict | Correction / detail | Where they'd check |
+        |---|---|---|---|---|
+        | 1 | Subsidy cap is $X/week | Wrong | Cap is $Y since the 2025 review | MSD operational guidelines |
+        | 2 | 40% of facilities run at a loss | Can't say | Outside their patch | — |
+    validations:
+      required: true
+  - type: textarea
+    id: judgement
+    attributes:
+      label: Judgement answers (worth pursuing? which direction first?)
+      description: Their answers to the sheet's two closing questions, if given.
+    validations:
+      required: false
+  - type: textarea
+    id: provenance
+    attributes:
+      label: Provenance
+      description: Who filed this, on whose behalf, read-back date, and where consent is recorded.
+      placeholder: "Filed by @steward on behalf of the reviewer above. Read-back confirmed 2026-07-15. Consent (tier + date) recorded in partners/ via manage-partner."
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you file (the SOP's hard gates — docs/REVIEW-ROUND.md)
+      options:
+        - label: I sanitized the reply BEFORE any agent saw it, and no personal name, email, phone number, or identifying detail of any individual appears above (I ran `npm run redact-check` on this body).
+          required: true
+        - label: I read the transcribed verdicts back to the reviewer and they confirmed I haven't misquoted them.
+          required: true
+        - label: The consent tier above is what the reviewer actually agreed to, and it is recorded (tier + date + how) in their `partners/` record.
+          required: true
+        - label: The raw reply will be deleted within 30 days of this round closing.
+          required: true

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -69,6 +69,9 @@
 - name: "feedback"
   color: "0EA5E9"
   description: "Stakeholder / domain-expert feedback on a stream"
+- name: "feedback: needs-fix"
+  color: "E11D48"
+  description: "Feedback filing failed the consent/PII validator (ADR-0026) — see the report comment for the exact repair"
 
 # --- Review: PR-scoped review-loop markers (NOT issue lifecycle states) ---
 - name: "review: claimed"

--- a/.github/workflows/feedback-consent.yml
+++ b/.github/workflows/feedback-consent.yml
@@ -1,0 +1,96 @@
+# Consent/PII gate for stakeholder feedback (ADR-0026) — zero model tokens.
+#
+# Every `feedback`-labelled issue (the Paper Round's landing artifact,
+# docs/REVIEW-ROUND.md) is validated mechanically by
+# scripts/check-feedback-consent.mjs: stream link, consent tier, org-naming
+# vs the partners/ registry, emails/phones/secrets, and the SOP's hard
+# gates. Failures FAIL CLOSED: the issue gets `feedback: needs-fix` plus a
+# comment with the exact repair; a later edit that passes clears the label.
+#
+# The same run counts feedback rounds in the last 30 days — ADR-0026's
+# escalation trigger (>5/month => consider the v2 web surface) is observable,
+# not self-reported.
+name: Feedback consent gate
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: feedback-consent-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    if: >-
+      contains(github.event.issue.labels.*.name, 'feedback') ||
+      github.event.label.name == 'feedback'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Validate the filing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ github.event.issue.number }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          set -uo pipefail
+          fixlabel="feedback: needs-fix"
+          marker="<!-- feedback-consent-report -->"
+
+          ok=0; report=$(node scripts/check-feedback-consent.mjs) || ok=$?
+          printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
+
+          # Upsert one report comment instead of stacking a new one per edit.
+          existing=$(gh api "repos/$REPO/issues/$NUM/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id // empty" 2>/dev/null || true)
+          body=$(printf '%s\n%s' "$marker" "$report")
+
+          if [ "$ok" -ne 0 ]; then
+            gh label create "$fixlabel" --repo "$REPO" --color E11D48 \
+              --description "Feedback filing failed the consent/PII validator — see the report comment" 2>/dev/null || true
+            gh issue edit "$NUM" --repo "$REPO" --add-label "$fixlabel" || true
+            if [ -n "$existing" ]; then
+              gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" >/dev/null
+            else
+              gh issue comment "$NUM" --repo "$REPO" --body "$body" >/dev/null
+            fi
+            echo "::error::Feedback filing on #$NUM failed the consent/PII validator (fail closed)."
+            exit 1
+          fi
+
+          # Passing: clear our label and refresh the report comment if one exists.
+          if gh issue view "$NUM" --repo "$REPO" --json labels --jq '.labels[].name' | grep -qxF "$fixlabel"; then
+            gh issue edit "$NUM" --repo "$REPO" --remove-label "$fixlabel" || true
+            [ -n "$existing" ] && gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" >/dev/null
+          fi
+          echo "Feedback filing on #$NUM passes."
+
+      - name: Count rounds (ADR-0026 escalation trigger)
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ github.event.issue.number }}
+        run: |
+          set -uo pipefail
+          since=$(date -u -d '30 days ago' +%Y-%m-%d)
+          count=$(gh issue list --repo "$REPO" --label feedback --state all \
+            --search "created:>=$since" --json number --jq 'length' 2>/dev/null || echo 0)
+          echo "Feedback rounds in the last 30 days: $count (trigger: >5 — ADR-0026)" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$count" -gt 5 ]; then
+            marker="<!-- feedback-volume-note -->"
+            existing=$(gh api "repos/$REPO/issues/$NUM/comments" --paginate \
+              --jq "[.[] | select(.body | startswith(\"$marker\"))][0].id // empty" 2>/dev/null || true)
+            [ -n "$existing" ] && exit 0
+            gh issue comment "$NUM" --repo "$REPO" --body "$(printf '%s\n%s' "$marker" \
+              "📈 That's **$count feedback rounds in the last 30 days** — past the >5/month tripwire in [ADR-0026](../blob/main/docs/adr/0026-human-review-paper-round.md). The email round may be saturating: time for a steward/maintainer to consider the pre-agreed v2 (a web review surface reusing this same feedback structure), via a superseding ADR.")" >/dev/null || true
+          fi

--- a/analysis/human-review-system-design.md
+++ b/analysis/human-review-system-design.md
@@ -1,0 +1,156 @@
+---
+title: "Design research: how non-GitHub people participate in the human review stage"
+type: "analysis"
+status: "record" # records the research behind ADR-0026; the ADR is the decision
+author: "adam (request); multi-agent research run (execution)"
+agent: "claude"
+model: "undisclosed — this session's policy withholds the model identifier from pushed artifacts"
+date: "2026-07-15"
+---
+
+# Design research: the human review system
+
+The evidence base behind [ADR-0026](../docs/adr/0026-human-review-paper-round.md)
+(the Paper Round). The question: **what is the best way to let people who don't
+know how to use GitHub participate in the human review stage** — SMEs correcting
+claims, stakeholders redirecting streams, outside judgement feeding the G1/G2
+gates?
+
+## Method
+
+A structured multi-agent run (38 agents): one agent grounded the repo's
+constraints; six researched independent angles with mandatory inline citations;
+every load-bearing claim was then **adversarially fact-checked** by a separate
+agent instructed to refute it (24 claims: 23 confirmed, 1 refuted and excluded);
+three competing designs were drafted under opposed philosophies and scored by a
+three-lens judge panel (non-technical reviewer friction / volunteer operability
+/ trust & safety); a synthesis grafted the judges' best-of-losers picks onto the
+winner. Confidence carried below is the fact-checkers', not the researchers'.
+
+## The one hard constraint everything follows from
+
+**GitHub has no anonymous write path.** Creating an issue or comment requires an
+authenticated token; unauthenticated access is 60 read-only requests/hour
+([GitHub REST docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api),
+[issues API](https://docs.github.com/en/rest/issues/issues)) — and comment
+widgets like giscus also require a GitHub sign-in
+([giscus.app](https://giscus.app/)). *(Confirmed.)* So every "no-account" design
+is a **proxy**: some identity we control writes on the reviewer's behalf, and
+the design question is really *which proxy* — a bot behind a form, a vendor
+platform, or a human. The Paper Round's answer: **the human steward is the
+proxy**, because a human proxy is also the moderation queue, the consent
+handler, and the PII filter, at zero infrastructure.
+
+## What the six angles established (verified highlights)
+
+- **GitHub-free bridges** — form→bot pipelines (a GitHub App installation token
+  is rate-limited to 80 content-writes/min, 500/hr, and self-expires after 1 h —
+  [docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation);
+  *confirmed*) are viable but bring spam handling, token custody, and an
+  endpoint to babysit. GitHub's own reply-by-email only works from the account
+  bound to the notification address ([GitHub blog](https://github.blog/news-insights/reply-to-comments-from-email/); *confirmed*).
+- **Civic-tech platforms** — Pol.is is self-hostable and NZ-proven (Scoop
+  HiveMind, 1,700+ participants; a government agency used the biodiversity
+  conversation for the national strategy —
+  [case study](https://compdemocracy.org/case-studies/2016-new-zealand-scoop-hivemind/);
+  *confirmed*), but it answers "what does a crowd think", not "is this claim
+  right". Loomio (Wellington co-op) has no free production tier
+  ([pricing](https://www.loomio.com/pricing/); *confirmed*). Verdict: imitate UX
+  patterns, adopt nothing.
+- **Expert-review UX** — structure beats freeform decisively: Elsevier's
+  9-question structured review pilot got 92% full completion and raised
+  reviewer agreement to 41% vs a 31% freeform baseline
+  ([PeerJ](https://peerj.com/articles/17514/); *confirmed*), while Wikipedia's
+  open feedback box produced ~12% useful input and was discontinued
+  ([report](https://www.mediawiki.org/wiki/Article_feedback/Version_5/Report);
+  *confirmed*). NZ government already runs "We asked, you said, we did"
+  loop-closing on Citizen Space ([DPMC hub](https://consultation.dpmc.govt.nz/); *confirmed*).
+- **Identity & consent** — magic-link auth needs server-side state
+  ([Auth.js docs](https://authjs.dev/getting-started/authentication/email);
+  *confirmed*) and free tiers pause or cap
+  ([Supabase](https://supabase.com/pricing); *confirmed*); unguessable
+  capability URLs get harvested into public scanner archives, so a link alone
+  must never grant access
+  ([Pulse Security](https://pulsesecurity.co.nz/articles/unguessable_url_issues);
+  *confirmed*). Email to a known address sidesteps the whole class.
+- **AI-guided interviews (IR-0001)** — Custom GPTs require the participant to
+  sign in ([OpenAI FAQ](https://help.openai.com/en/articles/8554407-gpts-faq);
+  *confirmed*), Claude Projects share only within an organisation
+  ([Anthropic](https://support.claude.com/en/articles/9519189-manage-project-visibility-and-sharing);
+  *confirmed*); the only genuinely account-free voice path found was an
+  embedded public agent widget (e.g. ElevenLabs, ~$0.08/min
+  [pricing](https://elevenlabs.io/pricing/agents); *confirmed*) — workable, but
+  a vendor + cost + consent surface that doesn't belong in v1.
+- **Comparable projects** — the strongest precedent is GOV.UK's SME fact-check:
+  the expert **replies to an email**; a script polls the inbox and lands the
+  review against the right edition
+  ([publisher docs](https://docs.publishing.service.gov.uk/repos/publisher/fact-checking.html);
+  *confirmed*), with reviewers bounded to factual inaccuracies — what/why/where,
+  never rewrites ([guidance](https://www.gov.uk/government/publications/how-content-requests-from-government-get-published/fact-checking-content-on-govuk);
+  *confirmed*). Retention evidence: personal invitations beat portals
+  ([Teahouse experiment](https://www.opensym.org/wp-content/uploads/2018/07/OpenSym2018_paper_15-1.pdf);
+  *confirmed*), and seeing your input published measurably retains contributors
+  ([Community Notes study](https://arxiv.org/html/2510.00650v1); *confirmed*).
+
+**Refuted and excluded:** "Decidim's API is read-only, preventing a two-way
+bridge" — its GraphQL API documents write mutations
+([docs](https://docs.decidim.org/en/develop/develop/api/)); no design relied on it.
+
+## The three designs and how they scored
+
+Judge panel: three lenses × four criteria (reviewer friction, operability,
+trust & safety, repo fit), each 1–10; max 120.
+
+| Design | Core idea | Score |
+|---|---|---|
+| **The Paper Round** (minimal-ops) | Steward-mediated email review; the human is the bridge; zero new infrastructure | **103** |
+| Review Rooms (web-first) | Dashboard review page + fleet-server endpoint + bot filing behind a moderation queue | 78 |
+| Conversation-first | The IR-0001 AI interviewer as the primary channel; forms as fallback | 60 |
+
+The judges' consistent findings: the email journey is the only one with **zero
+novel steps** for a non-technical reviewer; the web design adds an endpoint,
+token, OTP login cliff, and PII custody on hobby infrastructure; the
+interviewer design has the worst account/vendor constraints for v1 but is the
+right *optional* rung later. Weaknesses the synthesis fixed in the winner:
+pack-assembly labour (→ agent-drafted, steward-approved sheets), consent
+living in an inbox (→ recorded in `partners/` via `manage-partner`, enforced
+by an Action that fails closed), and an unmanaged PII trail (→
+sanitize-before-agent, mechanical redaction, read-back, 30-day retention).
+
+## What shipped (the implementing PR)
+
+[ADR-0026](../docs/adr/0026-human-review-paper-round.md) ·
+[docs/REVIEW-ROUND.md](../docs/REVIEW-ROUND.md) (SOP) ·
+[streams/REVIEW-SHEET.md](../streams/REVIEW-SHEET.md) (sheet template) ·
+[`draft-review-sheet` skill](../.claude/skills/draft-review-sheet/SKILL.md) ·
+[feedback issue form](../.github/ISSUE_TEMPLATE/5-feedback.yml) ·
+[consent validator](../scripts/check-feedback-consent.mjs) +
+[workflow](../.github/workflows/feedback-consent.yml) ·
+[`npm run redact-check`](../scripts/redact-check.mjs).
+
+## Confidence & limits
+
+- Every claim marked *confirmed* above survived an adversarial fact-check
+  against its primary source by a separate agent; the one refuted claim is
+  listed and was excluded from the design. Confidence in those cited facts:
+  **High**.
+- The judge scores are structured model judgement, not measurement — they
+  triangulate three lenses but remain opinion. Confidence that the ranking is
+  directionally right: **Medium-High** (the margins were large and the
+  rationales consistent); confidence in the exact numbers: Low, by nature.
+- The design has **not yet been proven with a real reviewer**. The acceptance
+  test is running a round end-to-end on stream #442 and filling its empty
+  Feedback log — until then, completion-rate claims are transferred evidence
+  (GOV.UK, Elsevier), not local evidence.
+- Vendor facts (pricing, account requirements) are point-in-time as of
+  2026-07-15 and drift; re-verify before building any v2 rung on them.
+
+## What would change this design
+
+- The escalation tripwire firing (>5 rounds/30 days, machine-counted) — then
+  Review Rooms comes off the shelf via a superseding ADR.
+- Evidence that reviewers *don't* complete emailed sheets (track per-round
+  completion in the Feedback logs) — then test the one-claim-per-screen card
+  UI ([GOV.UK form-structure guidance](https://www.gov.uk/service-manual/design/form-structure)).
+- A talk-first SME cohort — then pilot the IR-0001 interviewer as a capture
+  rung feeding this same filing flow.

--- a/docs/REVIEW-ROUND.md
+++ b/docs/REVIEW-ROUND.md
@@ -1,0 +1,152 @@
+# Running a review round (the Paper Round)
+
+How a person who will never touch GitHub reviews our work — and how their
+judgement lands in the repo safely. This is the operating procedure for
+[ADR-0026](adr/0026-human-review-paper-round.md). The reviewer's entire job is
+**reading a short sheet and replying to an email from someone they know**.
+Everything else is yours (the steward's).
+
+> **Roles.** *Reviewer*: the SME / practitioner / community member giving
+> judgement — no GitHub, no markdown, no account, ever. *Steward*: the human
+> running the round and bridging it into GitHub. *Agent*: drafts and checks
+> under your approval; it never contacts the reviewer and never files without
+> your sign-off.
+>
+> **Named responsibilities** (fill these in — an SOP with unnamed owners is a
+> wish): privacy officer: `TODO(maintainer)`; deputy steward: `TODO(maintainer)`.
+> Even community groups need a privacy officer under the
+> [NZ Privacy Act](https://www.privacy.org.nz/responsibilities/your-obligations/).
+
+## The round, step by step
+
+### 1. Draft the review sheet (~5 min)
+
+Run the [`draft-review-sheet`](../.claude/skills/draft-review-sheet/SKILL.md)
+skill against the stream's overview (`streams/<n>-<slug>.md`). It extracts 5–8
+claims **verbatim, with their confidence tags**, into the
+[`streams/REVIEW-SHEET.md`](../streams/REVIEW-SHEET.md) format. **Edit and
+approve it yourself** — cut claims the reviewer can't speak to, fix the two
+judgement questions, keep it under two screens. The agent drafts; you decide.
+
+Bound it like GOV.UK bounds fact-checks
+([guidance](https://www.gov.uk/government/publications/how-content-requests-from-government-get-published/fact-checking-content-on-govuk)):
+factual verification — *what's wrong, why, where would we check* — never a
+rewrite request.
+
+### 2. Send it — email by default
+
+Email the sheet body (not an attachment) from your own address to the
+reviewer's known address. Include the **privacy notice** (below) the first time
+you review with someone, and the consent ask every round. Use WhatsApp only
+where it's already the reviewer's proven channel — and then the notice must
+name **Meta** as a recipient of the message content.
+
+If the reviewer would rather talk, phone them and fill the sheet yourself
+during the call — NZ's written-first, oral-follow-up consultation norm
+([govt.nz](https://www.govt.nz/browse/engaging-with-government/consultations-have-your-say/give-feedback-on-a-bill-before-parliament/)).
+
+### 3. Receive the reply
+
+Inline answers to the numbered items are ideal; **a half-structured blob is
+fine by design** — the numbered sheet makes even a blob parseable against known
+claims. Don't send it back for reformatting; that's your job, not theirs.
+
+### 4. Sanitize, then transcribe (~10 min)
+
+Your inbox is the moderation queue: nothing reaches the repo unread by a human.
+
+**Hard rule — sanitize before any agent sees the text.** Strip email headers,
+signature, personal names, and contact details *first*; only then may an agent
+help you transcribe the sanitized text into the
+[feedback issue form](../.github/ISSUE_TEMPLATE/5-feedback.yml). Raw PII never
+enters an LLM context. If the reply mentions **third parties** (a colleague, a
+named client), strip that detail too (IPP3A — collection from the individual
+concerned, [in force May 2026](https://www.justice.govt.nz/about/news-and-media/news/new-privacy-information-principle-in/)).
+
+Before filing, run the mechanical redaction pass over your draft body:
+
+```
+npm run redact-check -- draft.md
+```
+
+It flags emails, phone numbers, and anything shaped like a secret (reusing the
+fleet's [`redact-patterns.mjs`](../server/clients/redact-patterns.mjs)). It
+cannot spot a personal name in prose — that's what this step and step 5 are for.
+
+### 5. Read back
+
+Email the reviewer the transcribed verdicts before filing: *"Here's what I'll
+record — reply if I've misquoted you."* The reviewer sees their words before
+they're public. No filing until they've confirmed (or corrected).
+
+### 6. File it
+
+Open one **[💬 Stakeholder feedback](../.github/ISSUE_TEMPLATE/5-feedback.yml)**
+issue per reviewer per round. It carries: the `Stream: #<n>` line (which
+propagates the stream label automatically), the verdict table, the reviewer as
+**role + sector only**, the **consent tier**, and a provenance footer — who
+filed, on whose behalf, and where consent is recorded.
+
+The [`feedback-consent` workflow](../.github/workflows/feedback-consent.yml)
+then validates it mechanically and **fails closed**: missing consent tier,
+an organisation named above its recorded consent in [`partners/`](../partners/README.md),
+or any email/phone/secret in the body gets the issue flagged
+`feedback: needs-fix` with the exact repair. Record the consent (tier + date +
+how it was given) in the reviewer's `partners/` record via the
+`manage-partner` skill — durable and auditable, not trapped in your inbox.
+
+### 7. Close the loop
+
+- Fold accepted corrections into findings via normal PRs (they get non-author
+  adversarial review like everything else).
+- Add the row to the stream overview's **Feedback log**
+  (`Date | Who (role, not name) | What they said | What we did`) — the overview
+  is yours alone to edit; automation never touches `streams/`.
+- Reply to the reviewer with the public link to what changed. "We asked, you
+  said, we did" ([DPMC's pattern](https://consultation.dpmc.govt.nz/)) is what
+  keeps reviewers coming back — unpublished feedback drives contributors away
+  ([Community Notes retention evidence](https://arxiv.org/html/2510.00650v1)).
+  The round is not done until the "What we did" cell is filled and the outcome
+  email is sent.
+
+### 8. Retention
+
+Delete the raw reply email once the round closes (read-back confirmed, consent
+recorded in `partners/`) — **30 days maximum**. The inbox must not become an
+unmanaged store of expert PII. What survives: the sanitized issue, the
+Feedback-log row, and the consent trail in `partners/`.
+
+## The privacy notice (IPP3)
+
+Include this (adapted) the first time you review with someone — the
+[Privacy Act's collection notice](https://www.privacy.org.nz/responsibilities/collecting/)
+duties apply to us like anyone else:
+
+> We're collecting your review comments to improve published research at The
+> For Good Project. Your answers may appear publicly in summarised form. Your
+> personal name and contact details are **never published, at any level** —
+> you choose whether we describe you by role only (e.g. "an aged-care banker"),
+> name your organisation, or credit your organisation publicly, and you can
+> change your mind later (we'll redact). This exchange travels over email
+> [**and WhatsApp, which means Meta processes the message content**], and is
+> deleted within 30 days of the round closing. Questions or corrections:
+> contact `TODO(maintainer: privacy officer contact)`.
+
+## Consent tiers (ADR-0010 — the ceiling does not move)
+
+| Tier | What the repo may say | What it may never say |
+|---|---|---|
+| `private` (default) | "an aged-care banker (15 yrs)" | any org name; any personal name/contact |
+| `org-named` | "a banker at {Org}" | any personal name/contact |
+| `public` | the organisation openly credited | any personal name/contact |
+
+Revocation (IPP7): the reviewer can ask at any time; the steward edits/redacts
+the issue and updates the `partners/` record. When in doubt, fail closed to
+`private`.
+
+## When this SOP is no longer enough
+
+The consent workflow counts rounds automatically. **More than 5 rounds in 30
+days, or more than 3 stewards running rounds** = the email round is saturating.
+That's the pre-agreed trigger (ADR-0026) to bring up the v2 web review surface
+— don't improvise infrastructure before the trigger fires.

--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -218,6 +218,8 @@ a human.
   domain: NFP staff, community workers, practitioners. They read stream
   overviews and give feedback that can redirect a stream — **no GitHub
   required**. Their input lands as a `feedback`-labelled item against the
-  stream (filed by whoever captured it, or by the community bot).
+  stream (filed by whoever captured it, or by the community bot). The
+  mechanism is the Paper Round — a steward-mediated email review round:
+  [docs/REVIEW-ROUND.md](REVIEW-ROUND.md) ([ADR-0026](adr/0026-human-review-paper-round.md)).
 
 (Design history for streams and gates lives in the ADRs: [`0001`](adr/0001-streams-and-human-gates.md), [`0003`](adr/0003-agent-drafted-synthesis.md), [`0007`](adr/0007-synthesis-drafts-candidate-outcomes.md), [`0011`](adr/0011-synthesis-rework-routing.md), [`0012`](adr/0012-synthesis-followup-research-loop.md).)

--- a/docs/adr/0026-human-review-paper-round.md
+++ b/docs/adr/0026-human-review-paper-round.md
@@ -1,0 +1,114 @@
+# ADR-0026: The human review stage runs as a steward-mediated email round ("the Paper Round") — no GitHub required of the reviewer
+
+- **Status:** proposed
+- **Date:** 2026-07-15
+- **Deciders:** maintainer (on merge); researched and drafted by agents at the maintainer's request
+- **Discussion:** direct maintainer request; design research recorded in [`analysis/human-review-system-design.md`](../../analysis/human-review-system-design.md)
+
+## Context
+
+The people whose judgement the project most needs — SMEs, practitioners, affected
+communities — will never use GitHub, markdown, or a CLI ([`docs/STREAMS.md`](../STREAMS.md)
+§Roles says exactly this, and promises "no GitHub required"). Today that promise has no
+mechanism: the first real SME review (stream #442, recorded in
+[IR-0001](../ideas/0001-sme-review-via-guided-ai-interviewer.md)) ran as a PDF out and
+freeform WhatsApp back, its consent trail lived in one person's inbox, and the #442
+Feedback log is still empty. The `feedback` label exists (`.github/labels.yml`) but nothing
+defines how a non-GitHub person's input reaches it.
+
+A multi-agent research pass (six angles, load-bearing claims adversarially fact-checked —
+23 of 24 confirmed; full record in the analysis doc) established the hard constraints:
+GitHub has **no anonymous write path** — every account-less design is some proxy writing
+under an identity we control ([GitHub REST docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)) —
+and the strongest precedent at national scale is GOV.UK's fact-check flow, where the
+expert's entire job is **replying to an email** and a script/human lands it in the CMS
+([GOV.UK publisher docs](https://docs.publishing.service.gov.uk/repos/publisher/fact-checking.html)).
+Structured, bounded questions measurably beat open feedback boxes
+([Elsevier structured-review pilot: 92% completion](https://peerj.com/articles/17514/) vs
+[Wikipedia's discontinued ~12%-useful feedback tool](https://www.mediawiki.org/wiki/Article_feedback/Version_5/Report)).
+Three designs were drafted and judged through reviewer-friction / operability /
+trust-safety lenses; steward-mediated email won decisively over a web review surface and
+an AI-interviewer-first design (scores and rationale in the analysis doc). ADR-0010's
+consent gate binds absolutely: no individual's name or contact detail in the repo at any
+tier; organisations named only at their recorded consent.
+
+## Decision
+
+We will run the human review stage as **the Paper Round**: a steward-mediated email
+review round, hardened with mechanical consent enforcement and a privacy SOP. The
+reviewer's entire job is *reading a short review sheet and replying to an email from
+someone they know* — the only journey with zero novel steps for a non-technical expert.
+The **human steward is the bridge into GitHub**; no new servers, tokens, or endpoints.
+
+Components (all shipped by this ADR's implementing PR):
+
+1. **A bounded review sheet** ([`streams/REVIEW-SHEET.md`](../../streams/REVIEW-SHEET.md)):
+   5–8 claims quoted verbatim with their confidence tags, each answerable
+   *Right / Wrong / Can't say* (+ what/why/where-to-check when wrong — GOV.UK's
+   fact-check bounding), plus at most two judgement questions. Never a rewrite request,
+   never one big open box.
+2. **An agent-drafted, steward-approved sheet** ([`draft-review-sheet` skill](../../.claude/skills/draft-review-sheet/SKILL.md)):
+   the agent only drafts from the stream overview; the steward edits, approves, and
+   sends. Judgement stays human (ADR-0001/0003/0007).
+3. **A structured landing form** ([`.github/ISSUE_TEMPLATE/5-feedback.yml`](../../.github/ISSUE_TEMPLATE/5-feedback.yml)):
+   the steward (or whoever captured the feedback) files one `feedback`-labelled issue per
+   reviewer per round, carrying the verdicts, a required **consent-tier field**, a
+   `Stream: #<n>` line for label propagation, and a provenance footer saying who filed on
+   whose behalf.
+4. **Mechanical consent enforcement** ([`scripts/check-feedback-consent.mjs`](../../scripts/check-feedback-consent.mjs)
+   via [`.github/workflows/feedback-consent.yml`](../../.github/workflows/feedback-consent.yml)):
+   on every `feedback` issue, validate the consent tier, org-naming against the
+   `partners/` registry, and scan for emails/phone numbers/secrets — **failing closed**
+   with the exact fix. The same workflow counts rounds per 30 days so the escalation
+   trigger below is observable, not self-reported.
+5. **A privacy SOP** ([`docs/REVIEW-ROUND.md`](../REVIEW-ROUND.md)): sanitize-before-agent
+   (raw PII never enters an LLM context), a read-back step before filing, a 30-day
+   retention rule for raw replies, and an NZ Privacy Act IPP3 notice that names every
+   channel recipient (including Meta when WhatsApp is used).
+6. **A redaction wrapper** (`npm run redact-check`) reusing the fleet's existing
+   [`server/clients/redact-patterns.mjs`](../../server/clients/redact-patterns.mjs) plus
+   email/phone detection, run before any feedback text is filed.
+
+Consent is recorded per round in the durable `partners/` record via the `manage-partner`
+skill (timestamped, surviving steward handover), never only in an inbox. Attribution
+ceiling per ADR-0010: **role + organisation-at-consent-tier, never a personal name** — no
+tier permits one, so the system doesn't offer it.
+
+Options seriously considered and rejected:
+
+- **A web review surface** ("Review Rooms": dashboard page + fleet-server endpoint + bot
+  filing) — rejected for v1: new endpoint/token/moderation surface to babysit, OTP login
+  cliff for the least technical users, PII on hobby infrastructure. It is the
+  **pre-agreed v2** once volume demands it (tripwire below), reusing this ADR's
+  `feedback.yml` structure.
+- **AI-interviewer-first** (IR-0001 as the primary channel) — rejected as the *default*:
+  every no-account voice path adds a vendor, cost, and consent complexity, and Custom
+  GPT / Claude links require reviewer accounts ([OpenAI](https://help.openai.com/en/articles/8554407-gpts-faq),
+  [Anthropic](https://support.claude.com/en/articles/9519189-manage-project-visibility-and-sharing)).
+  It stays a v2 rung for talk-first SMEs (e.g. an ElevenLabs widget needs no reviewer
+  account — [docs](https://elevenlabs.io/docs/eleven-agents/customization/widget)), feeding
+  the same sheet and filing flow.
+- **Per-reviewer capability URLs** — rejected: unguessable links get harvested into public
+  scanner archives; possession of a URL must not grant access
+  ([Pulse Security](https://pulsesecurity.co.nz/articles/unguessable_url_issues)). Email to
+  a known address avoids the class entirely.
+- **This is not a change of channel decision:** ADR-0001 recorded "WhatsApp/community bot
+  first" (#38). The Paper Round is that decision's *manual v1* — the #38 bridge, when
+  built, feeds the same `feedback.yml` structure and SOP rather than replacing them.
+
+## Consequences
+
+Easier: an SME can shape a stream from their phone with zero new skills; feedback gains a
+durable, labelled, stream-linked home with an auditable consent trail; the steward's pack
+assembly drops from ~20 minutes to a ~5-minute edit pass; $0/month and nothing that can
+break in front of a reviewer. Harder / accepted costs: the steward is a human bottleneck
+(~15 min/round) and a bus factor — mitigated by the agent draft, a named deputy in the
+SOP, and consent trails that survive handover; mechanical checks cannot catch every
+disclosure (a personal name in prose passes the regexes) — the SOP's sanitize + read-back
+steps and non-author adversarial review remain the real guard; raw replies live briefly
+in a private inbox — bounded by the 30-day deletion rule.
+
+Tripwire: when the consent workflow's counter shows **more than 5 rounds in 30 days**, or
+more than 3 stewards run rounds concurrently, the email round is saturating — that is the
+signal to take "Review Rooms" (v2) off the shelf via a superseding ADR, solving its OTP
+and data-custody problems first.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,5 +62,6 @@ routine fixes, copy changes, or web styling.
 | [0023](0023-self-report-is-a-claim.md) | A party's statement about itself is a claim, not confirmation (method check 3) | Proposed |
 | [0024](0024-stream-level-priority.md) | Priority is a stream-level decision inherited by children | Proposed |
 | [0025](0025-claim-fail-backoff.md) | An issue that keeps failing to produce a PR is parked status: blocked, not re-released forever | Proposed |
+| [0026](0026-human-review-paper-round.md) | The human review stage runs as a steward-mediated email round (the Paper Round) — no GitHub required of the reviewer | Proposed |
 
 Start from [`TEMPLATE.md`](TEMPLATE.md).

--- a/docs/ideas/0001-sme-review-via-guided-ai-interviewer.md
+++ b/docs/ideas/0001-sme-review-via-guided-ai-interviewer.md
@@ -1,6 +1,6 @@
 # IR-0001: SME review via a guided (voice-optional) AI interviewer
 
-- **Status:** exploring
+- **Status:** exploring — positioned as a v2 rung of the Paper Round ([ADR-0026](../adr/0026-human-review-paper-round.md)): the interviewer would feed the same review sheet + feedback filing, not replace them
 - **Date:** 2026-07-09
 - **Champions:** Matt (raised it), Adam (voice-driven adaptive questionnaire), Joe Sutheran (custom-GPT interviewer with a shareable transcript)
 - **Discussion:** For Good WhatsApp thread, 2026-07-09 (during the first live SME review of the #442 aged-care funding guide)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "fetch": "node scripts/fetch.mjs",
     "archive": "node scripts/archive-cite.mjs",
     "cloak": "node scripts/cloak-fetch.mjs",
-    "validate": "node scripts/validate-findings.mjs"
+    "validate": "node scripts/validate-findings.mjs",
+    "redact-check": "node scripts/redact-check.mjs",
+    "check-feedback-consent": "node scripts/check-feedback-consent.mjs"
   },
   "dependencies": {
     "cloakbrowser": "^0.4.8",

--- a/scripts/check-feedback-consent.mjs
+++ b/scripts/check-feedback-consent.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Consent + PII validator for `feedback`-labelled issues (ADR-0026).
+//
+// Usage:
+//   ISSUE_BODY="$(gh issue view N --json body --jq .body)" node scripts/check-feedback-consent.mjs
+//   node scripts/check-feedback-consent.mjs --body-file body.md
+//
+// Prints a markdown report to stdout. Exit 0 = pass, 1 = fail (fail closed).
+//
+// What it enforces mechanically:
+//   1. a `Stream: #<n>` line (stream-sync.yml propagates the label from it)
+//   2. a valid consent tier (private | org-named | public — ADR-0010)
+//   3. org-naming consistent with the tier AND with the org's own recorded
+//      consent in partners/ (attribution sections fail closed; org names in
+//      the verdict content only warn — they may be subject matter)
+//   4. no emails / phone numbers / secret-shaped content anywhere in the body
+//   5. the form's "Before you file" gates are all ticked
+//
+// What it can NOT check (the SOP's job — docs/REVIEW-ROUND.md): a personal
+// name in prose, whether read-back really happened, whether consent was
+// really given. The report says so rather than pretending otherwise.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { scanText } from "./redact-check.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const TIERS = ["private", "org-named", "public"];
+const NO_RESPONSE = /^_no response_$/i;
+
+// ---------- input ----------
+let body = process.env.ISSUE_BODY ?? "";
+const fileFlag = process.argv.indexOf("--body-file");
+if (fileFlag !== -1) body = readFileSync(process.argv[fileFlag + 1], "utf8");
+if (!body.trim()) {
+  console.error("no issue body: set ISSUE_BODY or pass --body-file <path>");
+  process.exit(2);
+}
+
+// ---------- parse the issue-form sections (### Heading\n\nvalue) ----------
+function sections(text) {
+  const out = {};
+  const re = /^### (.+)$/gm;
+  const heads = [...text.matchAll(re)];
+  heads.forEach((h, i) => {
+    const start = h.index + h[0].length;
+    const end = i + 1 < heads.length ? heads[i + 1].index : text.length;
+    out[h[1].trim()] = text.slice(start, end).trim();
+  });
+  return out;
+}
+const secs = sections(body);
+const sec = (prefix) => {
+  const key = Object.keys(secs).find((k) => k.toLowerCase().startsWith(prefix.toLowerCase()));
+  return key ? secs[key] : undefined;
+};
+const val = (prefix) => {
+  const v = sec(prefix);
+  return v === undefined || NO_RESPONSE.test(v.trim()) ? "" : v.trim();
+};
+
+// ---------- load the partners registry (org name -> recorded consent) ----------
+function partnerOrgs() {
+  const dir = join(ROOT, "partners");
+  const orgs = [];
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".md") || ["TEMPLATE.md", "README.md", "ASKS.md"].includes(f)) continue;
+    const text = readFileSync(join(dir, f), "utf8");
+    const fm = text.match(/^---\n([\s\S]*?)\n---/);
+    if (!fm) continue;
+    const org = fm[1].match(/^org:\s*"?([^"\n#]*?)"?\s*(?:#.*)?$/m)?.[1]?.trim();
+    const consent = fm[1].match(/^consent:\s*([\w-]+)/m)?.[1]?.trim() ?? "private";
+    if (org) orgs.push({ org, consent, file: `partners/${f}` });
+  }
+  return orgs;
+}
+
+// ---------- checks ----------
+const failures = [];
+const warnings = [];
+
+// 1. Stream line
+if (!/^\s*stream:\s*#\d+/im.test(body)) {
+  failures.push(
+    "No `Stream: #<n>` line found. Put the stream root in the **Stream** field exactly as `Stream: #442` — that line is what propagates the `stream:<n>` label (see `.github/workflows/stream-sync.yml`)."
+  );
+}
+
+// 2. Consent tier
+const tierRaw = val("Consent tier");
+const tier = TIERS.find((t) => tierRaw.toLowerCase().startsWith(t));
+if (!tier) {
+  failures.push(
+    "Missing or invalid **Consent tier**. It must be one of `private`, `org-named`, `public` (ADR-0010). Use the feedback issue form (`.github/ISSUE_TEMPLATE/5-feedback.yml`) — it has the dropdown."
+  );
+}
+
+// 3. Organisation attribution vs tier vs registry
+const orgField = val("Organisation");
+const registry = partnerOrgs();
+if (orgField) {
+  if (tier === "private") {
+    failures.push(
+      `The **Organisation** field names "${orgField}" but the consent tier is \`private\` (role + sector only). Either the reviewer consented to org-naming — set the tier accordingly — or remove the organisation.`
+    );
+  } else if (tier) {
+    const rec = registry.find((r) => r.org.toLowerCase() === orgField.toLowerCase());
+    if (!rec) {
+      failures.push(
+        `The **Organisation** field names "${orgField}", but no \`partners/\` record carries that org name. Record the relationship (and its consent) first via the \`manage-partner\` skill — consent must live in the durable registry, not an inbox.`
+      );
+    } else if (tier === "public" && rec.consent !== "public") {
+      failures.push(
+        `The tier is \`public\` but ${rec.file} records "${rec.org}" at \`${rec.consent}\`. An organisation is credited publicly only after its recorded consent says so — escalate the record first (logged, via \`manage-partner\`) or lower the tier.`
+      );
+    }
+  }
+}
+// Attribution sections must not smuggle a registry org name past a private tier.
+if (tier === "private") {
+  const attributionText = [val("Reviewer"), val("Provenance")].join("\n");
+  for (const r of registry) {
+    if (attributionText.toLowerCase().includes(r.org.toLowerCase())) {
+      failures.push(
+        `The reviewer/provenance text names "${r.org}" while the tier is \`private\`. Describe the reviewer by role + sector only, or set the tier the reviewer actually consented to.`
+      );
+    }
+  }
+  // In the verdict content an org name may be subject matter, not attribution — warn only.
+  const contentText = [val("What the reviewer said"), val("Judgement answers")].join("\n");
+  for (const r of registry) {
+    if (contentText.toLowerCase().includes(r.org.toLowerCase())) {
+      warnings.push(
+        `The feedback content mentions "${r.org}" (a \`partners/\` org) while the reviewer's tier is \`private\`. Fine if it's subject matter; a problem if it identifies the reviewer — steward to confirm.`
+      );
+    }
+  }
+}
+
+// 4. PII / secrets anywhere in the body
+for (const f of scanText(body)) {
+  failures.push(`Line ${f.line}: ${f.kind} — \`${f.match}\`. No personal contact detail or secret may land in the repo at any tier; sanitize and re-file (\`npm run redact-check\`).`);
+}
+
+// 5. The SOP's hard gates
+const gates = sec("Before you file");
+if (gates === undefined) {
+  failures.push("The **Before you file** checklist is missing — file feedback through the issue form (`.github/ISSUE_TEMPLATE/5-feedback.yml`), which carries the SOP's hard gates.");
+} else {
+  for (const m of gates.matchAll(/^\s*-\s*\[ \]\s*(.+)$/gm)) {
+    failures.push(`Unticked gate: "${m[1].slice(0, 80)}…" — the SOP (docs/REVIEW-ROUND.md) requires it before filing.`);
+  }
+}
+
+// ---------- report ----------
+const lines = [];
+if (failures.length) {
+  lines.push(`### ❌ Feedback filing failed the consent/PII validator (${failures.length} problem${failures.length > 1 ? "s" : ""})`, "");
+  failures.forEach((f) => lines.push(`- ${f}`));
+} else {
+  lines.push("### ✅ Feedback filing passes the consent/PII validator");
+}
+if (warnings.length) {
+  lines.push("", "**Warnings (not blocking — steward judgement):**");
+  warnings.forEach((w) => lines.push(`- ${w}`));
+}
+lines.push(
+  "",
+  "_Mechanical checks only: stream link, consent tier, org-naming vs `partners/`, emails/phones/secrets, SOP gates. A personal name in prose, real read-back, and real consent are the steward's responsibility — see [docs/REVIEW-ROUND.md](../blob/main/docs/REVIEW-ROUND.md) (ADR-0026)._"
+);
+console.log(lines.join("\n"));
+process.exit(failures.length ? 1 : 0);

--- a/scripts/redact-check.mjs
+++ b/scripts/redact-check.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Redaction pre-flight for feedback text (ADR-0026, docs/REVIEW-ROUND.md §4).
+//
+// Usage:  npm run redact-check -- <file>     (or pipe text on stdin)
+//
+// Flags, with line numbers: email addresses, phone-shaped numbers, and
+// anything the fleet's shared secret patterns would redact
+// (server/clients/redact-patterns.mjs — the ONE pattern library, ADR-0016).
+// Exit 0 = clean, 1 = findings, 2 = usage error.
+//
+// Honest limit: this cannot recognise a personal NAME in prose. The
+// sanitize-before-agent and read-back steps of the SOP are the guard for
+// that — this script only makes the mechanical part mechanical.
+
+import { readFileSync } from "node:fs";
+import { redactText, REDACTED } from "../server/clients/redact-patterns.mjs";
+
+export const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+// Phone shapes seen in NZ correspondence: +64 21 123 4567, 021 234 5678,
+// (04) 472-1234, 0800 123 456. Anchored to +64 / leading-0 prefixes and 7+
+// further digits so plain statistics ("45,000 people") don't false-positive.
+export const PHONE_RE = /(?:\+64|\(0[2-9]\)|\b0[2-9]0?)(?:[\s-]?\d){7,10}\b/g;
+
+export function scanText(text) {
+  const findings = [];
+  const lines = text.split("\n");
+  lines.forEach((line, i) => {
+    for (const m of line.match(EMAIL_RE) ?? [])
+      findings.push({ line: i + 1, kind: "email address", match: m });
+    for (const m of line.match(PHONE_RE) ?? [])
+      findings.push({ line: i + 1, kind: "phone-shaped number", match: m });
+    if (redactText(line) !== line)
+      findings.push({ line: i + 1, kind: "secret-shaped content", match: redactText(line).includes(REDACTED) ? "(matched the fleet secret patterns)" : "(rewritten by redaction)" });
+  });
+  return findings;
+}
+
+const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop());
+if (isMain) {
+  const arg = process.argv[2];
+  let text;
+  try {
+    text = arg ? readFileSync(arg, "utf8") : readFileSync(0, "utf8");
+  } catch (e) {
+    console.error(`usage: npm run redact-check -- <file>   (or pipe on stdin)\n${e.message}`);
+    process.exit(2);
+  }
+  const findings = scanText(text);
+  if (findings.length === 0) {
+    console.log("✅ redact-check: no emails, phone numbers, or secret-shaped content found.");
+    console.log("   (This can't spot a personal name in prose — that's the SOP's sanitize + read-back steps.)");
+    process.exit(0);
+  }
+  console.error(`❌ redact-check: ${findings.length} finding(s) — remove these before filing:\n`);
+  for (const f of findings) console.error(`  line ${f.line}: ${f.kind} — ${f.match}`);
+  process.exit(1);
+}

--- a/streams/REVIEW-SHEET.md
+++ b/streams/REVIEW-SHEET.md
@@ -1,0 +1,69 @@
+<!--
+REVIEW SHEET TEMPLATE (ADR-0026, docs/REVIEW-ROUND.md)
+
+This is what a domain expert actually receives — pasted into the BODY of an
+email (never an attachment), sent by the steward from their own address.
+Drafted by the `draft-review-sheet` skill from a stream overview, then edited
+and approved by the human steward before anything is sent.
+
+Rules for whoever drafts this:
+- 5–8 claims MAX, quoted VERBATIM from the stream overview / findings, each
+  with its confidence tag. Cut anything this reviewer can't speak to.
+- Factual verification only — what/why/where — never "please rewrite this".
+- At most TWO judgement questions, at the end.
+- Plain language, under two screens on a phone. No jargon, no repo-speak,
+  no issue numbers.
+- Neutral phrasing. Never lead the witness ("we think X is right, isn't it?").
+-->
+
+Subject: 10 minutes of your judgement on {topic} — {your name}
+
+Kia ora {reviewer's first name},
+
+You know {domain} better than we do. Below are {N} things our research
+currently says, and we'd like to know if we've got them right. For each one,
+just reply with the number and **Right**, **Wrong**, or **Can't say** — and if
+it's wrong: what's wrong, why, and where you'd check the real answer. Rough
+notes are fine; this should take about 10 minutes, and replying straight to
+this email is all you need to do.
+
+*(First round only — the privacy bit, short version: your answers may appear
+publicly in summarised form; your name and contact details are never
+published; you choose whether we describe you by role only, name your
+organisation, or credit it publicly — and you can change your mind later.
+This email is deleted within 30 days of us wrapping up.)*
+
+---
+
+**1.** "{claim quoted verbatim from the overview}"
+   *(our confidence: {High/Medium/Low})*
+   Right / Wrong / Can't say — if wrong: what, why, where would we check?
+
+**2.** "{claim}"
+   *(our confidence: {High/Medium/Low})*
+   Right / Wrong / Can't say
+
+**3.** …
+
+---
+
+Two bigger-picture questions, if you have another minute:
+
+**A.** Is this problem worth pursuing at all, from where you sit?
+
+**B.** Of the directions we're weighing — {option 1}, {option 2}, {option 3} —
+which would actually help first, and is there an obvious one we've missed?
+
+---
+
+How would you like to be described if we quote your feedback?
+- just your role — e.g. "{an aged-care banker}" (this is the default),
+- role + your organisation named, or
+- your organisation openly credited as a reviewer.
+
+Never your name — we don't publish people's names, full stop.
+
+Ngā mihi,
+{steward's name}
+{what happens next: "I'll send you back exactly what I plan to record, and
+after it lands I'll send you a link to what changed because of you."}


### PR DESCRIPTION
## What this is

Direct maintainer request (no originating issue): build the system for the human review stage — a way for people who don't know how to use GitHub to participate.

**Stage:** 🔨 Build
**Domain:** civic-transparency (project process — applies to all streams)

## Summary

Implements ADR-0026: a steward-mediated email review round ("the Paper Round") that lets domain experts give feedback without GitHub. Non-technical reviewers receive a bounded review sheet via email, reply with verdicts, and the steward files their feedback through a structured form with mechanical consent/PII validation. The system enforces consent tiers, org-naming against a durable registry, and redaction of personal contact details — all fail-closed.

## What shipped

**Core SOP & decision record:**
- `docs/adr/0026-human-review-paper-round.md` — the decision and rationale (steward-mediated email beats web surfaces and AI-interviewer-first designs per multi-agent research)
- `docs/REVIEW-ROUND.md` — step-by-step operating procedure: draft sheet, send, receive, sanitize, read-back, file, close loop, retain
- `analysis/human-review-system-design.md` — full research record: six angles, adversarial fact-checking (23/24 claims confirmed), three designs scored, judges' rationale

**Feedback landing & validation:**
- `.github/ISSUE_TEMPLATE/5-feedback.yml` — structured form for filing one feedback issue per reviewer per round; carries verdicts, consent tier, org name, provenance, and SOP hard gates (sanitize, read-back, consent recorded)
- `scripts/check-feedback-consent.mjs` — mechanical validator: checks stream link, consent tier, org-naming vs `partners/` registry, scans for emails/phones/secrets, verifies SOP gates; **fails closed** with exact repair instructions
- `.github/workflows/feedback-consent.yml` — runs validator on every `feedback`-labelled issue; upserts one report comment per issue; counts rounds/30 days to trigger escalation to v2 (web surface) if >5/month

**Redaction & review sheet:**
- `scripts/redact-check.mjs` — pre-flight scanner for feedback text: flags email addresses, phone numbers, and secret-shaped content (reusing fleet's `redact-patterns.mjs`); cannot spot personal names in prose (that's the SOP's sanitize + read-back steps)
- `streams/REVIEW-SHEET.md` — template for the email a reviewer receives: 5–8 claims quoted verbatim with confidence tags, factual-verification-only prompts, two judgement questions, attribution ask (role-only / org-named / org-credited, never personal name)
- `.claude/skills/draft-review-sheet/SKILL.md` — agent skill to draft sheets from stream overviews; steward edits and approves before sending; agent never contacts reviewer or files feedback

**Registry & labels:**
- `partners/` integration: consent tier + date recorded per org via `manage-partner` skill; org-naming in feedback validated against recorded consent (ADR-0010 ceiling: no personal names at any tier)
- `.github/labels.yml` — added `feedback: needs-fix` label for failed validations

**Documentation updates:**
- `docs/STREAMS.md` — clarified that reviewer feedback lands as `feedback`-labelled items via the Paper Round (no GitHub required)
- `docs/ideas/0001-sme-review-via-guided-ai-interviewer.md` — positioned IR-0001 as a v2 rung (optional AI interviewer) after the email round matures

## Still needs a human

- `docs/REVIEW-ROUND.md` has `TODO(maintainer)` slots: named privacy officer, deputy steward, and privacy-officer contact in the IPP3 notice.
- Acceptance test: run one round end-to-end (e.g. round two with the #442 reviewer) — the first row in a stream's Feedback log is the proof.
- This changes project process (new workflow + ADR), so it's `review: human-only` territory per repo convention — a maintainer applies that label and merges.

## Method checklist

- [x] Every factual claim in ADR-0026 and analysis doc has a source (inline citations to GitHub docs, GOV.UK, Elsevier, Wikipedia, NZ Privacy Act, etc.)
- [x] Load-bearing claims (GitHub's no-anonymous-write constraint, Elsevier structured-review completion rates, GOV.UK precedent) have multiple independent sources
- [x] Research confidence marked in analysis doc (23 of 24 adversarially fact-checked claims confirmed)
- [x] Stated what would change

https://claude.ai/code/session_01CRdDBsggm1PxQJtx5hnsPz